### PR TITLE
Add syncing from related objects

### DIFF
--- a/lib/Db/SynchronizationMapper.php
+++ b/lib/Db/SynchronizationMapper.php
@@ -144,6 +144,124 @@ class SynchronizationMapper extends QBMapper
 		return $this->findEntities(query: $qb);
 	}
 
+    /**
+     * Find synchronizations that are configured to trigger on related-object mutations.
+     *
+     * sourceConfig shape:
+     * - triggerFromRelatedObjects: {"<register/schema>": {"<relationKey>": ["create","update","delete"]}}
+     *
+     * @param string|int $register Related object register
+     * @param string|int $schema Related object schema
+     * @param string $mutationType create|update|delete
+     *
+     * @return array<Synchronization>
+     */
+    public function findAllByRelatedObjectTrigger(string|int $register, string|int $schema, string $mutationType): array
+    {
+        $allowedMutationTypes = ['create', 'update', 'delete'];
+        if (in_array($mutationType, $allowedMutationTypes, true) === false) {
+            return [];
+        }
+
+        $relatedSourceId = "$register/$schema";
+        $synchronizations = $this->findAll(limit: null, offset: null, filters: ['source_type' => 'register/schema']);
+
+        return array_values(array_filter($synchronizations, function (Synchronization $synchronization) use ($relatedSourceId, $mutationType): bool {
+            $sourceConfig = $synchronization->getSourceConfig();
+
+            $triggerConfig = $sourceConfig['triggerFromRelatedObjects'];
+
+            if (is_array($triggerConfig) === false || isset($triggerConfig[$relatedSourceId]) === false) {
+                return false;
+            }
+
+            return $this->isRelatedTriggerConfigAllowed($triggerConfig[$relatedSourceId], $mutationType);
+        }));
+    }
+
+    /**
+     * Validates trigger configuration for one related source entry.
+     *
+     * Expected shape:
+     * {"<relationKey>": ["create","update","delete"]}
+     *
+     * @param mixed $triggerSourceConfig Config value for one register/schema key.
+     * @param string $mutationType Current mutation type to validate.
+     *
+     * @return bool True when the config allows the given mutation type.
+     */
+    private function isRelatedTriggerConfigAllowed(mixed $triggerSourceConfig, string $mutationType): bool
+    {
+        if (is_array($triggerSourceConfig) === false) {
+            return false;
+        }
+
+        // Required shape: {"<relationKey>": ["create", "update", "delete"]}
+        if ($this->isAssociativeArray($triggerSourceConfig) === true) {
+            $firstRelationKey = array_key_first($triggerSourceConfig);
+            if (is_string($firstRelationKey) === false || trim($firstRelationKey) === '') {
+                return false;
+            }
+
+            return $this->isRelatedObjectMutationAllowed(
+                $triggerSourceConfig[$firstRelationKey] ?? [],
+                $mutationType
+            );
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks whether a mutation list allows the given mutation type.
+     *
+     * @param mixed $mutationConfig Array of allowed mutations.
+     * @param string $mutationType Current mutation type.
+     *
+     * @return bool True when allowed (or "all" is present), false otherwise.
+     */
+    private function isRelatedObjectMutationAllowed(mixed $mutationConfig, string $mutationType): bool
+    {
+        if (is_array($mutationConfig) === false) {
+            return false;
+        }
+
+        $normalizedMutations = array_map(
+            static fn (mixed $mutation): string => strtolower((string) $mutation),
+            $mutationConfig
+        );
+
+        if (in_array('all', $normalizedMutations, true) === true) {
+            return true;
+        }
+
+        $normalizedMutationType = strtolower($mutationType);
+
+        // Create and update are treated as one "upsert" group for trigger checks.
+        if ($normalizedMutationType === 'create' || $normalizedMutationType === 'update') {
+            return in_array('create', $normalizedMutations, true) || in_array('update', $normalizedMutations, true);
+        }
+
+        // Delete remains strict and must be explicitly configured.
+        return $normalizedMutationType === 'delete' && in_array('delete', $normalizedMutations, true);
+    }
+
+    /**
+     * Determines whether an array has associative keys.
+     *
+     * @param array $array The array to inspect.
+     *
+     * @return bool True when associative, false when list-like.
+     */
+    private function isAssociativeArray(array $array): bool
+    {
+        if ($array === []) {
+            return false;
+        }
+
+        return array_keys($array) !== range(0, count($array) - 1);
+    }
+
 	public function createFromArray(array $object): Synchronization
 	{
 		$obj = new Synchronization();

--- a/lib/EventListener/ObjectCreatedEventListener.php
+++ b/lib/EventListener/ObjectCreatedEventListener.php
@@ -6,14 +6,12 @@ use OCA\OpenConnector\Service\SynchronizationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
-use Psr\Log\LoggerInterface;
 
 class ObjectCreatedEventListener implements IEventListener
 {
 
 	public function __construct(
 		private readonly SynchronizationService $synchronizationService,
-        private readonly LoggerInterface $logger,
 	)
 	{
 	}
@@ -32,23 +30,13 @@ class ObjectCreatedEventListener implements IEventListener
         }
 
         $object = $event->getObject();
-        $register = $object->getRegister();
-        $schema = $object->getSchema();
-        if ($object === null || $register === null || $schema === null) {
+        if ($object === null) {
             return;
         }
 
-        $synchronizations = $this->synchronizationService->findAllBySourceId(register: $register, schema: $schema);
-        foreach ($synchronizations as $synchronization) {
-            try {
-                $objectArray = $object->jsonSerialize();
-                $this->synchronizationService->synchronize(synchronization: $synchronization, force: true, object: $objectArray, mutationType: 'create');
-            } catch (\Exception $e) {
-                $this->logger->error('Failed to process object event: ' . $e->getMessage() . ' for synchronization ' . $synchronization->getId(), [
-                    'exception' => $e,
-                    'event' => get_class($event)
-                ]);
-            }
-        }
+        $this->synchronizationService->handleObjectEventSynchronization(
+            object: $object,
+            eventMutationType: 'create'
+        );
     }
 }

--- a/lib/EventListener/ObjectDeletedEventListener.php
+++ b/lib/EventListener/ObjectDeletedEventListener.php
@@ -6,14 +6,12 @@ use OCA\OpenConnector\Service\SynchronizationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCA\OpenRegister\Event\ObjectDeletedEvent;
-use Psr\Log\LoggerInterface;
 
 class ObjectDeletedEventListener implements IEventListener
 {
 
 	public function __construct(
 		private readonly SynchronizationService $synchronizationService,
-        private readonly LoggerInterface $logger,
 	)
 	{
 	}
@@ -32,22 +30,13 @@ class ObjectDeletedEventListener implements IEventListener
         }
 
         $object = $event->getObject();
-        $register = $object->getRegister();
-        $schema = $object->getSchema();
-        if ($object === null || $register === null || $schema === null) {
+        if ($object === null) {
             return;
         }
 
-        $synchronizations = $this->synchronizationService->findAllBySourceId(register: $register, schema: $schema);
-        foreach ($synchronizations as $synchronization) {
-            try {
-                $this->synchronizationService->synchronize(synchronization: $synchronization, force: true, object: $object, mutationType: 'delete');
-            } catch (\Exception $e) {
-                $this->logger->error('Failed to process object event: ' . $e->getMessage() . ' for synchronization ' . $synchronization->getId(), [
-                    'exception' => $e,
-                    'event' => get_class($event)
-                ]);
-            }
-        }
+        $this->synchronizationService->handleObjectEventSynchronization(
+            object: $object,
+            eventMutationType: 'delete'
+        );
     }
 }

--- a/lib/EventListener/ObjectUpdatedEventListener.php
+++ b/lib/EventListener/ObjectUpdatedEventListener.php
@@ -6,14 +6,12 @@ use OCA\OpenConnector\Service\SynchronizationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
-use Psr\Log\LoggerInterface;
 
 class ObjectUpdatedEventListener implements IEventListener
 {
 
 	public function __construct(
 		private readonly SynchronizationService $synchronizationService,
-        private readonly LoggerInterface $logger,
 	)
 	{
 	}
@@ -32,23 +30,13 @@ class ObjectUpdatedEventListener implements IEventListener
         }
 
         $object = $event->getNewObject();
-        $register = $object->getRegister();
-        $schema = $object->getSchema();
-        if ($object === null || $register === null || $schema === null) {
+        if ($object === null) {
             return;
         }
 
-        $synchronizations = $this->synchronizationService->findAllBySourceId(register: $register, schema: $schema);
-        foreach ($synchronizations as $synchronization) {
-            try {
-                $objectArray = $object->jsonSerialize();
-                $this->synchronizationService->synchronize(synchronization: $synchronization, force: true, object: $objectArray, mutationType: 'update');
-            } catch (\Exception $e) {
-                $this->logger->error('Failed to process object event: ' . $e->getMessage() . ' for synchronization ' . $synchronization->getId(), [
-                    'exception' => $e,
-                    'event' => get_class($event)
-                ]);
-            }
-        }
+        $this->synchronizationService->handleObjectEventSynchronization(
+            object: $object,
+            eventMutationType: 'update'
+        );
     }
 }

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -71,6 +71,8 @@ class SynchronizationService
     const MERGE_EXTRA_DATA_OBJECT_LOCATION      = 'mergeExtraData';
     const UNSET_CONFIG_KEY_LOCATION             = 'unsetConfigKey';
     const EXTRA_DATA_BEFORE_CONDITIONS_LOCATION = 'fetchExtraDataBeforeConditions';
