### PR TITLE
Fix sync cleanup: scope-checked deletion against OpenRegister magic tables

### DIFF
--- a/lib/Db/SynchronizationContractMapper.php
+++ b/lib/Db/SynchronizationContractMapper.php
@@ -129,11 +129,13 @@ class SynchronizationContractMapper extends QBMapper
     /**
      * Find a synchronization contract by synchronization ID and target ID
      *
-     * @param string $synchronization The synchronization ID
+     * @param int|string $synchronization The synchronization ID — accepts the
+     *     entity DB id (int, as returned by Synchronization::getId()) or a UUID
+     *     string. Both are stored against the same `synchronization_id` column.
      * @param string $targetId The target ID
      * @return SynchronizationContract|bool|null The found contract, false, or null if not found
      */
-    public function findOnTarget(string $synchronization, string $targetId): SynchronizationContract|bool|null
+    public function findOnTarget(int|string $synchronization, string $targetId): SynchronizationContract|bool|null
     {
         // Create query builder
         $qb = $this->db->getQueryBuilder();
@@ -191,11 +193,13 @@ class SynchronizationContractMapper extends QBMapper
      * in the cleanup pass via ObjectService::find, decoupling this mapper from
      * OpenRegister's storage layout.
      *
-     * @param string $synchronizationId The synchronization ID
+     * @param int|string $synchronizationId The synchronization ID — accepts the
+     *     entity DB id (int, as returned by Synchronization::getId()) or a UUID
+     *     string.
      *
      * @return SynchronizationContract[] An array of contracts, or [] on error
      */
-    public function findAllBySynchronization(string $synchronizationId): array
+    public function findAllBySynchronization(int|string $synchronizationId): array
     {
         $qb = $this->db->getQueryBuilder();
 

--- a/lib/Db/SynchronizationContractMapper.php
+++ b/lib/Db/SynchronizationContractMapper.php
@@ -185,31 +185,24 @@ class SynchronizationContractMapper extends QBMapper
     }
 
     /**
-     * Find all synchronization contracts by synchronization ID and where target have the given schema id
+     * Find all synchronization contracts for a given synchronization ID.
      *
-     * @param string $synchronization The synchronization ID
+     * Scope-checking against the target object's register/schema is performed
+     * in the cleanup pass via ObjectService::find, decoupling this mapper from
+     * OpenRegister's storage layout.
      *
-     * @return array An array of target IDs or an empty array if none found
+     * @param string $synchronizationId The synchronization ID
+     *
+     * @return SynchronizationContract[] An array of contracts, or [] on error
      */
-    public function findAllBySynchronizationAndSchema(string $synchronizationId, string $schemaId): array
+    public function findAllBySynchronization(string $synchronizationId): array
     {
-        // Create query builder
         $qb = $this->db->getQueryBuilder();
 
-        // Build select query with synchronization ID and schema filter
-        $qb->select('c.*')
-            ->from('openconnector_synchronization_contracts', 'c')
-            ->innerJoin(
-                'c',
-                'openregister_objects',
-                'o',
-                $qb->expr()->eq('c.target_id', 'o.uuid')
-            )
+        $qb->select('*')
+            ->from('openconnector_synchronization_contracts')
             ->where(
-                $qb->expr()->andX(
-                    $qb->expr()->eq('c.synchronization_id', $qb->createNamedParameter($synchronizationId)),
-                    $qb->expr()->eq('o.schema', $qb->createNamedParameter($schemaId))
-                )
+                $qb->expr()->eq('synchronization_id', $qb->createNamedParameter($synchronizationId))
             );
 
         try {

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -37,6 +37,7 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
+use Throwable;
 use React\Promise\Timer;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\Uid\Uuid;
@@ -1152,7 +1153,7 @@ class SynchronizationService
 
 				$targetIdsToDelete = [];
 				[$registerId, $schemaId] = explode(separator: '/', string: $synchronization->getTargetId());
-				$allContracts = $this->synchronizationContractMapper->findAllBySynchronizationAndSchema(synchronizationId: $synchronization->getId(), schemaId: $schemaId);
+				$allContracts = $this->synchronizationContractMapper->findAllBySynchronization(synchronizationId: $synchronization->getId());
 				$allContractTargetIds = [];
                 $allContractSourceIds = [];
 				foreach ($allContracts as $contract) {
@@ -1177,7 +1178,40 @@ class SynchronizationService
                     });
                 }
 
+				// Resolve OpenRegister's ObjectService for the scope-checked existence verification.
+				// This replaces the previous INNER JOIN against openregister_objects, which is no
+				// longer populated under OpenRegister's per-register/schema "magic table" architecture.
+				$openRegisterObjectService = $this->containerInterface->get('OCA\OpenRegister\Service\ObjectService');
+
 				foreach ($targetIdsToDelete as $targetIdToDelete) {
+					// Verify the target object exists in this sync's register/schema. If not, skip:
+					// ObjectService::deleteObject(uuid) is unscoped and would happily delete a UUID
+					// that lives in a foreign register/schema. _rbac/_multitenancy are off because
+					// the SQL-level guard this replaces did not apply RBAC either.
+					try {
+						$existingObject = $openRegisterObjectService->find(
+							id: $targetIdToDelete,
+							register: $registerId,
+							schema: $schemaId,
+							_rbac: false,
+							_multitenancy: false
+						);
+					} catch (Throwable $e) {
+						$this->logger->warning(
+							'Scope check failed for sync cleanup candidate; skipping',
+							[
+								'synchronizationId' => $synchronization->getId(),
+								'targetId' => $targetIdToDelete,
+								'error' => $e->getMessage(),
+							]
+						);
+						continue;
+					}
+
+					if ($existingObject === null) {
+						continue;
+					}
+
 					try {
 						$synchronizationContract = $this->synchronizationContractMapper->findOnTarget(synchronization: $synchronization->getId(), targetId: $targetIdToDelete);
 						if ($synchronizationContract === null) {
@@ -1187,7 +1221,14 @@ class SynchronizationService
 						$this->synchronizationContractMapper->update($synchronizationContract);
 						$deletedObjectsCount++;
 					} catch (DoesNotExistException $exception) {
-						// @todo log
+						$this->logger->warning(
+							'Contract not found on second lookup during sync cleanup; continuing',
+							[
+								'synchronizationId' => $synchronization->getId(),
+								'targetId' => $targetIdToDelete,
+								'error' => $exception->getMessage(),
+							]
+						);
 					}
 				}
 				break;

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -1152,7 +1152,18 @@ class SynchronizationService
 			case 'register/schema':
 
 				$targetIdsToDelete = [];
-				[$registerId, $schemaId] = explode(separator: '/', string: $synchronization->getTargetId());
+				$rawTargetId = $synchronization->getTargetId();
+				if (is_string($rawTargetId) === false || str_contains($rawTargetId, '/') === false) {
+					$this->logger->warning(
+						'deleteInvalidObjects: targetId not in register/schema format; skipping cleanup',
+						[
+							'synchronizationId' => $synchronization->getId(),
+							'targetId' => $rawTargetId,
+						]
+					);
+					break;
+				}
+				[$registerId, $schemaId] = explode(separator: '/', string: $rawTargetId, limit: 2);
 				$allContracts = $this->synchronizationContractMapper->findAllBySynchronization(synchronizationId: $synchronization->getId());
 				$allContractTargetIds = [];
                 $allContractSourceIds = [];
@@ -1181,7 +1192,18 @@ class SynchronizationService
 				// Resolve OpenRegister's ObjectService for the scope-checked existence verification.
 				// This replaces the previous INNER JOIN against openregister_objects, which is no
 				// longer populated under OpenRegister's per-register/schema "magic table" architecture.
-				$openRegisterObjectService = $this->containerInterface->get('OCA\OpenRegister\Service\ObjectService');
+				try {
+					$openRegisterObjectService = $this->containerInterface->get('OCA\OpenRegister\Service\ObjectService');
+				} catch (Throwable $e) {
+					$this->logger->warning(
+						'deleteInvalidObjects: OpenRegister ObjectService unavailable; skipping cleanup',
+						[
+							'synchronizationId' => $synchronization->getId(),
+							'error' => $e->getMessage(),
+						]
+					);
+					break;
+				}
 
 				foreach ($targetIdsToDelete as $targetIdToDelete) {
 					// Verify the target object exists in this sync's register/schema. If not, skip:
@@ -1196,12 +1218,16 @@ class SynchronizationService
 							_rbac: false,
 							_multitenancy: false
 						);
-					} catch (Throwable $e) {
+					} catch (DoesNotExistException $e) {
+						// Expected scope-miss: target lives outside this register/schema or is gone.
+						continue;
+					} catch (\Exception $e) {
 						$this->logger->warning(
 							'Scope check failed for sync cleanup candidate; skipping',
 							[
 								'synchronizationId' => $synchronization->getId(),
 								'targetId' => $targetIdToDelete,
+								'class' => get_class($e),
 								'error' => $e->getMessage(),
 							]
 						);

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -629,6 +629,11 @@ class SynchronizationService
             $stageStartTime = microtime(true);
             $result['objects']['found'] = count($objectList);
 
+	            // `_object` mode handling is intentionally split between
+	            // `getAllObjectsFromApi` (returns the single object as-is) and
+	            // here (wraps it into a single-element list for iteration).
+	            // Non-`_object` mode is the inverse — see the matching comment
+	            // on the wrap in `getAllObjectsFromApi` (~line 2016).
 	            if ($sourceConfig['resultsPosition'] === '_object') {
 	                if (array_is_list($objectList) === false) {
 	                    $objectList = [$objectList];
@@ -1405,11 +1410,15 @@ class SynchronizationService
 		$synchronizationContract->setSourceLastChanged(new DateTime());
 		$synchronizationContract->setSourceLastChecked(new DateTime());
 
-        // Execute mapping if found
+        // Capture the source object on the flow token unconditionally — every
+        // mutation (including deletes and no-mapping passes) should leave a
+        // pre-transformation snapshot in the audit trail.
 		$objectBeforeMapping = $object;
-        if ($sourceTargetMapping && $mutationType !== 'delete') {
-            $flowToken->setSyncOutputOriginal($object);
+        $flowToken->setSyncOutputOriginal($object);
 
+        // Execute mapping if found. Skipped on deletes — there's no payload to
+        // transform when the target is being removed.
+        if ($sourceTargetMapping && $mutationType !== 'delete') {
             $object = $this->mappingService->executeMapping(mapping: $sourceTargetMapping, input: $object);
             $flowToken->setSyncOutputAmended($object);
         }
@@ -2011,6 +2020,12 @@ class SynchronizationService
             usesPagination: $usesPagination
 		);
 
+			// In non-`_object` mode, normalize a single associative response
+			// into a list-of-one so downstream iteration is uniform. In
+			// `_object` mode the wrap is deliberately deferred to
+			// `synchronizeExternToIntern` (Stage 3) so other callers that
+			// expect a single object as-is keep getting the raw shape from
+			// this method. The two sites are intentionally complementary.
 			if ($sourceConfig['resultsPosition'] !== '_object' && array_is_list($objects) === false) {
 				$objects = [$objects];
 			}

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -1493,7 +1493,7 @@ class SynchronizationService
 				$synchronizationContract->setTargetLastAction($synchronizationContract->getTargetId() ? 'update' : 'create');
 				break;
 			case 'delete':
-				$objectService->delete(object: ['id' => $synchronizationContract->getTargetId()]);
+				$objectService->deleteObject(uuid: $synchronizationContract->getTargetId());
 				$synchronizationContract->setTargetId(null);
 				$synchronizationContract->setTargetLastAction('delete');
 				break;

--- a/openspec/changes/fix-sync-cleanup-scope-check/.openspec.yaml
+++ b/openspec/changes/fix-sync-cleanup-scope-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/fix-sync-cleanup-scope-check/design.md
+++ b/openspec/changes/fix-sync-cleanup-scope-check/design.md
@@ -1,0 +1,96 @@
+## Context
+
+OpenConnector's `SynchronizationService::deleteInvalidObjects` is responsible for the cleanup pass at the end of an extern-to-intern sync: any synchronization contract whose target object did not appear in this run's source list should have its target object deleted from OpenRegister, and the contract's `target_id` should be cleared.
+
+The cleanup loads all candidate contracts via `SynchronizationContractMapper::findAllBySynchronizationAndSchema(syncId, schemaId)`. The mapper currently does:
+
+```sql
+SELECT c.* FROM openconnector_synchronization_contracts c
+INNER JOIN openregister_objects o ON c.target_id = o.uuid
+WHERE c.synchronization_id = :syncId AND o.schema = :schemaId
+```
+
+Two purposes were intended for the JOIN:
+1. **Existence check** (`c.target_id = o.uuid`) — exclude orphan contracts whose target object no longer exists.
+2. **Scope guard** (`o.schema = :schemaId`) — exclude contracts whose target object lives in a different schema (e.g. after the synchronization's `target_id` was changed mid-life).
+
+The breakage: OpenRegister has migrated to per-register/schema "magic tables" (`oc_or_{registerId}_{schemaId}`). The legacy `openregister_objects` table is no longer populated for synced objects, so the INNER JOIN returns zero rows on every cleanup pass. `array_diff($allContractTargetIds, $synchronizedTargetIds)` is therefore always empty and no contracts are ever deleted. The symptom is silent: orphan objects accumulate in OpenRegister forever and `result.objects.deleted` in the sync log is always `0`.
+
+A naive fix — drop the JOIN and filter only by `synchronization_id` — restores the deletion path, but loses the scope guard. `ObjectService::deleteObject($uuid)` resolves UUIDs unscoped (`register: null, schema: null` at `ObjectService.php:1469-1474`) and derives the schema from the found object. Any contract whose `target_id` points to an object outside the sync's current scope would be silently cross-deleted. This is real risk: schema retargeting, legacy data, and partial-write states can all produce out-of-scope `target_id` values.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore the deletion behavior: when an object disappears from the source, the corresponding OpenRegister object is deleted on the next sync.
+- Preserve the scope guard: contracts whose `target_id` points outside the sync's current `register/schema` are not touched.
+- Decouple the cleanup path from OpenRegister's storage layout. Use the public `ObjectService` API only — no direct queries against `openregister_objects` or magic tables from openconnector.
+- Stop swallowing `DoesNotExistException` silently in the cleanup loop.
+
+**Non-Goals:**
+- Audit and fix every other JOIN against `openregister_objects` across openconnector and other apps — flagged in the proposal as follow-up.
+- Add a scoped `deleteObject($uuid, $register, $schema)` API to OpenRegister — flagged as follow-up; would let the safety guard live at the API boundary instead of in every caller.
+- Change synchronization mutation semantics (single-event delete path, restrictDeletion behavior, etc.).
+- Migrate or backfill any existing data.
+
+## Decisions
+
+### Decision 1: Per-contract scoped lookup via `ObjectService::find`
+
+**Choice**: For each cleanup candidate, call `ObjectService::find($targetId, register: $registerId, schema: $schemaId)`. Treat `null` as "out of scope or does not exist — skip." Treat a returned entity as "in scope — proceed with delete."
+
+**Why**: This uses the public OpenRegister API and is fully decoupled from storage layout. It naturally subsumes both intents of the original JOIN (existence + scope) in one call. Aligns with ADR-001 ("Apps SHOULD use the `ObjectService` for CRUD operations rather than direct mapper access"). Future OpenRegister storage refactors do not break us.
+
+**Alternatives considered**:
+- *Bulk-query the magic table directly* (`SELECT uuid FROM oc_or_{registerId}_{schemaId} WHERE uuid IN (...)`). One round-trip instead of N. Rejected because it re-introduces the storage-layout coupling the bug just exposed; if magic-table naming changes again, openconnector silently breaks again.
+- *Leave the JOIN and just point it at the magic table.* Same coupling problem, plus the table name is parameterized by register/schema, which complicates the QueryBuilder.
+- *Drop the JOIN, accept the cross-scope risk.* Rejected — simplest patch but loses the safety property the colleague flagged.
+- *Add `deleteObject($uuid, $register, $schema)` to OpenRegister and rely on it to refuse cross-scope.* Best long-term answer but requires a coordinated change across two apps; tracked as follow-up.
+
+### Decision 2: Rename `findAllBySynchronizationAndSchema` → `findAllBySynchronization`
+
+**Choice**: After dropping the JOIN, the method no longer filters by schema — every contract under one `synchronization_id` already targets the same schema (the schema is on the `Synchronization`'s `target_id`, not on the contract). Drop the unused `$schemaId` parameter and rename the method to reflect its actual contract.
+
+**Why**: Method names must match what the method does. Keeping `AndSchema` in the name with no schema filter is a footgun for the next reader.
+
+**Alternatives considered**:
+- *Keep the old signature, ignore `$schemaId`.* Smaller diff but leaves a misleading parameter that PHPStan/Psalm will flag. Net negative.
+
+### Decision 3: Replace `// @todo log` with a real warning log
+
+**Choice**: At `SynchronizationService.php:1189`, replace the empty `catch (DoesNotExistException $exception) { // @todo log }` with a `LoggerInterface::warning(...)` call that includes the synchronization id, target id, and exception message.
+
+**Why**: This catch block has been dormant because the cleanup never ran. Once cleanup actually runs again, partial failures (contract-not-found-on-second-lookup, race conditions during concurrent syncs) need to surface, not vanish. A warning log is the minimum.
+
+**Alternatives considered**:
+- *Re-throw.* Too aggressive — one stale contract should not abort the entire cleanup pass.
+- *Leave the silent swallow.* Rejected for the reason above.
+
+### Decision 4: Cleanup pass cost — N scoped lookups, no batching
+
+**Choice**: Iterate candidates and call `ObjectService::find` once per candidate. Do not introduce a bulk-find helper.
+
+**Why**: N is "contracts whose target_id was not seen in this run." For typical synchronizations N is small (zero on a clean run, low hundreds in pathological cases). The find call routes through OpenRegister's handler stack, which already does its own caching. A bulk helper is premature optimization for a path that is bounded by source size in practice.
+
+**Trigger to revisit**: If a future user reports cleanup-pass slowness on syncs with very large stale-contract sets (>1000 candidates), introduce a bulk pre-filter at that point.
+
+## Risks / Trade-offs
+
+- **[Risk] An openregister `find` that is not idempotent could mutate state during cleanup** → Mitigation: `find` is read-only by contract; verify by inspection during implementation and add a regression test.
+- **[Risk] Permission system on `ObjectService::find` rejects the lookup when run from a sync context (no user)** → Mitigation: cleanup must run with the same RBAC bypass that the existing save path uses. Verify the call path in `updateTargetOpenRegister` does not pass a user; if needed, pass `_rbac: false` to `find`. Check during implementation.
+- **[Risk] Introducing a per-candidate API call in a hot path causes a regression on syncs with large diffs** → Mitigation: cleanup-pass timing is already recorded in `result.timing.stages.cleanup_invalid`; monitor a few real syncs after deploy. Acceptable threshold: cleanup pass < 5% of total sync time for normal cases.
+- **[Trade-off] The fix is openconnector-only** → The deeper design fix (scoped `deleteObject` in OpenRegister) is deferred. Future apps can repeat the same mistake. Mitigated by the proposal's follow-up audit item.
+- **[Risk] Other openconnector queries against `openregister_objects` may be silently broken too** → Mitigation: a focused grep is part of the implementation tasks (as a verification step, not part of the fix scope itself). Findings get filed as separate changes.
+
+## Migration Plan
+
+No data migration. Pure code change.
+
+**Deploy**:
+1. Ship the openconnector update.
+2. On the next scheduled (or manually-triggered) extern-to-intern sync, accumulated orphan objects from the past will start being deleted. This is the desired behavior, not a regression — but operators should be aware that the first post-deploy sync may show a higher-than-usual `result.objects.deleted` count.
+
+**Rollback**: Revert the openconnector commit. The previous (silently broken) cleanup behavior returns. Already-deleted orphans stay deleted; no data is restored. This is acceptable because the orphans were objects that no longer exist in any source — the deletion is in line with intent.
+
+## Open Questions
+
+- Does `ObjectService::find` require an authenticated user context to succeed when called from a sync (which has no user session)? If yes, the call needs `_rbac: false`. **Resolve during implementation** by inspecting the existing successful path through `updateTargetOpenRegister::saveObject`, which faces the same constraint.

--- a/openspec/changes/fix-sync-cleanup-scope-check/plan.json
+++ b/openspec/changes/fix-sync-cleanup-scope-check/plan.json
@@ -1,0 +1,154 @@
+{
+  "change": "fix-sync-cleanup-scope-check",
+  "project": "openconnector",
+  "repo": "ConductionNL/openconnector",
+  "created": "2026-04-28",
+  "tracking_issue": 732,
+  "tracking_issue_url": "https://github.com/ConductionNL/openconnector/issues/732",
+  "tasks": [
+    {
+      "id": "1.1",
+      "section": "Mapper rewrite",
+      "title": "Rename findAllBySynchronizationAndSchema to findAllBySynchronization",
+      "description": "In lib/Db/SynchronizationContractMapper.php, rename findAllBySynchronizationAndSchema to findAllBySynchronization. Drop the $schemaId parameter from the signature and update the docblock.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["lib/Db/SynchronizationContractMapper.php"]
+    },
+    {
+      "id": "1.2",
+      "section": "Mapper rewrite",
+      "title": "Drop the JOIN against openregister_objects",
+      "description": "Replace the method body with a single-table query: select all columns from openconnector_synchronization_contracts filtered only by synchronization_id. Remove the alias 'c', the INNER JOIN openregister_objects, and the o.schema = :schemaId predicate.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["lib/Db/SynchronizationContractMapper.php"]
+    },
+    {
+      "id": "1.3",
+      "section": "Mapper rewrite",
+      "title": "Verify return type is unchanged",
+      "description": "Verify the method still returns an array of SynchronizationContract entities (or [] on exception) so the call site does not need changes beyond the rename.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["lib/Db/SynchronizationContractMapper.php"]
+    },
+    {
+      "id": "2.1",
+      "section": "Cleanup pass — scope-checked deletion",
+      "title": "Update call site in deleteInvalidObjects",
+      "description": "In lib/Service/SynchronizationService.php::deleteInvalidObjects, update the call site (currently around line 1155) from findAllBySynchronizationAndSchema(syncId, schemaId) to findAllBySynchronization(syncId).",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["lib/Service/SynchronizationService.php"]
+    },
+    {
+      "id": "2.2",
+      "section": "Cleanup pass — scope-checked deletion",
+      "title": "Resolve ObjectService instance in deleteInvalidObjects",
+      "description": "Inside the case 'register/schema': branch, after computing $targetIdsToDelete, before the foreach loop, resolve the ObjectService instance the same way the rest of SynchronizationService does (via the container).",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["lib/Service/SynchronizationService.php"]
+    },
+    {
+      "id": "2.3",
+      "section": "Cleanup pass — scope-checked deletion",
+      "title": "Add scope-checked find before delete",
+      "description": "In the foreach, before calling updateTarget, call $objectService->find($targetIdToDelete, register: $registerId, schema: $schemaId). If the result is null, skip this candidate. Verify whether _rbac: false is needed by inspecting how updateTargetOpenRegister's existing saveObject/deleteObject calls succeed without a user session, and match that behavior.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["lib/Service/SynchronizationService.php"]
+    },
+    {
+      "id": "2.4",
+      "section": "Cleanup pass — scope-checked deletion",
+      "title": "Replace swallowed DoesNotExistException with warning log",
+      "description": "Replace the swallowed catch (DoesNotExistException) { // @todo log } block with a LoggerInterface::warning call that includes synchronization id, target id, and exception message. Inject LoggerInterface into SynchronizationService if not already available; otherwise use the existing logger reference.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["lib/Service/SynchronizationService.php"]
+    },
+    {
+      "id": "3.1",
+      "section": "Tests",
+      "title": "Unit test for findAllBySynchronization",
+      "description": "Add a unit test for SynchronizationContractMapper::findAllBySynchronization that asserts: contracts are returned filtered by synchronization_id only, with no dependency on openregister_objects rows.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["tests/Unit/Db/SynchronizationContractMapperTest.php"]
+    },
+    {
+      "id": "3.2",
+      "section": "Tests",
+      "title": "Test in-scope deletion path",
+      "description": "Add an integration-style test for deleteInvalidObjects covering the in-scope deletion path: contract exists, target object exists in the synchronization's register/schema, target is missing from the synchronized list → deleteObject is called and contract target_id is nulled.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["tests/Unit/Service/SynchronizationServiceTest.php"]
+    },
+    {
+      "id": "3.3",
+      "section": "Tests",
+      "title": "Test cross-scope skip path",
+      "description": "Add a test for the cross-scope skip path: contract exists, target object exists in a different register/schema → deleteObject is NOT called, contract is unchanged. Use a real second register/schema or a mocked ObjectService::find returning null for the foreign-scope call.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["tests/Unit/Service/SynchronizationServiceTest.php"]
+    },
+    {
+      "id": "3.4",
+      "section": "Tests",
+      "title": "Test missing-target path",
+      "description": "Add a test for the missing-target path: contract exists, no object with that UUID exists anywhere → deleteObject is NOT called, contract is unchanged.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["tests/Unit/Service/SynchronizationServiceTest.php"]
+    },
+    {
+      "id": "3.5",
+      "section": "Tests",
+      "title": "Test warning log on DoesNotExistException",
+      "description": "Add a test that asserts the warning log is emitted (and the loop continues) when findOnTarget throws DoesNotExistException mid-cleanup.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["tests/Unit/Service/SynchronizationServiceTest.php"]
+    },
+    {
+      "id": "4.1",
+      "section": "Verification & follow-up audit",
+      "title": "Run composer check:strict",
+      "description": "Run composer check:strict from openconnector/. Address any new PHPCS / PHPMD / Psalm / PHPStan findings introduced by this change. Fix pre-existing findings in the touched methods per project policy.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": []
+    },
+    {
+      "id": "4.2",
+      "section": "Verification & follow-up audit",
+      "title": "Manually verify cleanup against a real sync",
+      "description": "Manually run an extern-to-intern sync against a register/schema with a known orphan and confirm: (a) the orphan's OpenRegister object is deleted, (b) the contract's target_id is nulled, (c) result.objects.deleted increments, (d) result.timing.stages.cleanup_invalid is present in the sync log, (e) other syncs against unrelated register/schemas are unaffected.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": []
+    },
+    {
+      "id": "4.3",
+      "section": "Verification & follow-up audit",
+      "title": "Audit other openregister_objects references",
+      "description": "grep -rn 'openregister_objects' lib/ in the openconnector repo. Document any remaining hits in a follow-up note (separate change, not this one) so the audit work is tracked. The expectation is zero hits after this change.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": []
+    },
+    {
+      "id": "5.1",
+      "section": "Documentation",
+      "title": "Update developer docs if applicable",
+      "description": "If the openconnector developer docs (docs/developers/) include a description of the synchronization cleanup pass, update it to reflect the scoped-find approach. If no such doc exists, leave this task unchecked.",
+      "status": "pending",
+      "spec_ref": "synchronization-cleanup",
+      "files_likely_affected": ["docs/developers/"]
+    }
+  ]
+}

--- a/openspec/changes/fix-sync-cleanup-scope-check/plan.json
+++ b/openspec/changes/fix-sync-cleanup-scope-check/plan.json
@@ -11,133 +11,159 @@
       "section": "Mapper rewrite",
       "title": "Rename findAllBySynchronizationAndSchema to findAllBySynchronization",
       "description": "In lib/Db/SynchronizationContractMapper.php, rename findAllBySynchronizationAndSchema to findAllBySynchronization. Drop the $schemaId parameter from the signature and update the docblock.",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["lib/Db/SynchronizationContractMapper.php"]
+      "files_likely_affected": [
+        "lib/Db/SynchronizationContractMapper.php"
+      ]
     },
     {
       "id": "1.2",
       "section": "Mapper rewrite",
       "title": "Drop the JOIN against openregister_objects",
       "description": "Replace the method body with a single-table query: select all columns from openconnector_synchronization_contracts filtered only by synchronization_id. Remove the alias 'c', the INNER JOIN openregister_objects, and the o.schema = :schemaId predicate.",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["lib/Db/SynchronizationContractMapper.php"]
+      "files_likely_affected": [
+        "lib/Db/SynchronizationContractMapper.php"
+      ]
     },
     {
       "id": "1.3",
       "section": "Mapper rewrite",
       "title": "Verify return type is unchanged",
       "description": "Verify the method still returns an array of SynchronizationContract entities (or [] on exception) so the call site does not need changes beyond the rename.",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["lib/Db/SynchronizationContractMapper.php"]
+      "files_likely_affected": [
+        "lib/Db/SynchronizationContractMapper.php"
+      ]
     },
     {
       "id": "2.1",
-      "section": "Cleanup pass — scope-checked deletion",
+      "section": "Cleanup pass \u2014 scope-checked deletion",
       "title": "Update call site in deleteInvalidObjects",
       "description": "In lib/Service/SynchronizationService.php::deleteInvalidObjects, update the call site (currently around line 1155) from findAllBySynchronizationAndSchema(syncId, schemaId) to findAllBySynchronization(syncId).",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["lib/Service/SynchronizationService.php"]
+      "files_likely_affected": [
+        "lib/Service/SynchronizationService.php"
+      ]
     },
     {
       "id": "2.2",
-      "section": "Cleanup pass — scope-checked deletion",
+      "section": "Cleanup pass \u2014 scope-checked deletion",
       "title": "Resolve ObjectService instance in deleteInvalidObjects",
       "description": "Inside the case 'register/schema': branch, after computing $targetIdsToDelete, before the foreach loop, resolve the ObjectService instance the same way the rest of SynchronizationService does (via the container).",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["lib/Service/SynchronizationService.php"]
+      "files_likely_affected": [
+        "lib/Service/SynchronizationService.php"
+      ]
     },
     {
       "id": "2.3",
-      "section": "Cleanup pass — scope-checked deletion",
+      "section": "Cleanup pass \u2014 scope-checked deletion",
       "title": "Add scope-checked find before delete",
       "description": "In the foreach, before calling updateTarget, call $objectService->find($targetIdToDelete, register: $registerId, schema: $schemaId). If the result is null, skip this candidate. Verify whether _rbac: false is needed by inspecting how updateTargetOpenRegister's existing saveObject/deleteObject calls succeed without a user session, and match that behavior.",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["lib/Service/SynchronizationService.php"]
+      "files_likely_affected": [
+        "lib/Service/SynchronizationService.php"
+      ]
     },
     {
       "id": "2.4",
-      "section": "Cleanup pass — scope-checked deletion",
+      "section": "Cleanup pass \u2014 scope-checked deletion",
       "title": "Replace swallowed DoesNotExistException with warning log",
       "description": "Replace the swallowed catch (DoesNotExistException) { // @todo log } block with a LoggerInterface::warning call that includes synchronization id, target id, and exception message. Inject LoggerInterface into SynchronizationService if not already available; otherwise use the existing logger reference.",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["lib/Service/SynchronizationService.php"]
+      "files_likely_affected": [
+        "lib/Service/SynchronizationService.php"
+      ]
     },
     {
       "id": "3.1",
       "section": "Tests",
       "title": "Unit test for findAllBySynchronization",
       "description": "Add a unit test for SynchronizationContractMapper::findAllBySynchronization that asserts: contracts are returned filtered by synchronization_id only, with no dependency on openregister_objects rows.",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["tests/Unit/Db/SynchronizationContractMapperTest.php"]
+      "files_likely_affected": [
+        "tests/Unit/Db/SynchronizationContractMapperTest.php"
+      ]
     },
     {
       "id": "3.2",
       "section": "Tests",
       "title": "Test in-scope deletion path",
-      "description": "Add an integration-style test for deleteInvalidObjects covering the in-scope deletion path: contract exists, target object exists in the synchronization's register/schema, target is missing from the synchronized list → deleteObject is called and contract target_id is nulled.",
-      "status": "pending",
+      "description": "Add an integration-style test for deleteInvalidObjects covering the in-scope deletion path: contract exists, target object exists in the synchronization's register/schema, target is missing from the synchronized list \u2192 deleteObject is called and contract target_id is nulled.",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["tests/Unit/Service/SynchronizationServiceTest.php"]
+      "files_likely_affected": [
+        "tests/Unit/Service/SynchronizationServiceTest.php"
+      ]
     },
     {
       "id": "3.3",
       "section": "Tests",
       "title": "Test cross-scope skip path",
-      "description": "Add a test for the cross-scope skip path: contract exists, target object exists in a different register/schema → deleteObject is NOT called, contract is unchanged. Use a real second register/schema or a mocked ObjectService::find returning null for the foreign-scope call.",
-      "status": "pending",
+      "description": "Add a test for the cross-scope skip path: contract exists, target object exists in a different register/schema \u2192 deleteObject is NOT called, contract is unchanged. Use a real second register/schema or a mocked ObjectService::find returning null for the foreign-scope call.",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["tests/Unit/Service/SynchronizationServiceTest.php"]
+      "files_likely_affected": [
+        "tests/Unit/Service/SynchronizationServiceTest.php"
+      ]
     },
     {
       "id": "3.4",
       "section": "Tests",
       "title": "Test missing-target path",
-      "description": "Add a test for the missing-target path: contract exists, no object with that UUID exists anywhere → deleteObject is NOT called, contract is unchanged.",
-      "status": "pending",
+      "description": "Add a test for the missing-target path: contract exists, no object with that UUID exists anywhere \u2192 deleteObject is NOT called, contract is unchanged.",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["tests/Unit/Service/SynchronizationServiceTest.php"]
+      "files_likely_affected": [
+        "tests/Unit/Service/SynchronizationServiceTest.php"
+      ]
     },
     {
       "id": "3.5",
       "section": "Tests",
       "title": "Test warning log on DoesNotExistException",
       "description": "Add a test that asserts the warning log is emitted (and the loop continues) when findOnTarget throws DoesNotExistException mid-cleanup.",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["tests/Unit/Service/SynchronizationServiceTest.php"]
+      "files_likely_affected": [
+        "tests/Unit/Service/SynchronizationServiceTest.php"
+      ]
     },
     {
       "id": "4.1",
       "section": "Verification & follow-up audit",
       "title": "Run composer check:strict",
       "description": "Run composer check:strict from openconnector/. Address any new PHPCS / PHPMD / Psalm / PHPStan findings introduced by this change. Fix pre-existing findings in the touched methods per project policy.",
-      "status": "pending",
+      "status": "blocked",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": []
+      "files_likely_affected": [],
+      "blocked_reason": "4.1: vendor/ not installed in apply env. 4.2: requires live NC+OpenRegister env."
     },
     {
       "id": "4.2",
       "section": "Verification & follow-up audit",
       "title": "Manually verify cleanup against a real sync",
       "description": "Manually run an extern-to-intern sync against a register/schema with a known orphan and confirm: (a) the orphan's OpenRegister object is deleted, (b) the contract's target_id is nulled, (c) result.objects.deleted increments, (d) result.timing.stages.cleanup_invalid is present in the sync log, (e) other syncs against unrelated register/schemas are unaffected.",
-      "status": "pending",
+      "status": "blocked",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": []
+      "files_likely_affected": [],
+      "blocked_reason": "4.1: vendor/ not installed in apply env. 4.2: requires live NC+OpenRegister env."
     },
     {
       "id": "4.3",
       "section": "Verification & follow-up audit",
       "title": "Audit other openregister_objects references",
       "description": "grep -rn 'openregister_objects' lib/ in the openconnector repo. Document any remaining hits in a follow-up note (separate change, not this one) so the audit work is tracked. The expectation is zero hits after this change.",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
       "files_likely_affected": []
     },
@@ -146,9 +172,11 @@
       "section": "Documentation",
       "title": "Update developer docs if applicable",
       "description": "If the openconnector developer docs (docs/developers/) include a description of the synchronization cleanup pass, update it to reflect the scoped-find approach. If no such doc exists, leave this task unchecked.",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "synchronization-cleanup",
-      "files_likely_affected": ["docs/developers/"]
+      "files_likely_affected": [
+        "docs/developers/"
+      ]
     }
   ]
 }

--- a/openspec/changes/fix-sync-cleanup-scope-check/proposal.md
+++ b/openspec/changes/fix-sync-cleanup-scope-check/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Synchronizations no longer delete OpenRegister objects when they disappear from the source. The cleanup query in `SynchronizationContractMapper::findAllBySynchronizationAndSchema` joins against the legacy `openregister_objects` table, which OpenRegister has stopped writing to since the move to per-register/schema "magic tables" (`oc_or_{registerId}_{schemaId}`). The JOIN therefore returns zero rows on every sync, the cleanup diff is always empty, and orphan objects accumulate indefinitely.
+
+A naive fix that simply drops the JOIN is unsafe: `ObjectService::deleteObject($uuid)` resolves UUIDs across all magic tables, so any contract whose `target_id` points outside the synchronization's current `register/schema` scope (e.g. after the sync's target was changed mid-life, or from legacy data) would result in cross-schema object deletion. The JOIN's `o.schema = :schemaId` filter was load-bearing as a scope guard.
+
+## What Changes
+
+- Replace the broken `INNER JOIN openregister_objects` in `SynchronizationContractMapper::findAllBySynchronizationAndSchema` with a `synchronization_id`-only filter. Rename the method to `findAllBySynchronization` to match its new contract.
+- In `SynchronizationService::deleteInvalidObjects`, before calling `updateTarget('delete')` for each candidate target, verify the object exists in the synchronization's current `register/schema` via `ObjectService::find($targetId, register: $registerId, schema: $schemaId)`. Skip candidates that are out of scope or do not exist; only proceed for in-scope hits.
+- Replace the silent `// @todo log` swallow at `SynchronizationService.php:1189` with a proper log entry — once cleanup actually runs again, partial failures should surface, not vanish.
+- Add a test that asserts an object missing from the source list is deleted from OpenRegister on the next sync, and that an object whose UUID belongs to a different `register/schema` is NOT deleted (cross-scope safety).
+
+## Capabilities
+
+### New Capabilities
+
+- `synchronization-cleanup`: Behavior of the synchronization cleanup pass — which contracts are considered for deletion, what scope guards apply, and how out-of-scope or missing target objects are handled.
+
+### Modified Capabilities
+
+(none — no other openconnector specs exist yet)
+
+## Impact
+
+- **Code**:
+  - `openconnector/lib/Db/SynchronizationContractMapper.php` — rename and rewrite `findAllBySynchronizationAndSchema` → `findAllBySynchronization`; drop the JOIN against `openregister_objects`.
+  - `openconnector/lib/Service/SynchronizationService.php` — update the call site at `deleteInvalidObjects` (~line 1155); add per-candidate `ObjectService::find` scope check before `updateTarget('delete')`; replace the `// @todo log` swallow with a real log line.
+- **Behavior**:
+  - Sync runs that previously silently failed to delete missing objects will now correctly delete them.
+  - Contracts whose `target_id` falls outside the sync's current `register/schema` scope are left alone (defensive).
+  - Cleanup pass cost shifts from one JOINed query to one unjoined query plus N scoped lookups, where N is "contracts per synchronization." N is typically small (hundreds at most); fan-out is not a concern at current scales.
+- **Cross-app**: Aligns with ADR-001 ("Apps SHOULD use the `ObjectService` for CRUD operations rather than direct mapper access"). The fix removes the only remaining direct cross-app SQL coupling in the openconnector cleanup path.
+- **Follow-up (out of scope here)**: Other openconnector queries — and queries in other Conduction apps — may also JOIN against `openregister_objects` and be silently broken. A separate audit-level change should sweep for this pattern. Long-term, OpenRegister should expose a scoped `deleteObject($uuid, $register, $schema)` so the safety lives at the API boundary instead of being re-implemented in every caller.

--- a/openspec/changes/fix-sync-cleanup-scope-check/specs/synchronization-cleanup/spec.md
+++ b/openspec/changes/fix-sync-cleanup-scope-check/specs/synchronization-cleanup/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Cleanup deletes objects that disappeared from the source
+
+After an extern-to-intern synchronization processes the full source list, the cleanup pass SHALL delete every OpenRegister object whose synchronization contract was not matched against an item in this run's source list, provided the object exists in the synchronization's current `register/schema` scope.
+
+#### Scenario: Object missing from source is deleted on next sync
+
+- **WHEN** a synchronization has previously created a contract for an object with a populated `target_id` pointing to an OpenRegister object in the synchronization's current `register/schema`
+- **AND** a new sync run completes and the object's `originId` is not present in the source list
+- **THEN** the cleanup pass SHALL invoke `ObjectService::deleteObject` for that `target_id`
+- **AND** the synchronization contract's `target_id` SHALL be set to `null`
+- **AND** the contract's `targetLastAction` SHALL be set to `'delete'`
+- **AND** the sync log's `result.objects.deleted` counter SHALL be incremented
+
+#### Scenario: Object still in source is preserved
+
+- **WHEN** a sync run completes and the object's `originId` is present in the source list
+- **THEN** the cleanup pass SHALL NOT delete the corresponding object
+- **AND** the contract's `target_id` SHALL remain unchanged
+
+### Requirement: Cleanup respects the synchronization's register/schema scope
+
+The cleanup pass SHALL only delete objects that exist in the synchronization's current `register/schema` scope. Contracts whose `target_id` resolves to an object in a different scope, or to no object at all, SHALL be left untouched.
+
+#### Scenario: Contract targeting an object in a different schema is not deleted
+
+- **WHEN** the cleanup pass evaluates a candidate contract whose `target_id` is a UUID
+- **AND** `ObjectService::find($targetId, register: $registerId, schema: $schemaId)` returns `null` because the object lives in a different `register/schema`
+- **THEN** the cleanup pass SHALL NOT call `ObjectService::deleteObject` for that `target_id`
+- **AND** the contract SHALL remain unchanged
+- **AND** no entry SHALL be added to `result.objects.deleted` for that contract
+
+#### Scenario: Contract targeting a non-existent UUID is not deleted
+
+- **WHEN** the cleanup pass evaluates a candidate contract whose `target_id` does not match any object in any `register/schema`
+- **THEN** the cleanup pass SHALL NOT call `ObjectService::deleteObject` for that `target_id`
+- **AND** the contract SHALL remain unchanged
+
+### Requirement: Cleanup uses the public ObjectService API only
+
+The synchronization cleanup pass SHALL NOT issue direct SQL queries against OpenRegister's storage tables (`openregister_objects` or any per-register/schema "magic table" such as `oc_or_{registerId}_{schemaId}`). All object existence checks and deletions SHALL go through `ObjectService`.
+
+#### Scenario: No direct queries against openregister_objects
+
+- **WHEN** the cleanup pass runs
+- **THEN** the only OpenRegister interactions SHALL be calls to `ObjectService::find` (for scope-checked existence) and the existing `updateTarget('delete')` path (which uses `ObjectService::deleteObject`)
+- **AND** the contract mapper's candidate query SHALL filter only by `synchronization_id`, with no JOIN to OpenRegister tables
+
+### Requirement: Cleanup logs partial failures instead of swallowing them
+
+When `findOnTarget` for a candidate contract throws `DoesNotExistException` during the cleanup loop, the cleanup pass SHALL emit a warning log entry with the synchronization id, target id, and exception message, and SHALL continue processing remaining candidates.
+
+#### Scenario: Contract not found on second lookup is logged
+
+- **WHEN** the cleanup pass identifies a candidate `target_id` for deletion
+- **AND** the subsequent `findOnTarget` lookup throws `DoesNotExistException` (e.g. concurrent deletion by another process)
+- **THEN** the cleanup pass SHALL log a warning that includes the synchronization id, the candidate target id, and the exception message
+- **AND** the cleanup pass SHALL continue to the next candidate without aborting

--- a/openspec/changes/fix-sync-cleanup-scope-check/tasks.md
+++ b/openspec/changes/fix-sync-cleanup-scope-check/tasks.md
@@ -1,30 +1,30 @@
 ## 1. Mapper rewrite
 
-- [ ] 1.1 In `lib/Db/SynchronizationContractMapper.php`, rename `findAllBySynchronizationAndSchema` to `findAllBySynchronization`. Drop the `$schemaId` parameter from the signature and update the docblock.
-- [ ] 1.2 Replace the method body with a single-table query: select all columns from `openconnector_synchronization_contracts` filtered only by `synchronization_id`. Remove the alias `'c'`, the `INNER JOIN openregister_objects`, and the `o.schema = :schemaId` predicate.
-- [ ] 1.3 Verify the method still returns an array of `SynchronizationContract` entities (or `[]` on exception) so the call site does not need changes beyond the rename.
+- [x] 1.1 In `lib/Db/SynchronizationContractMapper.php`, rename `findAllBySynchronizationAndSchema` to `findAllBySynchronization`. Drop the `$schemaId` parameter from the signature and update the docblock.
+- [x] 1.2 Replace the method body with a single-table query: select all columns from `openconnector_synchronization_contracts` filtered only by `synchronization_id`. Remove the alias `'c'`, the `INNER JOIN openregister_objects`, and the `o.schema = :schemaId` predicate.
+- [x] 1.3 Verify the method still returns an array of `SynchronizationContract` entities (or `[]` on exception) so the call site does not need changes beyond the rename.
 
 ## 2. Cleanup pass — scope-checked deletion
 
-- [ ] 2.1 In `lib/Service/SynchronizationService.php::deleteInvalidObjects`, update the call site (currently around line 1155) from `findAllBySynchronizationAndSchema(syncId, schemaId)` to `findAllBySynchronization(syncId)`.
-- [ ] 2.2 Inside the `case 'register/schema':` branch, after computing `$targetIdsToDelete`, before the `foreach ($targetIdsToDelete ...)` loop, resolve the `ObjectService` instance the same way the rest of `SynchronizationService` does (via the container).
-- [ ] 2.3 In the `foreach`, before calling `$this->updateTarget(...)` for each candidate, call `$objectService->find($targetIdToDelete, register: $registerId, schema: $schemaId)`. If the result is `null`, skip this candidate (continue to the next). Verify whether `_rbac: false` is needed by inspecting how `updateTargetOpenRegister`'s existing `saveObject`/`deleteObject` calls succeed without a user session, and match that behavior.
-- [ ] 2.4 Replace the swallowed `catch (DoesNotExistException $exception) { // @todo log }` block with a `LoggerInterface::warning(...)` call that includes synchronization id, target id, and exception message. Inject `LoggerInterface` into `SynchronizationService` if not already available; otherwise use the existing logger reference.
+- [x] 2.1 In `lib/Service/SynchronizationService.php::deleteInvalidObjects`, update the call site (currently around line 1155) from `findAllBySynchronizationAndSchema(syncId, schemaId)` to `findAllBySynchronization(syncId)`.
+- [x] 2.2 Inside the `case 'register/schema':` branch, after computing `$targetIdsToDelete`, before the `foreach ($targetIdsToDelete ...)` loop, resolve the `ObjectService` instance the same way the rest of `SynchronizationService` does (via the container).
+- [x] 2.3 In the `foreach`, before calling `$this->updateTarget(...)` for each candidate, call `$objectService->find($targetIdToDelete, register: $registerId, schema: $schemaId)`. If the result is `null`, skip this candidate (continue to the next). Resolution: passed `_rbac: false, _multitenancy: false` to match the prior SQL JOIN's lack of authorization filtering.
+- [x] 2.4 Replace the swallowed `catch (DoesNotExistException $exception) { // @todo log }` block with a `LoggerInterface::warning(...)` call that includes synchronization id, target id, and exception message. (`LoggerInterface` was already injected as `$this->logger`.)
 
 ## 3. Tests
 
-- [ ] 3.1 Add a unit test for `SynchronizationContractMapper::findAllBySynchronization` that asserts: contracts are returned filtered by `synchronization_id` only, with no dependency on `openregister_objects` rows.
-- [ ] 3.2 Add an integration-style test for `SynchronizationService::deleteInvalidObjects` covering the in-scope deletion path: contract exists, target object exists in the synchronization's `register/schema`, target is missing from the synchronized list → `deleteObject` is called and contract `target_id` is nulled.
-- [ ] 3.3 Add a test for the cross-scope skip path: contract exists, target object exists in a *different* `register/schema` → `deleteObject` is NOT called, contract is unchanged. Use a real second register/schema or a mocked `ObjectService::find` returning `null` for the foreign-scope call.
-- [ ] 3.4 Add a test for the missing-target path: contract exists, no object with that UUID exists anywhere → `deleteObject` is NOT called, contract is unchanged.
-- [ ] 3.5 Add a test that asserts the warning log is emitted (and the loop continues) when `findOnTarget` throws `DoesNotExistException` mid-cleanup.
+- [x] 3.1 Add a unit test for `SynchronizationContractMapper::findAllBySynchronization` that asserts: contracts are returned filtered by `synchronization_id` only, with no dependency on `openregister_objects` rows. (`tests/Unit/Db/SynchronizationContractMapperTest.php`)
+- [x] 3.2 Add an integration-style test for `SynchronizationService::deleteInvalidObjects` covering the in-scope deletion path: contract exists, target object exists in the synchronization's `register/schema`, target is missing from the synchronized list → `deleteObject` is called and contract `target_id` is nulled. (`testInScopeOrphanIsDeleted`)
+- [x] 3.3 Add a test for the cross-scope skip path: contract exists, target object exists in a *different* `register/schema` → `deleteObject` is NOT called, contract is unchanged. (`testCrossScopeContractIsSkipped`)
+- [x] 3.4 Add a test for the missing-target path: contract exists, no object with that UUID exists anywhere → `deleteObject` is NOT called, contract is unchanged. (`testMissingTargetIsSkipped`)
+- [x] 3.5 Add a test that asserts the warning log is emitted (and the loop continues) when `findOnTarget` throws `DoesNotExistException` mid-cleanup. (`testWarningLoggedWhenContractLookupThrows`) — plus `testInScopeAndOutOfScopeMixedBatch` for combined-batch coverage.
 
 ## 4. Verification & follow-up audit
 
-- [ ] 4.1 Run `composer check:strict` from `openconnector/`. Address any new PHPCS / PHPMD / Psalm / PHPStan findings introduced by this change. Fix pre-existing findings in the touched methods per project policy.
-- [ ] 4.2 Manually run an extern-to-intern sync against a register/schema with a known orphan and confirm: (a) the orphan's OpenRegister object is deleted, (b) the contract's `target_id` is nulled, (c) `result.objects.deleted` increments, (d) `result.timing.stages.cleanup_invalid` is present in the sync log, (e) other syncs against unrelated register/schemas are unaffected.
-- [ ] 4.3 `grep -rn "openregister_objects" lib/` in the openconnector repo. Document any remaining hits in a follow-up note (separate change, not this one) so the audit work is tracked. The expectation is zero hits after this change.
+- [ ] 4.1 Run `composer check:strict` from `openconnector/`. **Status:** the openconnector repo has no `vendor/` installed in this environment (composer install not run), so the strict toolchain (PHPCS / PHPMD / Psalm / PHPStan / PHPUnit) cannot run here. Fallback: `php -l` clean for all four touched files (`SynchronizationContractMapper.php`, `SynchronizationService.php`, both new test files). Run `composer install && composer check:strict` locally before merging — CI will gate on PR.
+- [ ] 4.2 Manually run an extern-to-intern sync against a register/schema with a known orphan and confirm: (a) the orphan's OpenRegister object is deleted, (b) the contract's `target_id` is nulled, (c) `result.objects.deleted` increments, (d) `result.timing.stages.cleanup_invalid` is present in the sync log, (e) other syncs against unrelated register/schemas are unaffected. **Status:** requires a live Nextcloud + OpenRegister environment with seed data — cannot be executed from the apply environment. Reserved for the user during their manual verification pass.
+- [x] 4.3 `grep -rn "openregister_objects" lib/` in the openconnector repo. Result: zero real references; the only hit is a doc comment in `SynchronizationService.php:1184` explaining what the JOIN was replaced with. Expected outcome (zero hits) achieved.
 
 ## 5. Documentation
 
-- [ ] 5.1 If the openconnector developer docs (`docs/developers/`) include a description of the synchronization cleanup pass, update it to reflect the scoped-find approach. If no such doc exists, leave this task unchecked.
+- [x] 5.1 Checked `docs/developers/` for cleanup-pass documentation: no matching content. `docs/synchronization-timing.md` mentions the cleanup stage at a timing level only (no implementation details), so no update needed there either. Task complete with no doc edits.

--- a/openspec/changes/fix-sync-cleanup-scope-check/tasks.md
+++ b/openspec/changes/fix-sync-cleanup-scope-check/tasks.md
@@ -1,0 +1,30 @@
+## 1. Mapper rewrite
+
+- [ ] 1.1 In `lib/Db/SynchronizationContractMapper.php`, rename `findAllBySynchronizationAndSchema` to `findAllBySynchronization`. Drop the `$schemaId` parameter from the signature and update the docblock.
+- [ ] 1.2 Replace the method body with a single-table query: select all columns from `openconnector_synchronization_contracts` filtered only by `synchronization_id`. Remove the alias `'c'`, the `INNER JOIN openregister_objects`, and the `o.schema = :schemaId` predicate.
+- [ ] 1.3 Verify the method still returns an array of `SynchronizationContract` entities (or `[]` on exception) so the call site does not need changes beyond the rename.
+
+## 2. Cleanup pass — scope-checked deletion
+
+- [ ] 2.1 In `lib/Service/SynchronizationService.php::deleteInvalidObjects`, update the call site (currently around line 1155) from `findAllBySynchronizationAndSchema(syncId, schemaId)` to `findAllBySynchronization(syncId)`.
+- [ ] 2.2 Inside the `case 'register/schema':` branch, after computing `$targetIdsToDelete`, before the `foreach ($targetIdsToDelete ...)` loop, resolve the `ObjectService` instance the same way the rest of `SynchronizationService` does (via the container).
+- [ ] 2.3 In the `foreach`, before calling `$this->updateTarget(...)` for each candidate, call `$objectService->find($targetIdToDelete, register: $registerId, schema: $schemaId)`. If the result is `null`, skip this candidate (continue to the next). Verify whether `_rbac: false` is needed by inspecting how `updateTargetOpenRegister`'s existing `saveObject`/`deleteObject` calls succeed without a user session, and match that behavior.
+- [ ] 2.4 Replace the swallowed `catch (DoesNotExistException $exception) { // @todo log }` block with a `LoggerInterface::warning(...)` call that includes synchronization id, target id, and exception message. Inject `LoggerInterface` into `SynchronizationService` if not already available; otherwise use the existing logger reference.
+
+## 3. Tests
+
+- [ ] 3.1 Add a unit test for `SynchronizationContractMapper::findAllBySynchronization` that asserts: contracts are returned filtered by `synchronization_id` only, with no dependency on `openregister_objects` rows.
+- [ ] 3.2 Add an integration-style test for `SynchronizationService::deleteInvalidObjects` covering the in-scope deletion path: contract exists, target object exists in the synchronization's `register/schema`, target is missing from the synchronized list → `deleteObject` is called and contract `target_id` is nulled.
+- [ ] 3.3 Add a test for the cross-scope skip path: contract exists, target object exists in a *different* `register/schema` → `deleteObject` is NOT called, contract is unchanged. Use a real second register/schema or a mocked `ObjectService::find` returning `null` for the foreign-scope call.
+- [ ] 3.4 Add a test for the missing-target path: contract exists, no object with that UUID exists anywhere → `deleteObject` is NOT called, contract is unchanged.
+- [ ] 3.5 Add a test that asserts the warning log is emitted (and the loop continues) when `findOnTarget` throws `DoesNotExistException` mid-cleanup.
+
+## 4. Verification & follow-up audit
+
+- [ ] 4.1 Run `composer check:strict` from `openconnector/`. Address any new PHPCS / PHPMD / Psalm / PHPStan findings introduced by this change. Fix pre-existing findings in the touched methods per project policy.
+- [ ] 4.2 Manually run an extern-to-intern sync against a register/schema with a known orphan and confirm: (a) the orphan's OpenRegister object is deleted, (b) the contract's `target_id` is nulled, (c) `result.objects.deleted` increments, (d) `result.timing.stages.cleanup_invalid` is present in the sync log, (e) other syncs against unrelated register/schemas are unaffected.
+- [ ] 4.3 `grep -rn "openregister_objects" lib/` in the openconnector repo. Document any remaining hits in a follow-up note (separate change, not this one) so the audit work is tracked. The expectation is zero hits after this change.
+
+## 5. Documentation
+
+- [ ] 5.1 If the openconnector developer docs (`docs/developers/`) include a description of the synchronization cleanup pass, update it to reflect the scoped-find approach. If no such doc exists, leave this task unchecked.

--- a/tests/Unit/Db/SynchronizationContractMapperTest.php
+++ b/tests/Unit/Db/SynchronizationContractMapperTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace OCA\OpenConnector\Tests\Unit\Db;
+
+use OCA\OpenConnector\Db\SynchronizationContractMapper;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that findAllBySynchronization no longer JOINs against
+ * openregister_objects and filters only by synchronization_id.
+ */
+class SynchronizationContractMapperTest extends TestCase
+{
+    private SynchronizationContractMapper $mapper;
+    /** @var IDBConnection&MockObject */
+    private IDBConnection $db;
+    /** @var IQueryBuilder&MockObject */
+    private IQueryBuilder $qb;
+    /** @var IExpressionBuilder&MockObject */
+    private IExpressionBuilder $expr;
+
+    protected function setUp(): void
+    {
+        $this->db = $this->createMock(IDBConnection::class);
+        $this->qb = $this->createMock(IQueryBuilder::class);
+        $this->expr = $this->createMock(IExpressionBuilder::class);
+
+        $this->qb->method('expr')->willReturn($this->expr);
+        $this->qb->method('select')->willReturnSelf();
+        $this->qb->method('from')->willReturnSelf();
+        $this->qb->method('where')->willReturnSelf();
+        $this->qb->method('createNamedParameter')->willReturnArgument(0);
+
+        $this->db->method('getQueryBuilder')->willReturn($this->qb);
+
+        $this->mapper = new SynchronizationContractMapper($this->db);
+    }
+
+    public function testFindAllBySynchronizationDoesNotJoinAgainstOpenregisterObjects(): void
+    {
+        $this->qb->expects($this->never())->method('innerJoin');
+        $this->qb->expects($this->never())->method('leftJoin');
+
+        // findEntities will throw because we don't mock executeQuery; the catch block
+        // returns []. We just want to assert the query construction surface.
+        $result = $this->mapper->findAllBySynchronization('sync-1');
+
+        $this->assertSame([], $result);
+    }
+
+    public function testFindAllBySynchronizationSelectsAllColumnsWithoutAlias(): void
+    {
+        $this->qb->expects($this->once())
+            ->method('select')
+            ->with('*')
+            ->willReturnSelf();
+
+        $this->qb->expects($this->once())
+            ->method('from')
+            ->with('openconnector_synchronization_contracts')
+            ->willReturnSelf();
+
+        $this->mapper->findAllBySynchronization('sync-1');
+    }
+
+    public function testFindAllBySynchronizationFiltersOnlyBySynchronizationId(): void
+    {
+        $this->expr->expects($this->once())
+            ->method('eq')
+            ->with('synchronization_id', 'sync-42');
+
+        $this->mapper->findAllBySynchronization('sync-42');
+    }
+
+    public function testRenamedFromFindAllBySynchronizationAndSchema(): void
+    {
+        // The old method name must be gone so callers fail at parse time, not silently.
+        $this->assertFalse(
+            method_exists(SynchronizationContractMapper::class, 'findAllBySynchronizationAndSchema'),
+            'Old method findAllBySynchronizationAndSchema should be removed.'
+        );
+
+        $this->assertTrue(
+            method_exists(SynchronizationContractMapper::class, 'findAllBySynchronization'),
+            'New method findAllBySynchronization should exist.'
+        );
+    }
+}

--- a/tests/Unit/Service/SynchronizationServiceCleanupTest.php
+++ b/tests/Unit/Service/SynchronizationServiceCleanupTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionMethod;
 
 /**
  * Tests the scope-checked cleanup behavior in SynchronizationService::deleteInvalidObjects.
@@ -32,7 +33,7 @@ use Psr\Log\LoggerInterface;
  */
 class SynchronizationServiceCleanupTest extends TestCase
 {
-    private const SYNC_ID = 'sync-uuid-1';
+    private const SYNC_DB_ID = 1;
     private const REGISTER_ID = '1';
     private const SCHEMA_ID = '2';
     private const TARGET_IN_SCOPE = 'object-in-scope-uuid';
@@ -91,8 +92,8 @@ class SynchronizationServiceCleanupTest extends TestCase
     private function makeSync(): Synchronization
     {
         $sync = new Synchronization();
-        $sync->setId(1);
-        $sync->setUuid(self::SYNC_ID);
+        $sync->setId(self::SYNC_DB_ID);
+        $sync->setUuid('sync-uuid-1');
         $sync->setTargetType('register/schema');
         $sync->setTargetId(self::REGISTER_ID . '/' . self::SCHEMA_ID);
         return $sync;
@@ -101,34 +102,52 @@ class SynchronizationServiceCleanupTest extends TestCase
     private function makeContract(string $targetId, string $originId = 'origin-x'): SynchronizationContract
     {
         $contract = new SynchronizationContract();
-        $contract->setSynchronizationId(self::SYNC_ID);
+        $contract->setSynchronizationId((string) self::SYNC_DB_ID);
         $contract->setTargetId($targetId);
         $contract->setOriginId($originId);
         return $contract;
+    }
+
+    /**
+     * Map ObjectService::find parameter names to positional indices.
+     *
+     * Production calls find() with named arguments; PHPUnit's stub receives positional
+     * arguments after the runtime expansion. Using reflection here keeps assertions
+     * robust against signature changes — adding a parameter shifts all later positions
+     * but the named lookup follows automatically.
+     */
+    private function findParamPositions(): array
+    {
+        $rm = new ReflectionMethod(\OCA\OpenRegister\Service\ObjectService::class, 'find');
+        $positions = [];
+        foreach ($rm->getParameters() as $i => $p) {
+            $positions[$p->getName()] = $i;
+        }
+        return $positions;
     }
 
     public function testInScopeOrphanIsDeleted(): void
     {
         $sync = $this->makeSync();
         $contract = $this->makeContract(self::TARGET_IN_SCOPE);
+        $pos = $this->findParamPositions();
 
         $this->contractMapper->method('findAllBySynchronization')
-            ->with(self::SYNC_ID)
+            ->with(self::SYNC_DB_ID)
             ->willReturn([$contract]);
 
         $this->contractMapper->method('findOnTarget')
-            ->with(self::SYNC_ID, self::TARGET_IN_SCOPE)
+            ->with(self::SYNC_DB_ID, self::TARGET_IN_SCOPE)
             ->willReturn($contract);
 
         $this->openRegisterObjectService->expects($this->once())
             ->method('find')
-            ->willReturnCallback(function (...$args) {
-                // Positional after named-arg expansion: id, _extend, files, register, schema, _rbac, _multitenancy
-                $this->assertSame(self::TARGET_IN_SCOPE, $args[0]);
-                $this->assertSame(self::REGISTER_ID, $args[3]);
-                $this->assertSame(self::SCHEMA_ID, $args[4]);
-                $this->assertFalse($args[5], '_rbac must be false to match prior unscoped JOIN behavior');
-                $this->assertFalse($args[6], '_multitenancy must be false to match prior unscoped JOIN behavior');
+            ->willReturnCallback(function (...$args) use ($pos) {
+                $this->assertSame(self::TARGET_IN_SCOPE, $args[$pos['id']]);
+                $this->assertSame(self::REGISTER_ID, $args[$pos['register']]);
+                $this->assertSame(self::SCHEMA_ID, $args[$pos['schema']]);
+                $this->assertFalse($args[$pos['_rbac']], '_rbac must be false to match prior unscoped JOIN behavior');
+                $this->assertFalse($args[$pos['_multitenancy']], '_multitenancy must be false to match prior unscoped JOIN behavior');
                 return $this->createMock(ObjectEntity::class);
             });
 
@@ -148,7 +167,7 @@ class SynchronizationServiceCleanupTest extends TestCase
         $contract = $this->makeContract(self::TARGET_OUT_OF_SCOPE);
 
         $this->contractMapper->method('findAllBySynchronization')
-            ->with(self::SYNC_ID)
+            ->with(self::SYNC_DB_ID)
             ->willReturn([$contract]);
 
         // Foreign-scope find returns null — object exists but lives in a different register/schema.
@@ -167,7 +186,7 @@ class SynchronizationServiceCleanupTest extends TestCase
         $contract = $this->makeContract(self::TARGET_MISSING);
 
         $this->contractMapper->method('findAllBySynchronization')
-            ->with(self::SYNC_ID)
+            ->with(self::SYNC_DB_ID)
             ->willReturn([$contract]);
 
         // No object with that UUID exists anywhere.
@@ -186,7 +205,7 @@ class SynchronizationServiceCleanupTest extends TestCase
         $contract = $this->makeContract(self::TARGET_IN_SCOPE);
 
         $this->contractMapper->method('findAllBySynchronization')
-            ->with(self::SYNC_ID)
+            ->with(self::SYNC_DB_ID)
             ->willReturn([$contract]);
 
         $this->openRegisterObjectService->method('find')
@@ -220,7 +239,7 @@ class SynchronizationServiceCleanupTest extends TestCase
         $outOfScope = $this->makeContract(self::TARGET_OUT_OF_SCOPE, 'origin-b');
 
         $this->contractMapper->method('findAllBySynchronization')
-            ->with(self::SYNC_ID)
+            ->with(self::SYNC_DB_ID)
             ->willReturn([$inScope, $outOfScope]);
 
         $this->openRegisterObjectService->method('find')

--- a/tests/Unit/Service/SynchronizationServiceCleanupTest.php
+++ b/tests/Unit/Service/SynchronizationServiceCleanupTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace OCA\OpenConnector\Tests\Unit\Service;
+
+use OCA\OpenConnector\Db\Synchronization;
+use OCA\OpenConnector\Db\SynchronizationContract;
+use OCA\OpenConnector\Db\SynchronizationContractLogMapper;
+use OCA\OpenConnector\Db\SynchronizationContractMapper;
+use OCA\OpenConnector\Db\SynchronizationLogMapper;
+use OCA\OpenConnector\Db\SynchronizationMapper;
+use OCA\OpenConnector\Db\SourceMapper;
+use OCA\OpenConnector\Db\MappingMapper;
+use OCA\OpenConnector\Db\RuleMapper;
+use OCA\OpenConnector\Service\CallService;
+use OCA\OpenConnector\Service\MappingService;
+use OCA\OpenConnector\Service\ObjectService;
+use OCA\OpenConnector\Service\StorageService;
+use OCA\OpenConnector\Service\SynchronizationService;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the scope-checked cleanup behavior in SynchronizationService::deleteInvalidObjects.
+ *
+ * These tests use a partial mock of SynchronizationService so the cleanup logic can be
+ * exercised independently of updateTarget (which has its own deep dependency chain).
+ */
+class SynchronizationServiceCleanupTest extends TestCase
+{
+    private const SYNC_ID = 'sync-uuid-1';
+    private const REGISTER_ID = '1';
+    private const SCHEMA_ID = '2';
+    private const TARGET_IN_SCOPE = 'object-in-scope-uuid';
+    private const TARGET_OUT_OF_SCOPE = 'object-out-of-scope-uuid';
+    private const TARGET_MISSING = 'object-missing-uuid';
+
+    /** @var SynchronizationContractMapper&MockObject */
+    private $contractMapper;
+    /** @var ContainerInterface&MockObject */
+    private $container;
+    /** @var ObjectService&MockObject Mock for OpenRegister ObjectService (resolved via container) */
+    private $openRegisterObjectService;
+    /** @var LoggerInterface&MockObject */
+    private $logger;
+    /** @var SynchronizationService&MockObject */
+    private $service;
+
+    protected function setUp(): void
+    {
+        $this->contractMapper = $this->createMock(SynchronizationContractMapper::class);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->openRegisterObjectService = $this->createMock(\OCA\OpenRegister\Service\ObjectService::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        // The cleanup pass resolves OpenRegister's ObjectService via the container.
+        $this->container->method('get')
+            ->with('OCA\\OpenRegister\\Service\\ObjectService')
+            ->willReturn($this->openRegisterObjectService);
+
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('hasKey')->willReturn(false);
+
+        $constructorArgs = [
+            $this->createMock(CallService::class),
+            $this->createMock(MappingService::class),
+            $this->container,
+            $this->createMock(SourceMapper::class),
+            $this->createMock(MappingMapper::class),
+            $this->createMock(SynchronizationMapper::class),
+            $this->createMock(SynchronizationLogMapper::class),
+            $this->contractMapper,
+            $this->createMock(SynchronizationContractLogMapper::class),
+            $this->createMock(ObjectService::class),
+            $this->createMock(StorageService::class),
+            $this->createMock(RuleMapper::class),
+            $this->logger,
+            $appConfig,
+        ];
+
+        $this->service = $this->getMockBuilder(SynchronizationService::class)
+            ->setConstructorArgs($constructorArgs)
+            ->onlyMethods(['updateTarget'])
+            ->getMock();
+    }
+
+    private function makeSync(): Synchronization
+    {
+        $sync = new Synchronization();
+        $sync->setId(1);
+        $sync->setUuid(self::SYNC_ID);
+        $sync->setTargetType('register/schema');
+        $sync->setTargetId(self::REGISTER_ID . '/' . self::SCHEMA_ID);
+        return $sync;
+    }
+
+    private function makeContract(string $targetId, string $originId = 'origin-x'): SynchronizationContract
+    {
+        $contract = new SynchronizationContract();
+        $contract->setSynchronizationId(self::SYNC_ID);
+        $contract->setTargetId($targetId);
+        $contract->setOriginId($originId);
+        return $contract;
+    }
+
+    public function testInScopeOrphanIsDeleted(): void
+    {
+        $sync = $this->makeSync();
+        $contract = $this->makeContract(self::TARGET_IN_SCOPE);
+
+        $this->contractMapper->method('findAllBySynchronization')
+            ->with(self::SYNC_ID)
+            ->willReturn([$contract]);
+
+        $this->contractMapper->method('findOnTarget')
+            ->with(self::SYNC_ID, self::TARGET_IN_SCOPE)
+            ->willReturn($contract);
+
+        $this->openRegisterObjectService->expects($this->once())
+            ->method('find')
+            ->willReturnCallback(function (...$args) {
+                // Positional after named-arg expansion: id, _extend, files, register, schema, _rbac, _multitenancy
+                $this->assertSame(self::TARGET_IN_SCOPE, $args[0]);
+                $this->assertSame(self::REGISTER_ID, $args[3]);
+                $this->assertSame(self::SCHEMA_ID, $args[4]);
+                $this->assertFalse($args[5], '_rbac must be false to match prior unscoped JOIN behavior');
+                $this->assertFalse($args[6], '_multitenancy must be false to match prior unscoped JOIN behavior');
+                return $this->createMock(ObjectEntity::class);
+            });
+
+        $this->service->expects($this->once())
+            ->method('updateTarget')
+            ->with($contract, [], 'delete')
+            ->willReturn($contract);
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(1, $deleted, 'Orphan in scope should be deleted');
+    }
+
+    public function testCrossScopeContractIsSkipped(): void
+    {
+        $sync = $this->makeSync();
+        $contract = $this->makeContract(self::TARGET_OUT_OF_SCOPE);
+
+        $this->contractMapper->method('findAllBySynchronization')
+            ->with(self::SYNC_ID)
+            ->willReturn([$contract]);
+
+        // Foreign-scope find returns null — object exists but lives in a different register/schema.
+        $this->openRegisterObjectService->method('find')->willReturn(null);
+
+        $this->service->expects($this->never())->method('updateTarget');
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(0, $deleted, 'Out-of-scope contract must not trigger deletion');
+    }
+
+    public function testMissingTargetIsSkipped(): void
+    {
+        $sync = $this->makeSync();
+        $contract = $this->makeContract(self::TARGET_MISSING);
+
+        $this->contractMapper->method('findAllBySynchronization')
+            ->with(self::SYNC_ID)
+            ->willReturn([$contract]);
+
+        // No object with that UUID exists anywhere.
+        $this->openRegisterObjectService->method('find')->willReturn(null);
+
+        $this->service->expects($this->never())->method('updateTarget');
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(0, $deleted);
+    }
+
+    public function testWarningLoggedWhenContractLookupThrows(): void
+    {
+        $sync = $this->makeSync();
+        $contract = $this->makeContract(self::TARGET_IN_SCOPE);
+
+        $this->contractMapper->method('findAllBySynchronization')
+            ->with(self::SYNC_ID)
+            ->willReturn([$contract]);
+
+        $this->openRegisterObjectService->method('find')
+            ->willReturn($this->createMock(ObjectEntity::class));
+
+        $this->contractMapper->method('findOnTarget')
+            ->willThrowException(new DoesNotExistException('contract gone'));
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->stringContains('Contract not found on second lookup'),
+                $this->callback(function ($context) {
+                    return isset($context['synchronizationId'])
+                        && isset($context['targetId'])
+                        && isset($context['error']);
+                })
+            );
+
+        $this->service->expects($this->never())->method('updateTarget');
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(0, $deleted);
+    }
+
+    public function testInScopeAndOutOfScopeMixedBatch(): void
+    {
+        $sync = $this->makeSync();
+        $inScope = $this->makeContract(self::TARGET_IN_SCOPE, 'origin-a');
+        $outOfScope = $this->makeContract(self::TARGET_OUT_OF_SCOPE, 'origin-b');
+
+        $this->contractMapper->method('findAllBySynchronization')
+            ->with(self::SYNC_ID)
+            ->willReturn([$inScope, $outOfScope]);
+
+        $this->openRegisterObjectService->method('find')
+            ->willReturnCallback(function ($id) {
+                return $id === self::TARGET_IN_SCOPE
+                    ? $this->createMock(ObjectEntity::class)
+                    : null;
+            });
+
+        $this->contractMapper->method('findOnTarget')
+            ->willReturnCallback(function ($syncId, $targetId) use ($inScope) {
+                return $targetId === self::TARGET_IN_SCOPE ? $inScope : null;
+            });
+
+        $this->service->expects($this->once())
+            ->method('updateTarget')
+            ->with($inScope, [], 'delete')
+            ->willReturn($inScope);
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(1, $deleted, 'Only in-scope orphan should be deleted in mixed batch');
+    }
+}

--- a/tests/Unit/Service/SynchronizationServiceCleanupTest.php
+++ b/tests/Unit/Service/SynchronizationServiceCleanupTest.php
@@ -237,14 +237,15 @@ class SynchronizationServiceCleanupTest extends TestCase
         $sync = $this->makeSync();
         $inScope = $this->makeContract(self::TARGET_IN_SCOPE, 'origin-a');
         $outOfScope = $this->makeContract(self::TARGET_OUT_OF_SCOPE, 'origin-b');
+        $pos = $this->findParamPositions();
 
         $this->contractMapper->method('findAllBySynchronization')
             ->with(self::SYNC_DB_ID)
             ->willReturn([$inScope, $outOfScope]);
 
         $this->openRegisterObjectService->method('find')
-            ->willReturnCallback(function ($id) {
-                return $id === self::TARGET_IN_SCOPE
+            ->willReturnCallback(function (...$args) use ($pos) {
+                return $args[$pos['id']] === self::TARGET_IN_SCOPE
                     ? $this->createMock(ObjectEntity::class)
                     : null;
             });


### PR DESCRIPTION
## Summary

Restores synchronization cleanup against OpenRegister 1.0+'s per-register/schema "magic table" architecture, where the existing `INNER JOIN openregister_objects` in `SynchronizationContractMapper` returned zero rows on every sync — orphaned objects were never deleted.

- `SynchronizationContractMapper`: rename `findAllBySynchronizationAndSchema` → `findAllBySynchronization`, drop the JOIN, filter contracts by `synchronization_id` only.
- `SynchronizationService::deleteInvalidObjects`: verify each candidate is in scope via `ObjectService::find($uuid, register, schema, _rbac: false, _multitenancy: false)` before calling `updateTarget('delete')`. Out-of-scope / missing-target candidates are skipped, preventing cross-schema deletion when a sync's target was changed mid-life.
- `SynchronizationService::updateTarget`: use `ObjectService::deleteObject(uuid:)` instead of the deprecated `delete(['id' => …])`.
- Replace the previously-silent `DoesNotExistException` swallow in the cleanup loop with a `LoggerInterface::warning` entry so partial failures surface.
- Unit tests for both the mapper rewrite and the cleanup-path scenarios (in-scope delete, cross-scope skip, missing-target skip, warning log on second lookup, mixed batch).
- Full OpenSpec change artifacts under `openspec/changes/fix-sync-cleanup-scope-check/` (`proposal.md`, `design.md`, `specs/synchronization-cleanup/spec.md`, `tasks.md`, `plan.json`).

Refs #732. Companion PR #733 carries the same fix plus review-feedback iterations on top, targeted at `development`.

## Test plan

- [ ] `composer install && composer check:strict` from `openconnector/`.
- [ ] Manual sync verification: trigger an extern-to-intern sync against a register/schema with a known orphan and confirm:
  - The orphan's OpenRegister object is deleted.
  - The contract's `target_id` is nulled.
  - The sync log shows `result.objects.deleted` incremented and `result.timing.stages.cleanup_invalid` present.
  - Other syncs against unrelated `register/schema` combinations are unaffected.
- [ ] Confirm the warning log appears (and the loop continues) if `findOnTarget` throws `DoesNotExistException` mid-cleanup.
- [ ] CI runs against this PR (PHPCS / PHPMD / Psalm / PHPStan / unit tests).