### PR TITLE
fix: resolve cross-entity slug references during configuration import

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -124,7 +124,8 @@ return [
 		['name' => 'ui#cloudEventsEventsId', 'url' => '/cloud-events/events/{id}', 'verb' => 'GET'],
 		['name' => 'ui#cloudEventsLogs', 'url' => '/cloud-events/logs', 'verb' => 'GET'],
 		['name' => 'ui#import', 'url' => '/import', 'verb' => 'GET'],
-		// SPA catch-all — serves the Vue app for any frontend route (history mode routing)
-		['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
+		// SPA catch-all — serves the Vue app for frontend routes only.
+		// Exclude API paths so JSON endpoints resolve to their resource/controller routes.
+		['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '^(?!api(?:/|$)).+'], 'defaults' => ['path' => '']],
 	],
 ];

--- a/lib/Db/EndpointMapper.php
+++ b/lib/Db/EndpointMapper.php
@@ -209,6 +209,7 @@ class EndpointMapper extends QBMapper
 	public function updateFromArray(int $id, array $object): Endpoint
 	{
 		$obj = $this->find($id);
+		$updateRegex = false;
 
 		// Set version
 		if (empty($obj->getVersion()) === true) {

--- a/lib/Service/ConfigurationHandlers/EndpointHandler.php
+++ b/lib/Service/ConfigurationHandlers/EndpointHandler.php
@@ -4,6 +4,7 @@ namespace OCA\OpenConnector\Service\ConfigurationHandlers;
 
 use OCA\OpenConnector\Db\Endpoint;
 use OCA\OpenConnector\Db\EndpointMapper;
+use OCA\OpenConnector\Db\RuleMapper;
 use OCP\AppFramework\Db\Entity;
 
 /**
@@ -29,8 +30,43 @@ class EndpointHandler implements ConfigurationHandlerInterface
      * @param EndpointMapper $endpointMapper The endpoint mapper
      */
     public function __construct(
-        private readonly EndpointMapper $endpointMapper
+        private readonly EndpointMapper $endpointMapper,
+        private readonly RuleMapper $ruleMapper
     ) {
+    }
+
+    /**
+     * Resolve a rule identifier from imported endpoint data to a rule ID.
+     *
+     * Supports rule slugs, numeric IDs, names, and references so first-time
+     * imports do not silently drop endpoint rules when the source format varies.
+     *
+     * @param int|string $ruleIdentifier Imported rule identifier
+     * @param array      $mappings       Current import mappings
+     *
+     * @return int|string|null
+     */
+    private function resolveRuleIdentifier(int|string $ruleIdentifier, array $mappings): int|string|null
+    {
+        if (isset($mappings['rule']['slugToId'][$ruleIdentifier]) === true) {
+            return $mappings['rule']['slugToId'][$ruleIdentifier];
+        }
+
+        if (is_numeric($ruleIdentifier) === true) {
+            return (int) $ruleIdentifier;
+        }
+
+        $rulesByName = $this->ruleMapper->findAll(filters: ['name' => $ruleIdentifier], limit: 1);
+        if ($rulesByName !== []) {
+            return $rulesByName[0]->getId();
+        }
+
+        $rulesByReference = $this->ruleMapper->findByRef(reference: $ruleIdentifier);
+        if ($rulesByReference !== []) {
+            return $rulesByReference[0]->getId();
+        }
+
+        return null;
     }
 
     /**
@@ -153,13 +189,15 @@ class EndpointHandler implements ConfigurationHandlerInterface
 			$data['rules'] = [];
 		}
 		
-		$data['rules'] = array_filter(array_map(function(int|string $rule) use ($mappings) {
-			if(isset($mappings['rule']['slugToId'][$rule]) === true) {
-
-				return $mappings['rule']['slugToId'][$rule];
-			}
-			return null;
-		}, $data['rules']));
+		$data['rules'] = array_values(
+            array_filter(
+                array_map(
+                    fn(int|string $rule) => $this->resolveRuleIdentifier(ruleIdentifier: $rule, mappings: $mappings),
+                    $data['rules']
+                ),
+                static fn($ruleId) => $ruleId !== null
+            )
+        );
 
 
 		// Check if endpoint with this slug already exists.

--- a/lib/Service/ConfigurationHandlers/RuleHandler.php
+++ b/lib/Service/ConfigurationHandlers/RuleHandler.php
@@ -66,7 +66,7 @@ class RuleHandler implements ConfigurationHandlerInterface
      */
     private function convertIdsToSlugs(array $config, array $mappings, array &$mappingIds = []): array
     {
-        $entityTypes = ['source', 'job', 'endpoint', 'mapping', 'register', 'schema'];
+        $entityTypes = ['source', 'job', 'endpoint', 'mapping', 'register', 'schema', 'synchronization'];
 
         foreach ($config as $key => $value) {
             if (is_array($value)) {
@@ -134,7 +134,7 @@ class RuleHandler implements ConfigurationHandlerInterface
      */
     private function convertSlugsToIds(array $config, array $mappings): array
     {
-        $entityTypes = ['source', 'job', 'endpoint', 'mapping', 'register', 'schema'];
+        $entityTypes = ['source', 'job', 'endpoint', 'mapping', 'register', 'schema', 'synchronization'];
 
         foreach ($config as $key => $value) {
             if (is_array($value)) {

--- a/lib/Service/ConfigurationService.php
+++ b/lib/Service/ConfigurationService.php
@@ -22,6 +22,7 @@ use OCA\OpenConnector\Service\ConfigurationHandlers\MappingHandler;
 use OCA\OpenConnector\Service\ConfigurationHandlers\JobHandler;
 use OCA\OpenConnector\Service\ConfigurationHandlers\SourceHandler;
 use OCA\OpenConnector\Service\ConfigurationHandlers\RuleHandler;
+use OCP\AppFramework\Db\Entity;
 
 /**
  * Class ConfigurationService
@@ -216,6 +217,93 @@ class ConfigurationService
         $this->mappings['register']['slugToId'] = $this->registerMapper->getSlugToIdMap();
         $this->mappings['schema']['idToSlug'] = $this->schemaMapper->getIdToSlugMap();
         $this->mappings['schema']['slugToId'] = $this->schemaMapper->getSlugToIdMap();
+    }
+
+    /**
+     * Register a freshly imported entity in the in-memory slug/ID maps.
+     *
+     * This keeps references created earlier in the same import run available
+     * to later entities without requiring a second import pass.
+     *
+     * @param string $entityType Mapping bucket name
+     * @param Entity $entity     Imported entity
+     *
+     * @return void
+     */
+    private function registerImportedEntityMapping(string $entityType, Entity $entity): void
+    {
+        if (isset($this->mappings[$entityType]) === false) {
+            return;
+        }
+
+        if (method_exists($entity, 'getId') === false || method_exists($entity, 'getSlug') === false) {
+            return;
+        }
+
+        $id   = $entity->getId();
+        $slug = $entity->getSlug();
+
+        if ($id === null || $slug === null || $slug === '') {
+            return;
+        }
+
+        $id = (string) $id;
+
+        $this->mappings[$entityType]['idToSlug'][$id] = $slug;
+        $this->mappings[$entityType]['slugToId'][$slug] = $id;
+    }
+
+    /**
+     * Ensure imported component payloads always carry their component-key slug.
+     *
+     * Some exports reference related entities by component key even when the nested
+     * payload is missing or inconsistent about its own slug field. Normalizing the
+     * slug up front keeps first-pass imports referentially stable.
+     *
+     * @param array  $data Component payload
+     * @param string $slug Component key
+     *
+     * @return array
+     */
+    private function withComponentSlug(array $data, string $slug): array
+    {
+        if (($data['slug'] ?? null) === null || $data['slug'] === '') {
+            $data['slug'] = $slug;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Re-run import handlers after all mappings are known to resolve late references.
+     *
+     * This is intentionally limited to entity types that commonly depend on other
+     * imported slugs created earlier in the same run.
+     *
+     * @param array<string,mixed>               $components Original imported components
+     * @param array<string,array<string,Entity>> $result     Imported entity result map
+     *
+     * @return void
+     */
+    private function reconcileImportedReferences(array $components, array &$result): void
+    {
+        if (isset($components['endpoints']) && is_array($components['endpoints'])) {
+            foreach ($components['endpoints'] as $endpointSlug => $endpointData) {
+                $endpointData = $this->withComponentSlug($endpointData, $endpointSlug);
+                $endpoint = $this->handlers['endpoint']->import($endpointData, $this->mappings);
+                $result['endpoints'][$endpointSlug] = $endpoint;
+                $this->registerImportedEntityMapping('endpoint', $endpoint);
+            }
+        }
+
+        if (isset($components['synchronizations']) && is_array($components['synchronizations'])) {
+            foreach ($components['synchronizations'] as $syncSlug => $syncData) {
+                $syncData = $this->withComponentSlug($syncData, $syncSlug);
+                $synchronization = $this->handlers['synchronization']->import($syncData, $this->mappings);
+                $result['synchronizations'][$syncSlug] = $synchronization;
+                $this->registerImportedEntityMapping('synchronization', $synchronization);
+            }
+        }
     }
 
     /**
@@ -753,50 +841,65 @@ class ConfigurationService
         // 1. Import sources first (no dependencies).
         if (isset($components['sources'])) {
             foreach ($components['sources'] as $sourceSlug => $sourceData) {
+                $sourceData = $this->withComponentSlug($sourceData, $sourceSlug);
                 $source = $this->handlers['source']->import($sourceData, $this->mappings);
                 $result['sources'][$sourceSlug] = $source;
+                $this->registerImportedEntityMapping('source', $source);
             }
         }
 
         // 2. Import mappings (depends on sources).
         if (isset($components['mappings'])) {
             foreach ($components['mappings'] as $mappingSlug => $mappingData) {
+                $mappingData = $this->withComponentSlug($mappingData, $mappingSlug);
                 $mapping = $this->handlers['mapping']->import($mappingData, $this->mappings);
                 $result['mappings'][$mappingSlug] = $mapping;
+                $this->registerImportedEntityMapping('mapping', $mapping);
             }
         }
 
         // 3. Import rules (depends on sources).
         if (isset($components['rules'])) {
             foreach ($components['rules'] as $ruleSlug => $ruleData) {
+                $ruleData = $this->withComponentSlug($ruleData, $ruleSlug);
                 $rule = $this->handlers['rule']->import($ruleData, $this->mappings);
                 $result['rules'][$ruleSlug] = $rule;
+                $this->registerImportedEntityMapping('rule', $rule);
             }
         }
 
         // 4. Import endpoints (depends on sources and mappings).
         if (isset($components['endpoints'])) {
             foreach ($components['endpoints'] as $endpointSlug => $endpointData) {
+                $endpointData = $this->withComponentSlug($endpointData, $endpointSlug);
                 $endpoint = $this->handlers['endpoint']->import($endpointData, $this->mappings);
                 $result['endpoints'][$endpointSlug] = $endpoint;
+                $this->registerImportedEntityMapping('endpoint', $endpoint);
             }
         }
 
         // 5. Import synchronizations (depends on sources, mappings, and endpoints).
         if (isset($components['synchronizations'])) {
             foreach ($components['synchronizations'] as $syncSlug => $syncData) {
+                $syncData = $this->withComponentSlug($syncData, $syncSlug);
                 $synchronization = $this->handlers['synchronization']->import($syncData, $this->mappings);
                 $result['synchronizations'][$syncSlug] = $synchronization;
+                $this->registerImportedEntityMapping('synchronization', $synchronization);
             }
         }
 
         // 6. Import jobs (depends on synchronizations, endpoints, and sources).
         if (isset($components['jobs'])) {
             foreach ($components['jobs'] as $jobSlug => $jobData) {
+                $jobData = $this->withComponentSlug($jobData, $jobSlug);
                 $job = $this->handlers['job']->import($jobData, $this->mappings);
                 $result['jobs'][$jobSlug] = $job;
+                $this->registerImportedEntityMapping('job', $job);
             }
         }
+
+        $this->resetMappings();
+        $this->reconcileImportedReferences($components, $result);
 
         return $result;
     }


### PR DESCRIPTION
## Summary

- **ConfigurationService**: Added `registerImportedEntityMapping()` to update in-memory slug/ID maps after each entity is imported, so entities created earlier in the same run are immediately available as references for later ones. Added `withComponentSlug()` to normalize missing slug fields from the component key. Added `reconcileImportedReferences()` for a targeted second pass over endpoints and synchronizations, which commonly depend on entities imported just before them.
- **RuleHandler**: Added `synchronization` to the entity-type lists used during slug↔ID conversion, so synchronization references in rule configs are correctly serialized and deserialized.
- **EndpointHandler**: Replaced the simple slug-only rule resolver with `resolveRuleIdentifier()`, which falls back to numeric ID, DB name lookup, and DB reference lookup — preventing silent rule drops when the source export format varies. Also injects `RuleMapper` to support the DB lookups.
- **EndpointMapper**: Initialize `$updateRegex = false` before the update loop to avoid an undefined-variable notice.
- **routes.php**: Narrow the SPA catch-all regex to exclude `/api/…` paths so JSON API endpoints resolve to their resource controllers instead of being swallowed by the Vue app route.

## Test plan

- [ ] Import a configuration bundle that includes synchronizations referenced by rules; verify the synchronization IDs resolve correctly after import
- [ ] Import a bundle where endpoints reference rules by name or reference string (not just slug); verify no rules are silently dropped
- [ ] Import a bundle with cross-entity dependencies (e.g. endpoint referencing a synchronization imported in the same run); verify the second reconciliation pass resolves the reference without a double import
- [ ] Confirm `/api/…` REST calls are no longer captured by the SPA catch-all and return JSON as expected
- [ ] Run existing import-related test suites and confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)