+    const EXTEND_BEFORE_CONDITIONS_LOCATION     = 'extendInputBeforeConditions';
+    const EXTEND_BEFORE_CONDITIONS_FETCH_OBJECT = 'extendInputFetchObjectBeforeConditions';
     const FILE_TAG_TYPE                         = 'files';
     const VALID_MUTATION_TYPES                  = ['create', 'update', 'delete'];
     const DEFAULT_MAX_PAGES                     = 50; // Safety limit to prevent infinite page requesting loop
@@ -138,6 +140,204 @@ class SynchronizationService
 		return $this->synchronizationMapper->findAll(limit: null, offset: null, filters: ['source_id' => $sourceId]);
 	}
 
+    /**
+     * Handle synchronization for object create/update/delete events.
+     *
+     * This centralizes event listener behavior:
+     * - run direct source synchronizations for the object's register/schema
+     * - run related-object trigger synchronizations
+     *
+     * @param ObjectEntity $object The object from the event.
+     * @param string $eventMutationType The triggering mutation: create|update|delete
+     *
+     * @return void
+     */
+    public function handleObjectEventSynchronization(ObjectEntity $object, string $eventMutationType): void
+    {
+        if (in_array($eventMutationType, self::VALID_MUTATION_TYPES, true) === false) {
+            return;
+        }
+
+        $register = $object->getRegister();
+        $schema = $object->getSchema();
+        if ($register === null || $schema === null) {
+            return;
+        }
+
+        $objectArray = $object->jsonSerialize();
+        $processedSynchronizationIds = [];
+
+        $directSynchronizations = $this->findAllBySourceId(register: $register, schema: $schema);
+        foreach ($directSynchronizations as $synchronization) {
+            try {
+                if ($eventMutationType === 'delete') {
+                    $this->synchronize(
+                        synchronization: $synchronization,
+                        force: true,
+                        object: $object,
+                        mutationType: 'delete'
+                    );
+                } else {
+                    $this->synchronize(
+                        synchronization: $synchronization,
+                        force: true,
+                        object: $objectArray
+                    );
+                }
+
+                $processedSynchronizationIds[] = $synchronization->getId();
+            } catch (\Exception $e) {
+                $this->logger->error('Failed to process object event: ' . $e->getMessage() . ' for synchronization ' . $synchronization->getId(), [
+                    'exception' => $e,
+                    'eventMutationType' => $eventMutationType,
+                    'register' => $register,
+                    'schema' => $schema,
+                ]);
+            }
+        }
+
+        $triggeredSynchronizations = $this->synchronizationMapper->findAllByRelatedObjectTrigger(
+            register: $register,
+            schema: $schema,
+            mutationType: $eventMutationType
+        );
+
+        foreach ($triggeredSynchronizations as $synchronization) {
+            if (in_array($synchronization->getId(), $processedSynchronizationIds, true) === true) {
+                continue;
+            }
+
+            try {
+                $parentObjectArray = $this->resolveParentObjectForRelatedObjectTrigger(
+                    synchronization: $synchronization,
+                    triggerObject: $objectArray,
+                    triggerRegister: $register,
+                    triggerSchema: $schema,
+                    mutationType: $eventMutationType
+                );
+
+                if ($parentObjectArray === null) {
+                    continue;
+                }
+
+                $this->synchronize(
+                    synchronization: $synchronization,
+                    force: true,
+                    object: $parentObjectArray
+                );
+            } catch (\Exception $e) {
+                $this->logger->error('Failed to process related-object trigger: ' . $e->getMessage() . ' for synchronization ' . $synchronization->getId(), [
+                    'exception' => $e,
+                    'eventMutationType' => $eventMutationType,
+                    'register' => $register,
+                    'schema' => $schema,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Resolve and fetch the parent object for a related-object trigger.
+     *
+     * @param Synchronization $synchronization The synchronization that should run.
+     * @param array $triggerObject The related object payload from the event.
+     * @param string|int $triggerRegister The register of the related object source.
+     * @param string|int $triggerSchema The schema of the related object source.
+     *
+     * @return array|null The fetched parent object as array, or null when it cannot be resolved.
+     */
+    public function resolveParentObjectForRelatedObjectTrigger(
+        Synchronization $synchronization,
+        array $triggerObject,
+        string|int $triggerRegister,
+        string|int $triggerSchema,
+        ?string $mutationType = null
+    ): ?array {
+        if ($synchronization->getSourceType() !== 'register/schema') {
+            return null;
+        }
+
+        $sourceId = $synchronization->getSourceId();
+        if (empty($sourceId) === true || str_contains($sourceId, '/') === false) {
+            return null;
+        }
+
+        $triggerSourceId = "$triggerRegister/$triggerSchema";
+        $sourceConfig = $this->callService->applyConfigDot($synchronization->getSourceConfig());
+        $triggerConfig = $sourceConfig['triggerFromRelatedObjects'];
+
+        $relationKeys = [];
+        if (isset($triggerConfig[$triggerSourceId]) === true && is_array($triggerConfig[$triggerSourceId]) === true) {
+            $relationConfig = $triggerConfig[$triggerSourceId];
+            $firstRelationKey = array_key_first($relationConfig);
+            if (is_string($firstRelationKey) === true && trim($firstRelationKey) !== '') {
+                $relationKeys[] = trim($firstRelationKey);
+            }
+        }
+
+        if ($relationKeys === []) {
+            return null;
+        }
+
+        $triggerObjectDot = new Dot($triggerObject);
+        $relationReference = null;
+        foreach ($relationKeys as $relationKey) {
+            $candidateReference = $triggerObjectDot->get($relationKey);
+            if (is_string($candidateReference) === true && trim($candidateReference) !== '') {
+                $relationReference = trim($candidateReference);
+                break;
+            }
+        }
+
+        if ($relationReference === null) {
+            return null;
+        }
+
+        $parentObjectId = null;
+        if (Uuid::isValid($relationReference) === true) {
+            $parentObjectId = $relationReference;
+        } elseif (filter_var($relationReference, FILTER_VALIDATE_URL) !== false) {
+            $path = trim((string) parse_url($relationReference, PHP_URL_PATH), '/');
+            $segments = array_values(array_filter(explode('/', $path), static fn ($segment) => $segment !== ''));
+            $lastSegment = end($segments) ?: null;
+            if (is_string($lastSegment) === true && Uuid::isValid($lastSegment) === true) {
+                $parentObjectId = $lastSegment;
+            }
+        }
+
+        if ($parentObjectId === null) {
+            return null;
+        }
+
+        [$parentRegister, $parentSchema] = explode('/', $sourceId, 2);
+        $openRegisters = $this->objectService->getOpenRegisters();
+        if ($openRegisters === null) {
+            return null;
+        }
+
+        try {
+            $parentObject = $openRegisters->find(
+                id: $parentObjectId,
+                register: $parentRegister,
+                schema: $parentSchema
+            );
+
+            return $parentObject?->jsonSerialize();
+        } catch (\Throwable $e) {
+            $this->logger->debug('Failed resolving related parent object via configured relation key', [
+                'synchronizationId' => $synchronization->getId(),
+                'sourceId' => $sourceId,
+                'triggerSourceId' => $triggerSourceId,
+                'relationKeys' => $relationKeys,
+                'relationReference' => $relationReference,
+                'parentObjectId' => $parentObjectId,
+                'error' => $e->getMessage()
+            ]);
+
+            return null;
+        }
+    }
+
 	/**
 	 * Synchronizes internal data to external sources based on synchronization rules.
 	 *
@@ -165,9 +365,46 @@ class SynchronizationService
             $serializedObject = $object->jsonSerialize();
         }
 
+        $sourceConfig = $this->callService->applyConfigDot($synchronization->getSourceConfig());
+        if (isset($sourceConfig[self::EXTEND_BEFORE_CONDITIONS_LOCATION]) === true) {
+            $this->logger->debug('internToExtern before extendInputBeforeConditions', [
+                'objectId' => $serializedObject['@self']['id'] ?? $serializedObject['id'] ?? null,
+                'betrokkeneIdentificatie' => $serializedObject['betrokkeneIdentificatie'] ?? null,
+            ]);
+
+            $fetchObject = false;
+            if (isset($sourceConfig[self::EXTEND_BEFORE_CONDITIONS_FETCH_OBJECT]) === true) {
+                $fetchObject = filter_var(
+                    $sourceConfig[self::EXTEND_BEFORE_CONDITIONS_FETCH_OBJECT],
+                    FILTER_VALIDATE_BOOLEAN
+                ) === true;
+            }
+
+            $serializedObject = $this->processExtendInputRule(
+                config: [
+                    'extend_input' => [
+                        'properties' => $sourceConfig[self::EXTEND_BEFORE_CONDITIONS_LOCATION],
+                        'fetchObject' => $fetchObject,
+                    ]
+                ],
+                data: $serializedObject
+            );
+
+            $this->logger->debug('internToExtern after extendInputBeforeConditions', [
+                'objectId' => $serializedObject['@self']['id'] ?? $serializedObject['id'] ?? null,
+                'betrokkeneIdentificatie' => $serializedObject['betrokkeneIdentificatie'] ?? null,
+            ]);
+        }
+
 
 		if ($synchronization->getConditions() !== [] && !JsonLogic::apply($synchronization->getConditions(), $serializedObject)) {
 			return null;
+		}
+
+		// Keep the working object in sync with pre-condition enrichment so mapping
+		// and target payload generation use the same extended data.
+		if (is_array($serializedObject) === true) {
+			$object = $serializedObject;
 		}
 
 		$targetConfig = $synchronization->getTargetConfig();
@@ -2251,8 +2488,8 @@ class SynchronizationService
             } else if (isset($body['id']) === true) {
 				$targetId = $body['id'];
 			} else {
-				throw new Exception('Could not determine an id from target synchronization');
-			}
+					throw new Exception('Could not determine an id from target synchronization');
+				}
 
 			$contract->setTargetId($targetId);
 			return $contract;
@@ -2277,10 +2514,15 @@ class SynchronizationService
             $targetConfig['json'] = $this->processMapping(mapping: $mapping, data: $targetConfig['json']);
 		}
 
-		$response = $this->callService->call(source: $target, endpoint: $endpoint, method: $method, config: $targetConfig)->getResponse();
+			$response = $this->callService->call(source: $target, endpoint: $endpoint, method: $method, config: $targetConfig)->getResponse();
 
-		$body = array_merge(json_decode($response['body'], true), ['targetId' => $targetId]);
-        $targetObject = $body;
+            $decodedResponseBody = json_decode($response['body'] ?? '', true);
+            if (is_array($decodedResponseBody) === false) {
+                $decodedResponseBody = [];
+            }
+
+			$body = array_merge($decodedResponseBody, ['targetId' => $targetId]);
+	        $targetObject = $body;
 
 		return $contract;
 	}
@@ -3490,6 +3732,7 @@ class SynchronizationService
 
 		// Check if object adheres to conditions.
 		// Take note, JsonLogic::apply() returns a range of return types, so checking it with '=== false' or '!== true' does not work properly.
+		
 		if ($synchronization->getConditions() !== [] && !JsonLogic::apply($synchronization->getConditions(), $conditionsObject)) {
 			// Increment skipped count in log since object doesn't meet conditions
 			$result['objects']['skipped']++;


### PR DESCRIPTION
- Added related object triggers for synchronizations via sourceConfig.triggerFromRelatedObjects.
- Added mapper filtering to find synchronizations by related register/schema and allowed mutations.
- Added parent object resolution from configured relation key, with UUID or URL support.
- Fixed update API response handling to avoid crash on empty/non-JSON responses.