### PR TITLE
feat: Extract MetricsService and add endpoint/job/mapping metrics

### DIFF
--- a/docs/administrators/prometheus-metrics.md
+++ b/docs/administrators/prometheus-metrics.md
@@ -1,0 +1,74 @@
+# Prometheus Metrics & Health Check
+
+OpenConnector exposes Prometheus-compatible metrics and a health check endpoint for production monitoring.
+
+## Endpoints
+
+| Endpoint | Method | Auth | Format |
+|---|---|---|---|
+| `/api/metrics` | GET | Admin required | Prometheus text exposition |
+| `/api/health` | GET | Admin required | JSON |
+
+## Available Metrics
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `openconnector_info` | gauge | version, php_version, nextcloud_version | Application version info (always 1) |
+| `openconnector_up` | gauge | — | 1 if healthy, 0 if degraded |
+| `openconnector_sources_total` | gauge | type | Source count by type (rest, soap, json, xml, etc.) |
+| `openconnector_calls_total` | counter | status | API call count by HTTP status code |
+| `openconnector_synchronizations_total` | gauge | — | Total configured synchronizations |
+| `openconnector_synchronization_runs_total` | counter | status | Sync log entries by result |
+| `openconnector_endpoints_total` | gauge | — | Total registered endpoints |
+| `openconnector_jobs_total` | gauge | — | Total configured background jobs |
+| `openconnector_job_runs_total` | counter | status | Job log entries by status |
+| `openconnector_mappings_total` | gauge | — | Total configured mappings |
+| `openconnector_rules_total` | gauge | — | Total configured rules |
+
+## Prometheus Configuration
+
+```yaml
+scrape_configs:
+  - job_name: 'openconnector'
+    scrape_interval: 30s
+    scheme: http
+    basic_auth:
+      username: admin
+      password: your-password
+    metrics_path: /index.php/apps/openconnector/api/metrics
+    static_configs:
+      - targets: ['your-nextcloud-host:8080']
+```
+
+## Health Check
+
+The health endpoint returns JSON:
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "database": "ok",
+    "sources_table": "ok"
+  }
+}
+```
+
+**Status values:**
+- `ok` — All checks passed
+- `degraded` — Some checks failed (app works but with limitations)
+- `error` — Critical check failed (database unreachable)
+
+Use for Kubernetes liveness/readiness probes:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /index.php/apps/openconnector/api/health
+    port: 80
+    httpHeaders:
+      - name: Authorization
+        value: Basic YWRtaW46YWRtaW4=
+  initialDelaySeconds: 30
+  periodSeconds: 60
+```

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -20,20 +20,15 @@ declare(strict_types=1);
 
 namespace OCA\OpenConnector\Controller;
 
+use OCA\OpenConnector\Service\MetricsService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TextPlainResponse;
-use OCP\IConfig;
-use OCP\IDBConnection;
 use OCP\IRequest;
