### PR TITLE
docs: Add dependency license policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,17 @@ Full documentation is available at **[conductionnl.github.io/openconnector](http
 
 ## License
 
-EUPL-1.2
+This project is licensed under the [EUPL-1.2](LICENSE).
 
+### Dependency license policy
+
+All dependencies (PHP and JavaScript) are automatically checked against an approved license allowlist during CI. The following SPDX license families are approved for use in dependencies:
+
+- **Permissive:** MIT, ISC, BSD-2-Clause, BSD-3-Clause, 0BSD, Apache-2.0, Unlicense, CC0-1.0, CC-BY-3.0, CC-BY-4.0, Zlib, BlueOak-1.0.0, Artistic-2.0, BSL-1.0
+- **Copyleft (EUPL-compatible):** LGPL-2.0/2.1/3.0, GPL-2.0/3.0, AGPL-3.0, EUPL-1.1/1.2, MPL-2.0
+- **Font licenses:** OFL-1.0, OFL-1.1
+
+Dependencies with licenses not on this list will fail CI unless explicitly approved in `.license-overrides.json` with a documented justification.
 ## Authors
 
 Built by [Conduction](https://conduction.nl) -- open-source software for Dutch government and public sector organizations.


### PR DESCRIPTION
## Summary
- Replaces the one-line license section with a full dependency license policy
- Documents the approved SPDX license families (permissive, copyleft, font)
- Explains how `.license-overrides.json` works for exceptions

This aligns with the new automated license compliance check in the shared quality workflow.