### PR TITLE
Clear current values in extend_input to prevent contamination

### DIFF
--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -1335,7 +1335,9 @@ class EndpointService
 
             try {
                 $object = $this->objectService->getOpenRegisters()->find(id: $value, extend: $extends);
+                $this->objectService->getOpenRegisters()->clearCurrents();
             } catch (DoesNotExistException $exception) {
+                $this->objectService->getOpenRegisters()->clearCurrents();
                 continue;
             }
             $extendedParameters->add($property, $object->jsonSerialize());

--- a/website/docs/rules.md
+++ b/website/docs/rules.md
@@ -185,6 +185,8 @@ The type `audit_trail` gives the possibility to access the audit trails of an ob
 The type `extend_input` can be used to access pre-existing objects in the database when business logic has to check whether or not to create a new object. The rule takes the configuration `properties` containing a dot-array containing the properties in the input that will be extended if possible.
 The extended parameters will be included in the field extendedParameters in the data array for use by other actions.
 
+If an extended field also has fields that should be extended, then the property `extends` should be used with in it also a dot array of which properties should be extended in extended properties.
+
 #### Extend external inputs
 In addition to the `extend_input` rule type, there is also an `extend_external_input` rule type, which does virtually the same, but fetches the input that should be extended from an external source rather than from an internal source. This rule takes the following configuration parameters:
 


### PR DESCRIPTION
Requires the presence of this function in OpenRegister