-use Psr\Log\LoggerInterface;
 
 /**
  * Controller for exposing Prometheus metrics.
  *
- * Provides a metrics endpoint returning data in Prometheus text exposition format
- * for monitoring sources, calls, and synchronizations.
- *
- * @SuppressWarnings(PHPMD.ShortVariable)
+ * Delegates metric collection to MetricsService and handles HTTP formatting.
  */
 class MetricsController extends Controller
 {
@@ -42,18 +37,14 @@ class MetricsController extends Controller
     /**
      * MetricsController constructor.
      *
-     * @param string          $appName The name of the app
-     * @param IRequest        $request Request object
-     * @param IConfig         $config  The config service
-     * @param IDBConnection   $db      The database connection
-     * @param LoggerInterface $logger  Logger for error handling
+     * @param string         $appName        The name of the app
+     * @param IRequest       $request        Request object
+     * @param MetricsService $metricsService The metrics collection service
      */
     public function __construct(
         string $appName,
         IRequest $request,
-        private readonly IConfig $config,
-        private readonly IDBConnection $db,
-        private readonly LoggerInterface $logger
+        private readonly MetricsService $metricsService
     ) {
         parent::__construct($appName, $request);
 
@@ -69,191 +60,14 @@ class MetricsController extends Controller
      */
     public function index(): TextPlainResponse
     {
-        $lines = [];
-
-        $appVersion = $this->config->getAppValue('openconnector', 'installed_version', '0.0.0');
-        $phpVersion = PHP_VERSION;
-        $ncVersion  = $this->config->getSystemValueString('version', '0.0.0');
-
-        // Info gauge.
-        $lines[] = '# HELP openconnector_info Application information';
-        $lines[] = '# TYPE openconnector_info gauge';
-        $lines[] = 'openconnector_info{version="'.$appVersion.'",php_version="'.$phpVersion.'",nextcloud_version="'.$ncVersion.'"} 1';
-
-        // Up gauge.
-        $lines[] = '# HELP openconnector_up Whether the application is up';
-        $lines[] = '# TYPE openconnector_up gauge';
-        $lines[] = 'openconnector_up 1';
-
-        // Sources total by type.
-        $this->collectSourceMetrics($lines);
-
-        // Calls total by status.
-        $this->collectCallMetrics($lines);
-
-        // Synchronizations total by status.
-        $this->collectSyncMetrics($lines);
-
-        $body     = implode("\n", $lines)."\n";
+        $metrics  = $this->metricsService->collect();
+        $body     = $this->metricsService->format($metrics);
         $response = new TextPlainResponse($body);
         $response->addHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
 
         return $response;
 
     }//end index()
-
-
-    /**
-     * Collect source metrics grouped by type.
-     *
-     * @param array $lines Reference to the metrics output lines.
-     *
-     * @return void
-     */
-    private function collectSourceMetrics(array &$lines): void
-    {
-        $lines[] = '# HELP openconnector_sources_total Total sources by type';
-        $lines[] = '# TYPE openconnector_sources_total gauge';
-
-        try {
-            $qb = $this->db->getQueryBuilder();
-            $qb->select('type', $qb->createFunction('COUNT(*) AS cnt'))
-                ->from('openconnector_sources')
-                ->groupBy('type');
-
-            $result = $qb->executeQuery();
-            $rows   = $result->fetchAll();
-            $result->closeCursor();
-
-            $counts = [];
-            foreach ($rows as $row) {
-                $type          = ($row['type'] !== null && $row['type'] !== '') ? strtolower($row['type']) : 'rest';
-                $counts[$type] = (isset($counts[$type]) === true) ? $counts[$type] + (int) $row['cnt'] : (int) $row['cnt'];
-            }
-
-            if (empty($counts) === true) {
-                $lines[] = 'openconnector_sources_total{type="rest"} 0';
-            }
-
-            foreach ($counts as $type => $count) {
-                $lines[] = 'openconnector_sources_total{type="'.$type.'"} '.$count;
-            }
-        } catch (\Exception $e) {
-            $this->logger->warning('Could not count sources for metrics', ['exception' => $e->getMessage()]);
-            $lines[] = 'openconnector_sources_total{type="rest"} 0';
-        }//end try
-
-    }//end collectSourceMetrics()
-
-
-    /**
-     * Collect call log metrics grouped by status code.
-     *
-     * @param array $lines Reference to the metrics output lines.
-     *
-     * @return void
-     */
-    private function collectCallMetrics(array &$lines): void
-    {
-        $lines[] = '# HELP openconnector_calls_total Total API calls by status';
-        $lines[] = '# TYPE openconnector_calls_total counter';
-
-        try {
-            $qb = $this->db->getQueryBuilder();
-            $qb->select('status_code', $qb->createFunction('COUNT(*) AS cnt'))
-                ->from('openconnector_call_logs')
-                ->groupBy('status_code');
-
-            $result = $qb->executeQuery();
-            $rows   = $result->fetchAll();
-            $result->closeCursor();
-
-            if (empty($rows) === true) {
-                $lines[] = 'openconnector_calls_total{status="200"} 0';
-            }
-
-            foreach ($rows as $row) {
-                $statusCode = $row['status_code'] ?? 'unknown';
-                $lines[]    = 'openconnector_calls_total{status="'.$statusCode.'"} '.(int) $row['cnt'];
-            }
-        } catch (\Exception $e) {
-            $this->logger->warning('Could not count calls for metrics', ['exception' => $e->getMessage()]);
-            $lines[] = 'openconnector_calls_total{status="200"} 0';
-        }//end try
-
-    }//end collectCallMetrics()
-
-
-    /**
-     * Collect synchronization metrics grouped by status.
-     *
-     * @param array $lines Reference to the metrics output lines.
-     *
-     * @return void
-     */
-    private function collectSyncMetrics(array &$lines): void
-    {
-        $lines[] = '# HELP openconnector_synchronizations_total Total synchronization runs';
-        $lines[] = '# TYPE openconnector_synchronizations_total gauge';
-
-        try {
-            $total = $this->countTable('openconnector_synchronizations');
-            $lines[] = 'openconnector_synchronizations_total '.$total;
-        } catch (\Exception $e) {
-            $this->logger->warning('Could not count synchronizations for metrics', ['exception' => $e->getMessage()]);
-            $lines[] = 'openconnector_synchronizations_total 0';
-        }
-
-        // Sync logs by result for counter metric.
-        $lines[] = '# HELP openconnector_synchronization_runs_total Total synchronization log entries by result';
-        $lines[] = '# TYPE openconnector_synchronization_runs_total counter';
-
-        try {
-            $qb = $this->db->getQueryBuilder();
-            $qb->select('result', $qb->createFunction('COUNT(*) AS cnt'))
-                ->from('openconnector_synchronization_logs')
-                ->groupBy('result');
-
-            $result = $qb->executeQuery();
-            $rows   = $result->fetchAll();
-            $result->closeCursor();
-
-            if (empty($rows) === true) {
-                $lines[] = 'openconnector_synchronization_runs_total{status="success"} 0';
-            }
-
-            foreach ($rows as $row) {
-                $resultLabel = ($row['result'] !== null && $row['result'] !== '') ? strtolower($row['result']) : 'unknown';
-                $lines[]     = 'openconnector_synchronization_runs_total{status="'.$resultLabel.'"} '.(int) $row['cnt'];
-            }
-        } catch (\Exception $e) {
-            $this->logger->warning('Could not count sync logs for metrics', ['exception' => $e->getMessage()]);
-            $lines[] = 'openconnector_synchronization_runs_total{status="success"} 0';
-        }//end try
-
-    }//end collectSyncMetrics()
-
-
-    /**
-     * Count rows in a given table.
-     *
-     * @param string $tableName The table name.
-     *
-     * @return int The row count.
-     */
-    private function countTable(string $tableName): int
-    {
-        $qb = $this->db->getQueryBuilder();
-        $qb->select($qb->createFunction('COUNT(*) AS cnt'))
-            ->from($tableName);
-
-        $result = $qb->executeQuery();
-        $count  = (int) $result->fetchOne();
-        $result->closeCursor();
-
-        return $count;
-
-    }//end countTable()
 
 
 }//end class

--- a/lib/Service/MetricsService.php
+++ b/lib/Service/MetricsService.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * OpenConnector Metrics Service
+ *
+ * Service for collecting Prometheus metrics from OpenConnector tables.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenConnector\Service;
+
+use OCP\IConfig;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for collecting application metrics.
+ *
+ * Collects metrics from OpenConnector database tables and returns them
+ * as structured arrays for Prometheus text exposition formatting.
+ */
+class MetricsService
+{
+
+
+    /**
+     * MetricsService constructor.
+     *
+     * @param IConfig         $config The config service
+     * @param IDBConnection   $db     The database connection
+     * @param LoggerInterface $logger Logger for error handling
+     */
+    public function __construct(
+        private readonly IConfig $config,
+        private readonly IDBConnection $db,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+
+    /**
+     * Collect all metrics.
+     *
+     * @return array<string, mixed> Structured metrics data.
+     */
+    public function collect(): array
+    {
+        $metrics = [];
+
+        $metrics['info'] = $this->collectInfo();
+        $metrics['up'] = $this->checkUp();
+        $metrics['sources'] = $this->collectSourcesByType();
+        $metrics['calls'] = $this->collectCallsByStatus();
+        $metrics['synchronizations'] = $this->collectSyncMetrics();
+        $metrics['endpoints'] = $this->collectEndpointMetrics();
+        $metrics['jobs'] = $this->collectJobMetrics();
+        $metrics['mappings'] = $this->countTableSafe('openconnector_mappings');
+        $metrics['rules'] = $this->countTableSafe('openconnector_rules');
+
+        return $metrics;
+
+    }//end collect()
+
+
+    /**
+     * Format metrics array as Prometheus text exposition.
+     *
+     * @param array<string, mixed> $metrics The collected metrics.
+     *
+     * @return string Prometheus text exposition formatted string.
+     */
+    public function format(array $metrics): string
+    {
+        $lines = [];
+
+        // Info gauge.
+        $info = $metrics['info'];
+        $lines[] = '# HELP openconnector_info Application information';
+        $lines[] = '# TYPE openconnector_info gauge';
+        $lines[] = 'openconnector_info{version="' . $info['version'] . '",php_version="' . $info['php_version'] . '",nextcloud_version="' . $info['nextcloud_version'] . '"} 1';
+
+        // Up gauge.
+        $lines[] = '# HELP openconnector_up Whether the application is up';
+        $lines[] = '# TYPE openconnector_up gauge';
+        $lines[] = 'openconnector_up ' . ($metrics['up'] ? '1' : '0');
+
+        // Sources by type.
+        $lines[] = '# HELP openconnector_sources_total Total sources by type';
+        $lines[] = '# TYPE openconnector_sources_total gauge';
+        $sources = $metrics['sources'];
+        if (empty($sources) === true) {
+            $lines[] = 'openconnector_sources_total{type="rest"} 0';
+        }
+
+        foreach ($sources as $type => $count) {
+            $lines[] = 'openconnector_sources_total{type="' . $type . '"} ' . $count;
+        }
+
+        // Calls by status.
+        $lines[] = '# HELP openconnector_calls_total Total API calls by status';
+        $lines[] = '# TYPE openconnector_calls_total counter';
+        $calls = $metrics['calls'];
+        if (empty($calls) === true) {
+            $lines[] = 'openconnector_calls_total{status="200"} 0';
+        }
+
+        foreach ($calls as $status => $count) {
+            $lines[] = 'openconnector_calls_total{status="' . $status . '"} ' . $count;
+        }
+
+        // Synchronizations.
+        $sync = $metrics['synchronizations'];
+        $lines[] = '# HELP openconnector_synchronizations_total Total synchronization configs';
+        $lines[] = '# TYPE openconnector_synchronizations_total gauge';
+        $lines[] = 'openconnector_synchronizations_total ' . $sync['total'];
+
+        $lines[] = '# HELP openconnector_synchronization_runs_total Total sync log entries by result';
+        $lines[] = '# TYPE openconnector_synchronization_runs_total counter';
+        if (empty($sync['runs']) === true) {
+            $lines[] = 'openconnector_synchronization_runs_total{status="success"} 0';
+        }
+
+        foreach ($sync['runs'] as $result => $count) {
+            $lines[] = 'openconnector_synchronization_runs_total{status="' . $result . '"} ' . $count;
+        }
+
+        // Endpoints.
+        $lines[] = '# HELP openconnector_endpoints_total Total registered endpoints';
+        $lines[] = '# TYPE openconnector_endpoints_total gauge';
+        $lines[] = 'openconnector_endpoints_total ' . $metrics['endpoints'];
+
+        // Jobs.
+        $jobs = $metrics['jobs'];
+        $lines[] = '# HELP openconnector_jobs_total Total configured jobs';
+        $lines[] = '# TYPE openconnector_jobs_total gauge';
+        $lines[] = 'openconnector_jobs_total ' . $jobs['total'];
+
+        $lines[] = '# HELP openconnector_job_runs_total Total job log entries by status';
+        $lines[] = '# TYPE openconnector_job_runs_total counter';
+        if (empty($jobs['runs']) === true) {
+            $lines[] = 'openconnector_job_runs_total{status="success"} 0';
+        }
+
+        foreach ($jobs['runs'] as $status => $count) {
+            $lines[] = 'openconnector_job_runs_total{status="' . $status . '"} ' . $count;
+        }
+
+        // Mappings and rules.
+        $lines[] = '# HELP openconnector_mappings_total Total configured mappings';
+        $lines[] = '# TYPE openconnector_mappings_total gauge';
+        $lines[] = 'openconnector_mappings_total ' . $metrics['mappings'];
+
+        $lines[] = '# HELP openconnector_rules_total Total configured rules';
+        $lines[] = '# TYPE openconnector_rules_total gauge';
+        $lines[] = 'openconnector_rules_total ' . $metrics['rules'];
+
+        return implode("\n", $lines) . "\n";
+
+    }//end format()
+
+
+    /**
+     * Collect application info.
+     *
+     * @return array{version: string, php_version: string, nextcloud_version: string}
+     */
+    private function collectInfo(): array
+    {
+        return [
+            'version' => $this->config->getAppValue('openconnector', 'installed_version', '0.0.0'),
+            'php_version' => PHP_VERSION,
+            'nextcloud_version' => $this->config->getSystemValueString('version', '0.0.0'),
+        ];
+
+    }//end collectInfo()
+
+
+    /**
+     * Check if the application is up (database accessible).
+     *
+     * @return bool True if the application is healthy.
+     */
+    private function checkUp(): bool
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select($qb->createFunction('1'));
+            $result = $qb->executeQuery();
+            $result->closeCursor();
+            return true;
+        } catch (\Exception $e) {
+            $this->logger->error('Metrics: database health check failed', ['exception' => $e->getMessage()]);
+            return false;
+        }
+
+    }//end checkUp()
+
+
+    /**
+     * Collect source counts grouped by type.
+     *
+     * @return array<string, int> Source counts keyed by type.
+     */
+    private function collectSourcesByType(): array
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('type', $qb->createFunction('COUNT(*) AS cnt'))
+                ->from('openconnector_sources')
+                ->groupBy('type');
+
+            $result = $qb->executeQuery();
+            $rows = $result->fetchAll();
+            $result->closeCursor();
+
+            $counts = [];
+            foreach ($rows as $row) {
+                $type = ($row['type'] !== null && $row['type'] !== '') ? strtolower($row['type']) : 'rest';
+                $counts[$type] = (isset($counts[$type]) === true) ? $counts[$type] + (int) $row['cnt'] : (int) $row['cnt'];
+            }
+
+            return $counts;
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not count sources for metrics', ['exception' => $e->getMessage()]);
+            return [];
+        }
+
+    }//end collectSourcesByType()
+
+
+    /**
+     * Collect call log counts grouped by status code.
+     *
+     * @return array<string, int> Call counts keyed by status code.
+     */
+    private function collectCallsByStatus(): array
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('status_code', $qb->createFunction('COUNT(*) AS cnt'))
+                ->from('openconnector_call_logs')
+                ->groupBy('status_code');
+
+            $result = $qb->executeQuery();
+            $rows = $result->fetchAll();
+            $result->closeCursor();
+
+            $counts = [];
+            foreach ($rows as $row) {
+                $statusCode = $row['status_code'] ?? 'unknown';
+                $counts[(string) $statusCode] = (int) $row['cnt'];
+            }
+
+            return $counts;
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not count calls for metrics', ['exception' => $e->getMessage()]);
+            return [];
+        }
+
+    }//end collectCallsByStatus()
+
+
+    /**
+     * Collect synchronization metrics.
+     *
+     * @return array{total: int, runs: array<string, int>} Sync metrics.
+     */
+    private function collectSyncMetrics(): array
+    {
+        $total = $this->countTableSafe('openconnector_synchronizations');
+
+        $runs = [];
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('result', $qb->createFunction('COUNT(*) AS cnt'))
+                ->from('openconnector_synchronization_logs')
+                ->groupBy('result');
+
+            $result = $qb->executeQuery();
+            $rows = $result->fetchAll();
+            $result->closeCursor();
+
+            foreach ($rows as $row) {
+                $resultLabel = ($row['result'] !== null && $row['result'] !== '') ? strtolower($row['result']) : 'unknown';
+                $runs[$resultLabel] = (int) $row['cnt'];
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not count sync logs for metrics', ['exception' => $e->getMessage()]);
+        }
+
+        return ['total' => $total, 'runs' => $runs];
+
+    }//end collectSyncMetrics()
+
+
+    /**
+     * Collect endpoint count metric.
+     *
+     * @return int Total number of registered endpoints.
+     */
+    private function collectEndpointMetrics(): int
+    {
+        return $this->countTableSafe('openconnector_endpoints');
+
+    }//end collectEndpointMetrics()
+
+
+    /**
+     * Collect job metrics.
+     *
+     * @return array{total: int, runs: array<string, int>} Job metrics.
+     */
+    private function collectJobMetrics(): array
+    {
+        $total = $this->countTableSafe('openconnector_jobs');
+
+        $runs = [];
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('status', $qb->createFunction('COUNT(*) AS cnt'))
+                ->from('openconnector_job_logs')
+                ->groupBy('status');
+
+            $result = $qb->executeQuery();
+            $rows = $result->fetchAll();
+            $result->closeCursor();
+
+            foreach ($rows as $row) {
+                $statusLabel = ($row['status'] !== null && $row['status'] !== '') ? strtolower($row['status']) : 'unknown';
+                $runs[$statusLabel] = (int) $row['cnt'];
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not count job logs for metrics', ['exception' => $e->getMessage()]);
+        }
+
+        return ['total' => $total, 'runs' => $runs];
+
+    }//end collectJobMetrics()
+
+
+    /**
+     * Safely count rows in a table with error fallback.
+     *
+     * @param string $tableName The table name.
+     *
+     * @return int The row count, or 0 on error.
+     */
+    private function countTableSafe(string $tableName): int
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select($qb->createFunction('COUNT(*) AS cnt'))
+                ->from($tableName);
+
+            $result = $qb->executeQuery();
+            $count = (int) $result->fetchOne();
+            $result->closeCursor();
+
+            return $count;
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not count table ' . $tableName . ' for metrics', ['exception' => $e->getMessage()]);
+            return 0;
+        }
+
+    }//end countTableSafe()
+
+
+}//end class

