### PR TITLE
fix: exclude API paths from SPA catch-all route

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -124,7 +124,8 @@ return [
 		['name' => 'ui#cloudEventsEventsId', 'url' => '/cloud-events/events/{id}', 'verb' => 'GET'],
 		['name' => 'ui#cloudEventsLogs', 'url' => '/cloud-events/logs', 'verb' => 'GET'],
 		['name' => 'ui#import', 'url' => '/import', 'verb' => 'GET'],
-		// SPA catch-all — serves the Vue app for any frontend route (history mode routing)
-		['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
+		// SPA catch-all — serves the Vue app for frontend routes only.
+		// Exclude API paths so JSON endpoints resolve to their resource/controller routes.
+		['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '^(?!api(?:/|$)).+'], 'defaults' => ['path' => '']],
 	],
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -126,6 +126,6 @@ return [
 		['name' => 'ui#import', 'url' => '/import', 'verb' => 'GET'],
 		// SPA catch-all — serves the Vue app for frontend routes only.
 		// Exclude API paths so JSON endpoints resolve to their resource/controller routes.
-		['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '^(?!api(?:/|$)).+'], 'defaults' => ['path' => '']],
+		['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '(?!api(?:/|$)).+'], 'defaults' => ['path' => '']],
 	],
 ];


### PR DESCRIPTION
## Summary

Commit `45644173` (2026-03-16, "feat: Enrich 3 specs, add prometheus metrics") introduced a SPA catch-all route `/{path}` with requirement `.+` for the first time. Before that, every frontend route was explicitly registered as a `ui#*` route — there was no catch-all, and the API worked correctly. The catch-all was broken from the moment it was added: `.+` matches every GET path including `/api/…`, so any API GET request without a more specific route registered above it was handled by the Vue app controller and returned HTML instead of JSON.

Changed the regex to `(?!api(?:/|$)).+` so only non-API paths fall through to the SPA. Requests to `/api/*` now resolve to their resource controllers as intended.

The leading `^` was intentionally omitted from the requirement: Symfony embeds parameter requirements verbatim inside named capture groups in the compiled route regex, so a `^` inside the group would assert start-of-string from a mid-URL position and never match — disabling the catch-all entirely and causing SPA deep links to 404. The negative lookahead anchors implicitly at the start of the parameter value without it.

## Test plan

- [x] GET any `/api/…` endpoint — verify JSON is returned, not HTML
- [x] Navigate to a SPA deep link directly in the browser (e.g. `/sources/123`) — verify the Vue app loads correctly
- [x] Navigate between frontend routes in the app — verify client-side routing still works
- [x] Verify no existing API routes are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)