### PR TITLE
Allow setting the source ad hock for a synchronisation in the synchronysation service and allow the passing trought he controller

### DIFF
--- a/lib/Controller/SynchronizationsController.php
+++ b/lib/Controller/SynchronizationsController.php
@@ -302,6 +302,8 @@ class SynchronizationsController extends Controller
         $parameters = $this->request->getParams();
         $test  = filter_var($parameters['test'] ?? false, FILTER_VALIDATE_BOOLEAN);
         $force = filter_var($parameters['force'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $source = $parameters['source'] ?? null;
+        $data = $parameters['data'] ?? [];
 
         try {
             $synchronization = $this->synchronizationMapper->find(id: $id);
@@ -314,7 +316,9 @@ class SynchronizationsController extends Controller
             $logAndContractArray = $this->synchronizationService->synchronize(
                 synchronization: $synchronization,
                 isTest: $test,
-                force: $force
+                force: $force,
+                source: $source,
+                data: $data
             );
 
             // Return the result as a JSON response

--- a/lib/Db/SourceMapper.php
+++ b/lib/Db/SourceMapper.php
@@ -129,4 +129,44 @@ class SourceMapper extends QBMapper
         // Return the total count
         return (int)$row['count'];
     }
+
+    /**
+     * Find or create a source based on the location.
+     * If a source with the given location exists, it will be returned.
+     * If no source exists, a new one will be created with the provided data.
+     *
+     * @param string $location The location to search for
+     * @param array $defaultData Additional data to use when creating a new source
+     * @return Source The found or newly created source
+     * @throws \OCP\AppFramework\Db\DoesNotExistException
+     * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+     * @throws \OCP\DB\Exception
+     */
+    public function findOrCreateByLocation(string $location, array $defaultData = []): Source
+    {
+        // Create query builder
+        $qb = $this->db->getQueryBuilder();
+
+        // Search for existing source with the given location
+        $qb->select('*')
+            ->from('openconnector_sources')
+            ->where(
+                $qb->expr()->eq('location', $qb->createNamedParameter($location))
+            );
+
+        try {
+            // Try to find existing source
+            return $this->findEntity(query: $qb);
+        } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
+            // If source doesn't exist, create a new one
+            $sourceData = array_merge([
+                'location' => $location,
+                'name' => basename($location),
+                'type' => 'file',
+                'enabled' => true,
+            ], $defaultData);
+
+            return $this->createFromArray($sourceData);
+        }
+    }
 }


### PR DESCRIPTION
Allow setting the source (location) ad hoc for a synchronization in the SynchronizationService, and allow passing a source (location) and additional object data (e.g., documentation URL) in the SynchronizationController.

Small note:
This still requires the current Software Catalog frontend to pass the source (location) as the source parameter and the documentation base URL as the data.documentation_url parameter.

Also, this will now (by default) only work on a force, since the entire validation and contracting setup still needs to be refactored to handle multiple sources for a synchronization.