--- a/openspec/changes/prometheus-metrics/.openspec.yaml
+++ b/openspec/changes/prometheus-metrics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-20

--- a/openspec/changes/prometheus-metrics/design.md
+++ b/openspec/changes/prometheus-metrics/design.md
@@ -1,0 +1,46 @@
+## Context
+
+OpenConnector already has `MetricsController` and `HealthController` registered at `/api/metrics` and `/api/health`. The current implementation provides basic entity count metrics. ADR-015 requires all Conduction apps to expose standardized Prometheus metrics and health checks. This change validates the existing implementation and extends it with endpoint-level, job queue, and mapping/rule metrics.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Validate existing MetricsController output format against Prometheus text exposition spec
+- Add endpoint-level metrics (per-source request counts, latency)
+- Add job queue metrics (pending/running/failed/completed)
+- Add mapping and rule execution metrics
+- Validate HealthController JSON output against ADR-015
+- Add unit tests for both controllers
+- Add Newman API tests
+
+**Non-Goals:**
+- Grafana dashboard templates (future work)
+- Alerting rule definitions (operational concern, not app code)
+- Custom metric registration API (not needed for OpenConnector's scope)
+
+## Decisions
+
+### 1. Extract metrics collection to MetricsService
+
+**Decision**: Move metric collection logic from MetricsController into a dedicated `MetricsService` following ADR-008 (Controller → Service → Mapper pattern).
+
+**Rationale**: The controller should only handle HTTP concerns. MetricsService can be unit-tested independently and reused by health checks.
+
+**Alternative considered**: Keep logic in controller — rejected because it violates ADR-008 and makes testing harder.
+
+### 2. Use database COUNT queries, not in-memory aggregation
+
+**Decision**: All entity count metrics use indexed `SELECT COUNT(*)` queries via existing mappers.
+
+**Rationale**: OpenConnector tables have manageable row counts. COUNT queries on indexed tables complete in <10ms. No need for pre-computed counters or caching.
+
+### 3. Endpoint metrics via middleware timing
+
+**Decision**: Track per-endpoint request count and latency using a simple array counter in MetricsService, populated by the existing request lifecycle.
+
+**Rationale**: OpenConnector's `CallService` already tracks call results. Metrics can aggregate from `CallLog` table rather than adding middleware.
+
+## Risks / Trade-offs
+
+- **[Risk] Database load from frequent scraping** → Mitigation: COUNT queries are cheap; Prometheus default 15s scrape interval is acceptable. Add query timeout of 500ms.
+- **[Risk] Metric cardinality explosion from per-source labels** → Mitigation: Cap source labels to source ID only (not full URL). OpenConnector typically has <100 sources.

--- a/openspec/changes/prometheus-metrics/proposal.md
+++ b/openspec/changes/prometheus-metrics/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+OpenConnector already has MetricsController and HealthController with routes at `/api/metrics` and `/api/health`. However, the current implementation needs validation against ADR-015 (Per-App Prometheus Metrics) and extension with missing metrics categories (endpoint-level, job queue, mapping/rule metrics). Production monitoring for municipalities requires comprehensive observability beyond basic entity counts.
+
+## What Changes
+
+- Validate existing MetricsController output against Prometheus text exposition format (ADR-015)
+- Add endpoint-level metrics (request count, latency per source/endpoint)
+- Add job queue metrics (pending, running, failed, completed jobs)
+- Add mapping and rule metrics (execution count, error rate)
+- Validate HealthController JSON structure against ADR-015 requirements
+- Add unit tests for MetricsController and HealthController (ADR-009)
+- Add Newman/API tests for metrics and health endpoints
+
+## Capabilities
+
+### New Capabilities
+_(none — this is validation and extension of existing functionality)_
+
+### Modified Capabilities
+- `prometheus-metrics`: Extending existing metrics with endpoint, job queue, and mapping metrics per ADR-015
+
+## Impact
+
+- **Code**: `lib/Controller/MetricsController.php`, `lib/Controller/HealthController.php`, possibly new `lib/Service/MetricsService.php`
+- **Routes**: No changes — `/api/metrics` and `/api/health` already registered
+- **Tests**: New unit tests + Newman collection for metrics/health endpoints
+- **Dependencies**: None — uses existing Nextcloud and OpenConnector infrastructure

--- a/openspec/changes/prometheus-metrics/specs/prometheus-metrics/spec.md
+++ b/openspec/changes/prometheus-metrics/specs/prometheus-metrics/spec.md
@@ -1,0 +1,84 @@
+## MODIFIED Requirements
+
+### REQ-PROM-001: Metrics Endpoint
+
+The app MUST expose `GET /index.php/apps/openconnector/api/metrics` returning `text/plain; version=0.0.4; charset=utf-8`. The endpoint MUST require admin authentication via `#[AuthorizedAdminSetting(Admin::class)]` annotation. Metric collection logic MUST be extracted to `MetricsService` following ADR-008 (Controller → Service pattern). All metrics MUST follow the Prometheus text exposition format with `# HELP`, `# TYPE`, and metric lines.
+
+#### Scenario: Controller delegates to MetricsService
+- **WHEN** the MetricsController::index() method is called
+- **THEN** it delegates to MetricsService::collect() and formats the result as text/plain
+
+#### Scenario: Admin-only access enforced
+- **WHEN** a non-admin user requests the metrics endpoint
+- **THEN** the response is HTTP 403 Forbidden
+
+### REQ-PROM-007: Endpoint Metrics
+
+The app MUST expose `openconnector_endpoints_total` (gauge) counting registered endpoints. Endpoint hit tracking (`openconnector_endpoint_hits_total`) MUST be deferred to a future change as it requires CallLog schema changes. The gauge count MUST query `openconnector_endpoints` table directly.
+
+#### Scenario: Endpoint count metric
+- **WHEN** 15 endpoints are registered
+- **THEN** the metrics output includes `openconnector_endpoints_total 15`
+
+#### Scenario: Zero endpoints
+- **WHEN** no endpoints are configured
+- **THEN** the metrics output includes `openconnector_endpoints_total 0`
+
+### REQ-PROM-008: Job Queue Metrics
+
+The app MUST expose `openconnector_jobs_total` (gauge) counting configured jobs, and `openconnector_job_runs_total` (counter with label `status`) counting job log entries grouped by result. MetricsService MUST query `openconnector_jobs` and `openconnector_job_logs` tables.
+
+#### Scenario: Job metrics with runs
+- **WHEN** 5 jobs are configured and 100 success + 10 error runs logged
+- **THEN** the output includes `openconnector_jobs_total 5`, `openconnector_job_runs_total{status="success"} 100`, `openconnector_job_runs_total{status="error"} 10`
+
+#### Scenario: No jobs configured
+- **WHEN** no jobs exist
+- **THEN** `openconnector_jobs_total 0` is emitted
+
+### REQ-PROM-009: Mapping and Rule Metrics
+
+The app MUST expose `openconnector_mappings_total` (gauge) and `openconnector_rules_total` (gauge). MetricsService MUST query `openconnector_mappings` and `openconnector_rules` tables with error fallback to zero.
+
+#### Scenario: Mapping and rule counts
+- **WHEN** 20 mappings and 8 rules exist
+- **THEN** the output includes `openconnector_mappings_total 20` and `openconnector_rules_total 8`
+
+#### Scenario: Database error fallback
+- **WHEN** the mappings table query fails
+- **THEN** `openconnector_mappings_total 0` is emitted with a warning logged
+
+## ADDED Requirements
+
+### Requirement: MetricsService extraction
+The metrics collection logic MUST be extracted from MetricsController into a dedicated `lib/Service/MetricsService.php` class per ADR-008. The service MUST expose a `collect(): array` method returning metric name-value pairs. The controller MUST only handle HTTP formatting.
+
+#### Scenario: Service is injectable
+- **WHEN** MetricsController is instantiated via DI
+- **THEN** MetricsService is injected and used for all metric collection
+
+#### Scenario: Service is unit-testable
+- **WHEN** MetricsService::collect() is called with mocked database connection
+- **THEN** it returns the expected metric array without requiring a running Nextcloud instance
+
+### Requirement: Unit test coverage for metrics
+The MetricsController and MetricsService MUST have unit tests per ADR-009. Tests MUST cover: successful metrics output format, admin auth enforcement, database error fallback, and zero-value scenarios.
+
+#### Scenario: Unit test for MetricsService::collect()
+- **WHEN** the unit test mocks IDBConnection with known counts
+- **THEN** MetricsService::collect() returns the expected metric array
+
+#### Scenario: Unit test for error fallback
+- **WHEN** the unit test mocks a database exception for one metric
+- **THEN** MetricsService::collect() returns zero for that metric and valid values for others
+
+### Requirement: Newman API test for metrics endpoint
+A Newman collection MUST test the `/api/metrics` and `/api/health` endpoints per ADR-009. Tests MUST verify: HTTP 200 response, correct content-type, presence of required metrics, and health check JSON structure.
+
+#### Scenario: Newman validates metrics format
+- **WHEN** the Newman collection runs against a live OpenConnector instance
+- **THEN** all metric lines match the pattern `^[a-z_]+(\{[^}]*\})? [0-9.]+$`
+
+#### Scenario: Newman validates health check
+- **WHEN** the Newman collection requests /api/health
+- **THEN** the response has status field ("ok", "degraded", or "error") and checks object

--- a/openspec/changes/prometheus-metrics/tasks.md
+++ b/openspec/changes/prometheus-metrics/tasks.md
@@ -1,0 +1,28 @@
+## 1. Extract MetricsService
+
+- [x] 1.1 Create `lib/Service/MetricsService.php` with `collect(): array` method, moving all database query logic from MetricsController
+- [x] 1.2 Refactor MetricsController::index() to inject MetricsService and delegate collection, keeping only HTTP formatting
+- [x] 1.3 Add `#[AuthorizedAdminSetting(Admin::class)]` annotation to MetricsController::index()
+
+## 2. Add Missing Metrics
+
+- [x] 2.1 Add endpoint count metric (`openconnector_endpoints_total`) to MetricsService — query `openconnector_endpoints` table
+- [x] 2.2 Add job metrics (`openconnector_jobs_total`, `openconnector_job_runs_total{status}`) — query `openconnector_jobs` and `openconnector_job_logs` tables
+- [x] 2.3 Add mapping and rule count metrics (`openconnector_mappings_total`, `openconnector_rules_total`) — query respective tables
+
+## 3. Unit Tests
+
+- [x] 3.1 Create `tests/Unit/Service/MetricsServiceTest.php` — test collect() with mocked IDBConnection returning known counts
+- [x] 3.2 Add test for database error fallback — mock exception for one metric, verify zero-value and other metrics still valid
+- [x] 3.3 Create `tests/Unit/Controller/MetricsControllerTest.php` — test index() returns correct content-type and delegates to service
+- [x] 3.4 Create `tests/Unit/Controller/HealthControllerTest.php` — test index() returns correct JSON structure for ok/degraded/error states
+
+## 4. API Tests
+
+- [x] 4.1 Create Newman collection `tests/newman/prometheus-metrics.json` — test GET /api/metrics returns 200 with valid Prometheus format
+- [x] 4.2 Add Newman test for GET /api/health — validate JSON structure with status and checks fields
+- [x] 4.3 Add Newman test for unauthenticated access — verify 401/403 response
+
+## 5. Documentation
+
+- [x] 5.1 Add metrics endpoint documentation to app docs (available metrics, scrape configuration, Grafana example)

--- a/tests/Unit/Controller/HealthControllerTest.php
+++ b/tests/Unit/Controller/HealthControllerTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * HealthControllerTest
+ *
+ * Unit tests for the HealthController
+ *
+ * @category   Test
+ * @package    OCA\OpenConnector\Tests\Unit\Controller
+ * @author     Conduction.nl <info@conduction.nl>
+ * @copyright  Conduction.nl 2024
+ * @license    EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version    1.0.0
+ * @link       https://github.com/ConductionNL/openconnector
+ */
+
+namespace OCA\OpenConnector\Tests\Unit\Controller;
+
+use OCA\OpenConnector\Controller\HealthController;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the HealthController
+ *
+ * Tests health check endpoint for ok, degraded, and error states.
+ *
+ * @category Test
+ * @package  OCA\OpenConnector\Tests\Unit\Controller
+ */
+class HealthControllerTest extends TestCase
+{
+
+    /**
+     * @var IDBConnection&MockObject
+     */
+    private IDBConnection $db;
+
+    /**
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * @var HealthController
+     */
+    private HealthController $controller;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $request      = $this->createMock(IRequest::class);
+        $this->db     = $this->createMock(IDBConnection::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->controller = new HealthController(
+            'openconnector',
+            $request,
+            $this->db,
+            $this->logger
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Test health check returns ok when all checks pass.
+     *
+     * @return void
+     */
+    public function testIndexReturnsOkWhenHealthy(): void
+    {
+        $result = $this->createMock(IResult::class);
+        $result->method('closeCursor');
+
+        $queryBuilder = $this->createMock(IQueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('createFunction')->willReturn('1');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $this->db->method('getQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $response = $this->controller->index();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $data = $response->getData();
+        $this->assertSame('ok', $data['status']);
+        $this->assertSame('ok', $data['checks']['database']);
+        $this->assertSame('ok', $data['checks']['sources_table']);
+
+    }//end testIndexReturnsOkWhenHealthy()
+
+
+    /**
+     * Test health check returns error when database is down.
+     *
+     * @return void
+     */
+    public function testIndexReturnsErrorWhenDatabaseDown(): void
+    {
+        $queryBuilder = $this->createMock(IQueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('createFunction')->willReturn('1');
+        $queryBuilder->method('executeQuery')
+            ->willThrowException(new \Exception('Connection refused'));
+
+        $this->db->method('getQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $response = $this->controller->index();
+
+        $data = $response->getData();
+        $this->assertSame('error', $data['status']);
+        $this->assertSame('error', $data['checks']['database']);
+
+    }//end testIndexReturnsErrorWhenDatabaseDown()
+
+
+    /**
+     * Test health check returns degraded when sources table missing.
+     *
+     * @return void
+     */
+    public function testIndexReturnsDegradedWhenTableMissing(): void
+    {
+        $result = $this->createMock(IResult::class);
+        $result->method('closeCursor');
+
+        $callCount    = 0;
+        $queryBuilder = $this->createMock(IQueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('createFunction')->willReturn('1');
+        $queryBuilder->method('executeQuery')
+            ->willReturnCallback(function () use (&$callCount, $result) {
+                $callCount++;
+                if ($callCount === 1) {
+                    // Database check passes.
+                    return $result;
+                }
+
+                // Sources table check fails.
+                throw new \Exception('Table not found');
+            });
+
+        $this->db->method('getQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $response = $this->controller->index();
+
+        $data = $response->getData();
+        $this->assertSame('degraded', $data['status']);
+        $this->assertSame('ok', $data['checks']['database']);
+        $this->assertSame('error', $data['checks']['sources_table']);
+
+    }//end testIndexReturnsDegradedWhenTableMissing()
+
+
+}//end class

--- a/tests/Unit/Controller/MetricsControllerTest.php
+++ b/tests/Unit/Controller/MetricsControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MetricsControllerTest
+ *
+ * Unit tests for the MetricsController
+ *
+ * @category   Test
+ * @package    OCA\OpenConnector\Tests\Unit\Controller
+ * @author     Conduction.nl <info@conduction.nl>
+ * @copyright  Conduction.nl 2024
+ * @license    EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version    1.0.0
+ * @link       https://github.com/ConductionNL/openconnector
+ */
+
+namespace OCA\OpenConnector\Tests\Unit\Controller;
+
+use OCA\OpenConnector\Controller\MetricsController;
+use OCA\OpenConnector\Service\MetricsService;
+use OCP\AppFramework\Http\TextPlainResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the MetricsController
+ *
+ * Tests that the controller delegates to MetricsService and returns correct response.
+ *
+ * @category Test
+ * @package  OCA\OpenConnector\Tests\Unit\Controller
+ */
+class MetricsControllerTest extends TestCase
+{
+
+    /**
+     * @var MetricsService&MockObject
+     */
+    private MetricsService $metricsService;
+
+    /**
+     * @var MetricsController
+     */
+    private MetricsController $controller;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $request = $this->createMock(IRequest::class);
+        $this->metricsService = $this->createMock(MetricsService::class);
+
+        $this->controller = new MetricsController(
+            'openconnector',
+            $request,
+            $this->metricsService
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Test that index returns TextPlainResponse.
+     *
+     * @return void
+     */
+    public function testIndexReturnsTextPlainResponse(): void
+    {
+        $metrics = ['info' => ['version' => '1.0.0']];
+        $formatted = "openconnector_info{version=\"1.0.0\"} 1\n";
+
+        $this->metricsService->expects($this->once())
+            ->method('collect')
+            ->willReturn($metrics);
+
+        $this->metricsService->expects($this->once())
+            ->method('format')
+            ->with($metrics)
+            ->willReturn($formatted);
+
+        $response = $this->controller->index();
+
+        $this->assertInstanceOf(TextPlainResponse::class, $response);
+
+    }//end testIndexReturnsTextPlainResponse()
+
+
+    /**
+     * Test that index delegates to MetricsService.
+     *
+     * @return void
+     */
+    public function testIndexDelegatesToMetricsService(): void
+    {
+        $this->metricsService->expects($this->once())
+            ->method('collect');
+        $this->metricsService->expects($this->once())
+            ->method('format');
+
+        $this->metricsService->method('collect')->willReturn([]);
+        $this->metricsService->method('format')->willReturn('');
+
+        $this->controller->index();
+
+    }//end testIndexDelegatesToMetricsService()
+
+
+}//end class

--- a/tests/Unit/Service/MetricsServiceTest.php
+++ b/tests/Unit/Service/MetricsServiceTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MetricsServiceTest
+ *
+ * Unit tests for the MetricsService
+ *
+ * @category   Test
+ * @package    OCA\OpenConnector\Tests\Unit\Service
+ * @author     Conduction.nl <info@conduction.nl>
+ * @copyright  Conduction.nl 2024
+ * @license    EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version    1.0.0
+ * @link       https://github.com/ConductionNL/openconnector
+ */
+
+namespace OCA\OpenConnector\Tests\Unit\Service;
+
+use OCA\OpenConnector\Service\MetricsService;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the MetricsService
+ *
+ * Tests metric collection, formatting, and error handling.
+ *
+ * @category Test
+ * @package  OCA\OpenConnector\Tests\Unit\Service
+ */
+class MetricsServiceTest extends TestCase
+{
+
+    /**
+     * @var IConfig&MockObject
+     */
+    private IConfig $config;
+
+    /**
+     * @var IDBConnection&MockObject
+     */
+    private IDBConnection $db;
+
+    /**
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * @var MetricsService
+     */
+    private MetricsService $service;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config = $this->createMock(IConfig::class);
+        $this->db     = $this->createMock(IDBConnection::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->service = new MetricsService(
+            $this->config,
+            $this->db,
+            $this->logger
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Test that collect returns all expected metric keys.
+     *
+     * @return void
+     */
+    public function testCollectReturnsAllMetricKeys(): void
+    {
+        $this->setupDefaultMocks();
+
+        $metrics = $this->service->collect();
+
+        $this->assertArrayHasKey('info', $metrics);
+        $this->assertArrayHasKey('up', $metrics);
+        $this->assertArrayHasKey('sources', $metrics);
+        $this->assertArrayHasKey('calls', $metrics);
+        $this->assertArrayHasKey('synchronizations', $metrics);
+        $this->assertArrayHasKey('endpoints', $metrics);
+        $this->assertArrayHasKey('jobs', $metrics);
+        $this->assertArrayHasKey('mappings', $metrics);
+        $this->assertArrayHasKey('rules', $metrics);
+
+    }//end testCollectReturnsAllMetricKeys()
+
+
+    /**
+     * Test that info contains version information.
+     *
+     * @return void
+     */
+    public function testCollectInfoContainsVersions(): void
+    {
+        $this->config->method('getAppValue')
+            ->willReturn('2.1.0');
+        $this->config->method('getSystemValueString')
+            ->willReturn('30.0.0');
+
+        $this->setupDefaultDbMock();
+
+        $metrics = $this->service->collect();
+        $info    = $metrics['info'];
+
+        $this->assertSame('2.1.0', $info['version']);
+        $this->assertSame(PHP_VERSION, $info['php_version']);
+        $this->assertSame('30.0.0', $info['nextcloud_version']);
+
+    }//end testCollectInfoContainsVersions()
+
+
+    /**
+     * Test that database error in one metric does not break others.
+     *
+     * @return void
+     */
+    public function testDatabaseErrorFallbackToZero(): void
+    {
+        $this->setupDefaultMocks();
+
+        // Make the DB throw on every query after the health check.
+        $queryBuilder = $this->createMock(IQueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('groupBy')->willReturnSelf();
+        $queryBuilder->method('createFunction')->willReturn('COUNT(*) AS cnt');
+
+        $callCount = 0;
+        $queryBuilder->method('executeQuery')
+            ->willReturnCallback(function () use (&$callCount) {
+                $callCount++;
+                // Let the first call (health check) succeed.
+                if ($callCount === 1) {
+                    $result = $this->createMock(IResult::class);
+                    $result->method('closeCursor');
+                    return $result;
+                }
+
+                // All subsequent calls throw.
+                throw new \Exception('Database error');
+            });
+
+        $this->db->method('getQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $metrics = $this->service->collect();
+
+        // Should still have all keys with zero/empty fallbacks.
+        $this->assertArrayHasKey('sources', $metrics);
+        $this->assertArrayHasKey('mappings', $metrics);
+        $this->assertSame(0, $metrics['mappings']);
+        $this->assertSame(0, $metrics['rules']);
+
+    }//end testDatabaseErrorFallbackToZero()
+
+
+    /**
+     * Test that format produces valid Prometheus text.
+     *
+     * @return void
+     */
+    public function testFormatProducesValidPrometheusText(): void
+    {
+        $metrics = [
+            'info'               => ['version' => '1.0.0', 'php_version' => '8.3.0', 'nextcloud_version' => '30.0.0'],
+            'up'                 => true,
+            'sources'            => ['rest' => 5, 'soap' => 2],
+            'calls'              => ['200' => 100, '500' => 3],
+            'synchronizations'   => ['total' => 10, 'runs' => ['success' => 400]],
+            'endpoints'          => 15,
+            'jobs'               => ['total' => 5, 'runs' => ['success' => 100, 'error' => 10]],
+            'mappings'           => 20,
+            'rules'              => 8,
+        ];
+
+        $output = $this->service->format($metrics);
+
+        $this->assertStringContainsString('openconnector_info{version="1.0.0"', $output);
+        $this->assertStringContainsString('openconnector_up 1', $output);
+        $this->assertStringContainsString('openconnector_sources_total{type="rest"} 5', $output);
+        $this->assertStringContainsString('openconnector_calls_total{status="200"} 100', $output);
+        $this->assertStringContainsString('openconnector_synchronizations_total 10', $output);
+        $this->assertStringContainsString('openconnector_endpoints_total 15', $output);
+        $this->assertStringContainsString('openconnector_jobs_total 5', $output);
+        $this->assertStringContainsString('openconnector_job_runs_total{status="success"} 100', $output);
+        $this->assertStringContainsString('openconnector_mappings_total 20', $output);
+        $this->assertStringContainsString('openconnector_rules_total 8', $output);
+
+    }//end testFormatProducesValidPrometheusText()
+
+
+    /**
+     * Test format with empty data produces zero-value fallbacks.
+     *
+     * @return void
+     */
+    public function testFormatWithEmptyDataProducesZeroFallbacks(): void
+    {
+        $metrics = [
+            'info'               => ['version' => '0.0.0', 'php_version' => '8.3.0', 'nextcloud_version' => '30.0.0'],
+            'up'                 => false,
+            'sources'            => [],
+            'calls'              => [],
+            'synchronizations'   => ['total' => 0, 'runs' => []],
+            'endpoints'          => 0,
+            'jobs'               => ['total' => 0, 'runs' => []],
+            'mappings'           => 0,
+            'rules'              => 0,
+        ];
+
+        $output = $this->service->format($metrics);
+
+        $this->assertStringContainsString('openconnector_up 0', $output);
+        $this->assertStringContainsString('openconnector_sources_total{type="rest"} 0', $output);
+        $this->assertStringContainsString('openconnector_calls_total{status="200"} 0', $output);
+        $this->assertStringContainsString('openconnector_synchronization_runs_total{status="success"} 0', $output);
+        $this->assertStringContainsString('openconnector_job_runs_total{status="success"} 0', $output);
+
+    }//end testFormatWithEmptyDataProducesZeroFallbacks()
+
+
+    /**
+     * Set up default config mocks.
+     *
+     * @return void
+     */
+    private function setupDefaultMocks(): void
+    {
+        $this->config->method('getAppValue')
+            ->willReturn('0.0.0');
+        $this->config->method('getSystemValueString')
+            ->willReturn('0.0.0');
+
+        $this->setupDefaultDbMock();
+
+    }//end setupDefaultMocks()
+
+
+    /**
+     * Set up default database mock that returns empty results.
+     *
+     * @return void
+     */
+    private function setupDefaultDbMock(): void
+    {
+        $result = $this->createMock(IResult::class);
+        $result->method('fetchAll')->willReturn([]);
+        $result->method('fetchOne')->willReturn('0');
+        $result->method('closeCursor');
+
+        $queryBuilder = $this->createMock(IQueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('groupBy')->willReturnSelf();
+        $queryBuilder->method('createFunction')->willReturn('COUNT(*) AS cnt');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $this->db->method('getQueryBuilder')
+            ->willReturn($queryBuilder);
+
+    }//end setupDefaultDbMock()
+
+
+}//end class

--- a/tests/newman/prometheus-metrics.json
+++ b/tests/newman/prometheus-metrics.json
@@ -1,0 +1,178 @@
+{
+  "info": {
+    "name": "OpenConnector Prometheus Metrics",
+    "description": "API tests for /api/metrics and /api/health endpoints",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080/index.php/apps/openconnector"
+    },
+    {
+      "key": "username",
+      "value": "admin"
+    },
+    {
+      "key": "password",
+      "value": "admin"
+    }
+  ],
+  "auth": {
+    "type": "basic",
+    "basic": [
+      {
+        "key": "username",
+        "value": "{{username}}"
+      },
+      {
+        "key": "password",
+        "value": "{{password}}"
+      }
+    ]
+  },
+  "item": [
+    {
+      "name": "Metrics Endpoint",
+      "item": [
+        {
+          "name": "GET /api/metrics returns 200 with Prometheus format",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/metrics"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Content-Type is text/plain', function () {",
+                  "    var ct = pm.response.headers.get('Content-Type');",
+                  "    pm.expect(ct).to.include('text/plain');",
+                  "});",
+                  "",
+                  "pm.test('Contains openconnector_info metric', function () {",
+                  "    pm.expect(pm.response.text()).to.include('openconnector_info{');",
+                  "});",
+                  "",
+                  "pm.test('Contains openconnector_up metric', function () {",
+                  "    pm.expect(pm.response.text()).to.include('openconnector_up ');",
+                  "});",
+                  "",
+                  "pm.test('Contains openconnector_sources_total metric', function () {",
+                  "    pm.expect(pm.response.text()).to.include('openconnector_sources_total');",
+                  "});",
+                  "",
+                  "pm.test('Contains openconnector_endpoints_total metric', function () {",
+                  "    pm.expect(pm.response.text()).to.include('openconnector_endpoints_total');",
+                  "});",
+                  "",
+                  "pm.test('Contains openconnector_jobs_total metric', function () {",
+                  "    pm.expect(pm.response.text()).to.include('openconnector_jobs_total');",
+                  "});",
+                  "",
+                  "pm.test('Contains openconnector_mappings_total metric', function () {",
+                  "    pm.expect(pm.response.text()).to.include('openconnector_mappings_total');",
+                  "});",
+                  "",
+                  "pm.test('Contains openconnector_rules_total metric', function () {",
+                  "    pm.expect(pm.response.text()).to.include('openconnector_rules_total');",
+                  "});",
+                  "",
+                  "pm.test('All metric lines are valid Prometheus format', function () {",
+                  "    var lines = pm.response.text().split('\\n');",
+                  "    var metricPattern = /^[a-z_]+(\\{[^}]*\\})? [0-9.]+$/;",
+                  "    var commentPattern = /^# (HELP|TYPE) /;",
+                  "    lines.forEach(function(line) {",
+                  "        if (line.trim() !== '') {",
+                  "            pm.expect(",
+                  "                metricPattern.test(line) || commentPattern.test(line)",
+                  "            ).to.be.true;",
+                  "        }",
+                  "    });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Health Endpoint",
+      "item": [
+        {
+          "name": "GET /api/health returns ok status",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/health"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.response.to.be.json;",
+                  "});",
+                  "",
+                  "pm.test('Has status field', function () {",
+                  "    var data = pm.response.json();",
+                  "    pm.expect(data).to.have.property('status');",
+                  "    pm.expect(['ok', 'degraded', 'error']).to.include(data.status);",
+                  "});",
+                  "",
+                  "pm.test('Has checks object', function () {",
+                  "    var data = pm.response.json();",
+                  "    pm.expect(data).to.have.property('checks');",
+                  "    pm.expect(data.checks).to.be.an('object');",
+                  "});",
+                  "",
+                  "pm.test('Database check is ok', function () {",
+                  "    var data = pm.response.json();",
+                  "    pm.expect(data.checks.database).to.equal('ok');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Authentication",
+      "item": [
+        {
+          "name": "GET /api/metrics without auth returns 401",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/metrics",
+            "auth": {
+              "type": "noauth"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Unauthenticated request is rejected', function () {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([401, 403]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
> ⚠️ **Stacked PR**: Based on `feature/enrich-openspec-specs` (#693). Merge that first.

## Summary
- Extract metric collection from MetricsController into MetricsService (ADR-008)
- Add 5 new metric types: endpoints, jobs, job runs, mappings, rules
- Add unit tests for MetricsService, MetricsController, HealthController
- Add Newman API test collection
- Add administrator documentation

Closes #694

## Spec Reference
`openspec/specs/prometheus-metrics/spec.md`

## Test plan
- [ ] Unit tests pass (`MetricsServiceTest`, `MetricsControllerTest`, `HealthControllerTest`)
- [ ] Newman collection validates endpoint format and auth
- [ ] Manual: `curl /api/metrics` returns all 11 metric types