### PR TITLE
fix: align list header search and actions on one row with top spacing

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -68,9 +68,8 @@
 }
 
 .listHeaderActions {
-  display: flex !important;
-  justify-content: flex-end !important;
-  margin: 0 5px 5px auto !important;
+  flex-shrink: 0;
+  margin-inline-end: 5px !important;
 }
 
 /* Chart Card Specific */
@@ -243,10 +242,13 @@
 }
 
 .listHeader {
+  display: flex;
+  align-items: center;
   border-bottom: 1px solid var(--color-border);
 }
 
 .searchField {
+  flex: 1;
   padding-inline-start: 65px;
   padding-inline-end: 20px;
   margin-block-start: 11px !important;

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -1,6 +1,24 @@
 /**
  * Global (unscoped) styles for OpenConnector.
  */
+
+/* List header: search + actions on one row */
+.listHeader {
+	display: flex;
+	align-items: center;
+	padding-block-start: 8px;
+}
+
+.searchField {
+	flex: 1;
+	min-width: 0;
+}
+
+.listHeaderActions {
+	flex-shrink: 0;
+	margin-inline-end: 5px;
+}
+
 .emptyListHeader {
 	margin-top: 20px;
 	margin-left: 20px;


### PR DESCRIPTION
## Summary

- `.listHeader` was missing `display: flex`, causing the search field and `...` actions menu to stack vertically instead of appearing side by side
- Added `padding-block-start: 8px` for top spacing between the Nextcloud header bar and the search row
- `flex: 1; min-width: 0` on `.searchField` so it expands to fill remaining width without overflowing
- `flex-shrink: 0` on `.listHeaderActions` so the dots button stays at its natural size

Applies to all 8 list sidebars at once (Endpoints, Synchronizations, Jobs, Mappings, Consumers, Webhooks, Rules, Events) via the shared CSS classes.

The flex layout is defined in `src/assets/app.css` (compiled via webpack, always cache-busted on build). The `border-bottom` and `padding-inline-start: 65px` (toggle button clearance) remain in `css/main.css` where they were already correctly defined.

## Test plan

- [x] Open any list sidebar (e.g. Endpoints, Jobs, Synchronizations)
- [x] Confirm search field and `...` menu appear on the same horizontal row
- [x] Confirm there is visible top spacing between the Nextcloud header and the search bar
- [x] Confirm search field expands to fill available width with the dots button flush to the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)