### PR TITLE
feat(openspec): openconnector-adopt-or-abstractions — RuleService cleanup + retention dedupe

### DIFF
--- a/openspec/changes/openconnector-adopt-or-abstractions/design.md
+++ b/openspec/changes/openconnector-adopt-or-abstractions/design.md
@@ -1,0 +1,143 @@
+# Design — openconnector: adopt OR abstractions
+
+## Context
+
+openconnector is the integration / synchronization fabric of the Conduction stack: sources,
+mappings, contracts, webhooks, rules, and protocol-specific adapters (DSO/Omgevingsloket,
+StUF, iBabs-Notubiz). The 2026-05-03 OR-abstraction audit places it at Tier 2: a real
+domain-specific app with intentional store proliferation and a custom mapping/rule engine,
+but with three concrete duplications of OR machinery that should migrate.
+
+This change pairs with the docudesk and pipelinq adoption changes and depends on the same
+OR-side and Hydra-side prerequisites.
+
+## Goals
+
+- Eliminate the cognitive collision between openconnector's `ObjectService` and OR's
+  generic `ObjectService` by renaming.
+- Stop hardcoding schema-property GUIDs that break on schema rebuilds.
+- Stop triplicating retention constants across three services.
+- Migrate inline `'status'` writes onto lifecycle annotations.
+- Add a manifest declaring tier and dependencies.
+- Explicitly document the parts that stay app-local (stores, mapping engine).
+
+## Non-Goals
+
+- Replacing the mapping/rule engine. By-design transforms between schemas, KEPT.
+- Replacing the 20+ Pinia stores with `createObjectStore`. Intentionally
+  domain-specific, KEPT.
+- Replacing protocol-specific adapters. DSO, StUF, iBabs-Notubiz integrations stay
+  app-local and use the `pluggable-integration-registry` from OR.
+- Touching `prometheus-metrics/spec.md`. Audit flagged it CURRENT.
+
+## Decisions
+
+### Decision 1 — Rename to `SourceMappingService`, keep deprecated alias
+
+`lib/Service/ObjectService.php` collides with OR's generic `ObjectService` cognitively.
+Internal usages confirmed by audit grep; no external consumers depend on the class name.
+
+**Decision**: rename to `SourceMappingService.php`. Keep
+`OCA\OpenConnector\Service\ObjectService extends SourceMappingService` as a deprecated alias
+for one minor version per ADR-022 deprecation policy.
+
+**Why**: low-risk, high-clarity. Stream 1's S/M (small effort, medium impact) calculus.
+
+### Decision 2 — Slug-based property lookup, not GUID constants
+
+`RuleService.php:125-131` declares eight `PROP_*` constants holding raw schema-property GUIDs
+(`id-7d91e5c8-…`). Schema rebuilds — common during dev — invalidate these GUIDs silently.
+
+**Decision**: replace with `RegisterResolverService::resolveProperty($schemaSlug,
+$propertySlug)` calls. Resolved at boot, cached for the request.
+
+**Why**: stream 4 finding. Slugs are stable across rebuilds; GUIDs are not. Brittleness
+removal is the audit's primary motivation here.
+
+### Decision 3 — Single archival annotation, three services drop their constants
+
+`DEFAULT_SUCCESS_LOG_RETENTION = 3600000` (1 hour in milliseconds) and
+`DEFAULT_ERROR_LOG_RETENTION = 2592000000` (30 days in milliseconds) appear identical in
+`JobService:60-61`, `CallService:66-67`, `SynchronizationService:83-84`.
+
+**Decision**: declare retention ONCE on the log schema as
+`x-openregister-archival.retention: PT1H` (success) and `P30D` (error). The schema may
+need a discriminator (success/error) so the annotation can route by row.
+
+**Why**: ADR-024 mandates per-schema declaration. Consolidating three identical constants
+is the cheapest stream 4 win in the codebase.
+
+### Decision 4 — Per-value review of state-enum smell
+
+The audit flagged controllers exposing `'status' => 'active'|'inactive'|'error'|'success'|
+'warning'|'info'|'debug'` as filter values. Some of these are lifecycle (active, inactive,
+error). Some are not (success/warning/info/debug — log-level filters).
+
+**Decision**:
+- `active`, `inactive`, `error` on `SynchronizationContractsController:366-368` → LIFECYCLE.
+  Migrate to `x-openregister-lifecycle` on the contract schema.
+- `success`, `warning`, `info`, `debug` on `SynchronizationsController:510-514` → LOG-LEVEL
+  filter, NOT lifecycle. Document as filter whitelist.
+
+**Why**: the spec must distinguish state from filter. Audit explicitly flags both for
+review; the disposition lives in the spec scenarios so a future audit can verify.
+
+### Decision 5 — Stores and mapping engine STAY app-local
+
+The audit's stream 1 explicitly classifies openconnector's 20+ Pinia stores and the
+mapping/rule engine as intentionally domain-specific. Without this decision in the spec,
+a future audit would re-flag them.
+
+**Decision**: the new capability spec ADDS a Requirement saying these stay app-local. Future
+audits cite this Requirement to skip the re-investigation.
+
+**Why**: codifies the audit's "by design" judgement so the question doesn't re-open every
+six months.
+
+### Decision 6 — Magic-number defaults preserve current behavior
+
+Same rule as docudesk: each constant moving to admin-config keeps its current value as
+the default.
+
+**Why**: zero behavioral change at install. Stream 4's standard discipline.
+
+### Decision 7 — `prometheus-metrics` not rewritten
+
+Audit (stream 2) found `prometheus-metrics/spec.md` CURRENT. This change does NOT touch
+it. The new capability spec cites it under "See Also" so readers find the existing
+metrics contract.
+
+**Why**: scope discipline. Spec-only change, only fix what audit flags as broken.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| --- | --- |
+| Renaming `ObjectService` may break a third-party app importing the class. | One-minor-version deprecated class alias. Apply phase emits a `@trigger_error('… renamed to SourceMappingService …', E_USER_DEPRECATED)`. |
+| `RuleService::PROP_*` constants may be referenced from rule definitions persisted in DB (not in code). | Apply phase ships a migration that rewrites stored rule references from GUID to slug-based form. |
+| Triple constants may have legitimate divergent values in some tenants (admin set them differently). | Audit checked: all three are PHP `const`, not `IAppConfig`. No tenant override exists today. Migration is safe. |
+| Filter-vs-lifecycle review may misclassify a value. | Per-value disposition is in the spec scenario list; future audit can re-check by reading the spec. |
+| `prometheus-metrics` spec drift between this change and the next OR upgrade. | Phase 6 explicitly tasks a drift check (no rewrite, just verify). |
+
+## Migration path
+
+1. OR ships `register-resolver-service`, `pluggable-integration-registry`,
+   `i18n-source-of-truth`, `i18n-api-language-negotiation` (gates Phase 1, 9).
+2. OR ships ADR-022 lifecycle + ADR-024 archival + ADR-025 notification annotation runtime
+   (gates Phases 2, 3, 4).
+3. nc-vue ships `multi-tenancy-context` (gates Phase 9).
+4. Hydra ships `adopt-app-manifest` (gates Phase 8).
+5. openconnector apply phase runs in order: 7.1 (rename) → 1 → 4 → 2 → 3 → 5 → 6 → 7.2-7.5
+   → 8 → 9 → 10. Rename happens FIRST so subsequent phases edit the renamed file.
+
+## Open Questions
+
+- DSO message lifecycle states beyond `ontvangen`: full state list (e.g. `verwerkt`,
+  `gefaald`, `geretourneerd`) needs confirmation from DSO/Omgevingsloket spec authors.
+  Apply phase confirms.
+- Log-level filter values (`success/warning/info/debug`): should they be a JSON-schema
+  enum on the log schema, or remain as ad-hoc filter whitelist values? Spec scenario
+  proposes enum; apply phase confirms.
+- Retention discriminator on the log schema: does the schema have a `level` field, or do
+  success and error logs live in different schemas? Audit didn't drill that deep; apply
+  phase confirms before declaring `x-openregister-archival`.

--- a/openspec/changes/openconnector-adopt-or-abstractions/proposal.md
+++ b/openspec/changes/openconnector-adopt-or-abstractions/proposal.md
@@ -1,0 +1,117 @@
+# openconnector: adopt OpenRegister abstractions
+
+## Why
+
+The OR-abstraction audit (2026-05-03) places openconnector at Tier 2 — backend-heavy with
+some legitimately app-specific machinery (mapping/rule transforms, source orchestration)
+and some duplicated abstractions that now live in OR.
+
+Findings driving this change:
+
+- **Naming collision**: `lib/Service/ObjectService.php` is a connector-specific source +
+  mapping orchestrator, not a generic object CRUD service. It collides cognitively with
+  OR's generic `ObjectService`. The audit (stream 1) recommends renaming to
+  `SourceMappingService`.
+- **Hardcoded schema GUIDs**: `lib/Service/RuleService.php:125-131` has eight `PROP_*`
+  constants holding raw schema property GUIDs (e.g. `id-7d91e5c8-…`). Brittle to schema
+  rebuilds; should reference schemas by slug.
+- **Triplicated retention constants**: `DEFAULT_SUCCESS_LOG_RETENTION = 3600000` and
+  `DEFAULT_ERROR_LOG_RETENTION = 2592000000` appear identical in three services
+  (`JobService`, `CallService`, `SynchronizationService`). Belongs in OR's
+  `x-openregister-archival` annotation, declared once on the log schema.
+- **Hardcoded magic numbers**: `EndpointCacheService::CACHE_TTL = 3600`,
+  `SoftwareCatalogueService::SUFFIX = '-sc'` belong in admin-config.
+- **State-enum smell on the wire**: synchronization-contracts and synchronizations
+  controllers expose `'status' => 'active'|'inactive'|'error'|'success'|...` as filter
+  values. Some of these are legitimate filter taxonomy, some are lifecycle states. Audit
+  flags both for a per-value review.
+- **Lifecycle status writes**: `DSOController:115` and `EventService:170,256` write
+  `'status' => 'ontvangen'|'pending'` inline.
+- **No app manifest** declaring tier, dependencies, or consumed shared specs.
+
+Findings explicitly KEPT (per audit, not migrated):
+
+- **Domain-specific stores**: openconnector has 20+ Pinia modules (source, mapping,
+  endpoint, contract, webhooks, rule, etc). The audit (stream 1) classifies these as
+  intentionally domain-specific, NOT duplication of OR's object store. KEEP as-is. This
+  spec explicitly notes that.
+- **Mapping/Rule rewrite engine**: by-design transforms between schemas, app-local. KEEP.
+
+This change adopts the OR-side specs (`register-resolver-service`,
+`pluggable-integration-registry`, `i18n-source-of-truth`,
+`i18n-api-language-negotiation`), the nc-vue `multi-tenancy-context` spec, and the Hydra
+`adopt-app-manifest` change. It also migrates retention constants and lifecycle writes onto
+OR annotations.
+
+The audit references this proposal must respect:
+
+- `.claude/audit-2026-05-03/01-code-cleanup.md` (stream 1: rename, keep stores, keep mapping)
+- `.claude/audit-2026-05-03/02-spec-rewrite.md` (stream 2: prometheus-metrics current,
+  ibabs-notubiz + stuf-adapter integrations stay app-local)
+- `.claude/audit-2026-05-03/04-hardcoded.md` (stream 4: GUID consts, retention, magic numbers)
+- `hydra/openspec/architecture/ADR-022.md` (lifecycle annotation)
+- `hydra/openspec/architecture/ADR-024.md` (archival annotation)
+
+## What Changes
+
+### Code-level renames + de-duplication
+
+1. Rename `lib/Service/ObjectService.php` to `lib/Service/SourceMappingService.php` (S
+   effort, M impact). Disambiguates from OR's generic `ObjectService`. All call sites
+   updated.
+2. Replace eight `PROP_*` GUID constants in `RuleService.php:125-131` with schema-slug
+   based property references. Lookup happens at boot time via `RegisterResolverService`.
+3. Consolidate `DEFAULT_SUCCESS_LOG_RETENTION` / `DEFAULT_ERROR_LOG_RETENTION` triplicated
+   across `JobService`, `CallService`, `SynchronizationService` into a single
+   `x-openregister-archival` declaration on the log schema. Drop the source constants.
+
+### Lifecycle annotation migration
+
+4. `lib/Controller/DSOController.php:115` `'status' => 'ontvangen'` and
+   `lib/Service/EventService.php:170,256` `'status' => 'pending'` migrated to
+   `x-openregister-lifecycle` annotation per ADR-022.
+5. Status filter values exposed by `SynchronizationContractsController:366-368` and
+   `SynchronizationsController:510-514` reviewed: filter-only values stay in the
+   controller's filter whitelist; lifecycle states migrate to the annotation. The
+   spec's scenario list documents the per-value disposition.
+
+### Hardcoded magic-number cleanup
+
+6. `EndpointCacheService::CACHE_TTL` → admin-config.
+7. `SoftwareCatalogueService::SUFFIX` → admin-config.
+
+### Manifest + multi-tenancy + i18n adoption
+
+8. `openspec/manifest.yaml` — Tier 2, `dependencies: ["openregister"]`,
+   `consumes: [register-resolver-service, pluggable-integration-registry,
+   i18n-source-of-truth, i18n-api-language-negotiation, multi-tenancy-context]`.
+9. Frontend stores stay app-local but consume `multi-tenancy-context` for tenant scope.
+10. i18n adoption for endpoint/source/mapping label + description + error messages.
+
+### Spec note: domain-specific stores stay
+
+11. The new `openconnector-or-adoption` capability spec explicitly documents that the 20+
+    Pinia modules are intentionally domain-specific and not subject to the
+    `createObjectStore` exemplar pattern (which applies to apps with generic object views).
+
+## Impact
+
+- Affected code (apply-phase hints, NOT changed here):
+  `lib/Service/ObjectService.php` (rename), `lib/Service/RuleService.php`,
+  `lib/Service/JobService.php`, `lib/Service/CallService.php`,
+  `lib/Service/SynchronizationService.php`, `lib/Service/EndpointCacheService.php`,
+  `lib/Service/SoftwareCatalogueService.php`,
+  `lib/Controller/DSOController.php`,
+  `lib/Service/EventService.php`,
+  `lib/Controller/SynchronizationContractsController.php`,
+  `lib/Controller/SynchronizationsController.php`.
+- Affected specs: `openspec/specs/prometheus-metrics/spec.md` (kept current; cite from this
+  change), `ibabs-notubiz-connector` and `stuf-adapter` change folders (kept app-local;
+  cite from this change). New `openconnector-or-adoption` capability spec.
+- Breaking changes:
+  - `ObjectService` → `SourceMappingService` rename. Any external consumer importing the
+    class breaks; grep confirms current usages are internal only. PHP class alias kept for
+    one minor version per ADR-022 deprecation policy.
+  - `RuleService::PROP_*` constants removed. Internal-only; no external consumers.
+  - `DEFAULT_SUCCESS_LOG_RETENTION` / `DEFAULT_ERROR_LOG_RETENTION` removed.
+- Dependencies: same as docudesk — OR + nc-vue + Hydra ship the prerequisite specs first.

--- a/openspec/changes/openconnector-adopt-or-abstractions/specs/openconnector-or-adoption/spec.md
+++ b/openspec/changes/openconnector-adopt-or-abstractions/specs/openconnector-or-adoption/spec.md
@@ -1,0 +1,205 @@
+# Capability — openconnector-or-adoption
+
+## ADDED Requirements
+
+### Requirement: Connector-specific service is renamed to SourceMappingService
+
+`lib/Service/ObjectService.php` SHALL be renamed to
+`lib/Service/SourceMappingService.php`. A deprecated PHP class alias
+`OCA\OpenConnector\Service\ObjectService` SHALL extend the new class for one minor version
+to preserve external compatibility.
+
+#### Scenario: Class rename is the canonical name
+
+- **GIVEN** the rename is applied
+- **WHEN** a developer searches `lib/` for `class ObjectService`
+- **THEN** they SHALL find only the deprecated alias (single line) and the new
+  `SourceMappingService` definition.
+
+#### Scenario: Deprecated alias triggers E_USER_DEPRECATED
+
+- **GIVEN** an external app instantiates `OCA\OpenConnector\Service\ObjectService`
+- **WHEN** the constructor runs
+- **THEN** a `E_USER_DEPRECATED` notice SHALL fire pointing to `SourceMappingService`.
+
+### Requirement: Schema property references use slug-based lookup
+
+The eight `PROP_*` constants in `lib/Service/RuleService.php:125-131` SHALL be replaced
+with `RegisterResolverService::resolveProperty($schemaSlug, $propertySlug)` calls. Raw
+schema-property GUIDs SHALL NOT appear as PHP constants anywhere in `lib/`.
+
+#### Scenario: Slug-based lookup survives schema rebuild
+
+- **GIVEN** the rule engine is configured against a schema slug (e.g. `synchronization-rule`)
+- **WHEN** that schema is rebuilt and gets new property GUIDs
+- **THEN** the rule engine SHALL continue to function without code changes
+- **AND** no `id-…` GUID literal SHALL exist in `lib/Service/RuleService.php`.
+
+### Requirement: Log retention is declared once via archival annotation
+
+The triplicated retention constants `DEFAULT_SUCCESS_LOG_RETENTION = 3600000` and
+`DEFAULT_ERROR_LOG_RETENTION = 2592000000` in `JobService.php:60-61`,
+`CallService.php:66-67`, and `SynchronizationService.php:83-84` SHALL be removed. The
+log schema SHALL declare `x-openregister-archival.retention` (`PT1H` for success rows,
+`P30D` for error rows). Conversion from milliseconds to ISO-8601 SHALL preserve current
+duration.
+
+#### Scenario: Single archival declaration replaces three constants
+
+- **GIVEN** the log schema declares `x-openregister-archival`
+- **WHEN** OR's archival job runs
+- **THEN** success-log rows older than 1 hour SHALL be eligible for archival
+- **AND** error-log rows older than 30 days SHALL be eligible for archival
+- **AND** no `DEFAULT_*_LOG_RETENTION` constants SHALL exist in `lib/Service/`.
+
+### Requirement: Lifecycle annotation backs status state changes
+
+Inline `'status'` writes in `lib/Controller/DSOController.php:115` and
+`lib/Service/EventService.php:170,256` SHALL be replaced with lifecycle transition API
+calls. The dso-message and event schemas SHALL declare `x-openregister-lifecycle`. The
+on-wire status value SHALL remain identical to the current value.
+
+#### Scenario: DSO message ontvangen state via lifecycle
+
+- **GIVEN** the dso-message schema declares lifecycle states including `ontvangen`
+- **WHEN** `DSOController::receiveMessage()` would have written `'status' => 'ontvangen'`
+- **THEN** the controller SHALL invoke
+  `lifecycleService->transitionTo($msg, 'ontvangen')` instead
+- **AND** the response payload SHALL still contain `"status": "ontvangen"`.
+
+#### Scenario: Event pending state via lifecycle
+
+- **GIVEN** the event schema declares lifecycle states including `pending`
+- **WHEN** `EventService` reaches a previously-inline `'status' => 'pending'` write
+- **THEN** the service SHALL invoke `lifecycleService->transitionTo($event, 'pending')`.
+
+### Requirement: Sync-contract status filter values reflect lifecycle
+
+The `'status' => 'active'|'inactive'|'error'` values exposed by
+`SynchronizationContractsController:366-368` SHALL be backed by the contract schema's
+`x-openregister-lifecycle` annotation. Filter queries SHALL read the values from the
+lifecycle's state list rather than a controller-side whitelist.
+
+#### Scenario: Active/inactive/error are lifecycle states
+
+- **GIVEN** the contract schema declares lifecycle states `active`, `inactive`, `error`
+- **WHEN** `SynchronizationContractsController` returns the filter whitelist
+- **THEN** the whitelist SHALL be derived from the schema's lifecycle states
+- **AND** no hardcoded `'active'|'inactive'|'error'` literals SHALL exist in the
+  controller.
+
+### Requirement: Sync log-level filter values are documented as filter-only
+
+The `'status' => 'success'|'warning'|'info'|'debug'` values exposed by
+`SynchronizationsController:510-514` are LOG-LEVEL filters, NOT lifecycle states. They
+SHALL remain as a filter whitelist (declared as a JSON-schema `enum` on the log schema).
+They SHALL NOT be migrated to a lifecycle annotation.
+
+#### Scenario: Log levels stay as enum, not lifecycle
+
+- **GIVEN** the log schema declares
+  `level: { enum: [success, warning, info, debug] }`
+- **WHEN** an auditor inspects the log schema
+- **THEN** there SHALL be no `x-openregister-lifecycle` annotation referencing log levels
+- **AND** the filter whitelist SHALL match the enum.
+
+### Requirement: Notification annotation backs sync alerts
+
+Synchronization-failed, contract-broken, and job-failed notifications SHALL be declared as
+`x-openregister-notifications` triggers keyed on lifecycle transitions. Direct
+`notificationManager->notify()` calls in `lib/Service/` SHALL be removed.
+
+#### Scenario: Sync failure notification is annotation-driven
+
+- **GIVEN** the synchronization schema declares
+  `x-openregister-notifications` keyed on `running → error`
+- **WHEN** `SynchronizationService` transitions a run to `error`
+- **THEN** the notification SHALL fire automatically
+- **AND** no direct `notificationManager->notify()` call SHALL exist for this event.
+
+### Requirement: Tenant-tunable values move to admin-config
+
+Hardcoded constants flagged in `.claude/audit-2026-05-03/04-hardcoded.md` SHALL move to
+admin-config. Default values SHALL preserve current behavior.
+
+#### Scenario: Endpoint cache TTL is admin-config
+
+- **GIVEN** an admin sets `openconnector.endpoint_cache.ttl_seconds = 7200`
+- **WHEN** `EndpointCacheService` reads its TTL
+- **THEN** the TTL SHALL equal 7200
+- **AND** the constant `CACHE_TTL` SHALL no longer exist in
+  `lib/Service/EndpointCacheService.php`.
+
+#### Scenario: Software-catalogue suffix is admin-config
+
+- **GIVEN** an admin sets `openconnector.software_catalogue.suffix = '-sc-test'`
+- **WHEN** `SoftwareCatalogueService` constructs an external slug
+- **THEN** the suffix SHALL be `-sc-test`
+- **AND** the constant `SUFFIX` SHALL no longer exist in
+  `lib/Service/SoftwareCatalogueService.php`.
+
+### Requirement: Domain-specific Pinia stores stay app-local
+
+The 20+ Pinia store modules in `src/store/modules/` (source, mapping, endpoint, contract,
+webhooks, rule, etc.) are intentionally domain-specific and SHALL NOT be migrated to a
+generic `createObjectStore` pattern. They SHALL consume `multi-tenancy-context` from
+nc-vue for tenant scope.
+
+#### Scenario: Stores read tenant from shared composable
+
+- **GIVEN** the nc-vue `multi-tenancy-context` composable is available
+- **WHEN** any of the 20+ openconnector stores reads tenant scope
+- **THEN** it SHALL read from `useTenantContext()` rather than computing locally.
+
+#### Scenario: Stores are not flagged as duplication in future audits
+
+- **GIVEN** this Requirement exists in the capability spec
+- **WHEN** a future OR-abstraction audit reviews openconnector
+- **THEN** the auditor SHALL cite this Requirement and SKIP a re-investigation of the
+  20+ Pinia stores as duplication.
+
+### Requirement: Mapping/rule engine stays app-local
+
+The mapping engine and rule rewrite engine in
+`lib/Service/MappingService.php` and `lib/Service/RuleService.php` are by-design
+schema-to-schema transforms specific to openconnector. They SHALL remain app-local. They
+SHALL NOT be migrated to OR.
+
+#### Scenario: Mapping engine not flagged as duplication
+
+- **GIVEN** this Requirement exists in the capability spec
+- **WHEN** a future audit reviews the mapping/rule engine
+- **THEN** the auditor SHALL cite this Requirement and SKIP a migration recommendation.
+
+### Requirement: openconnector declares its manifest
+
+openconnector SHALL ship `openspec/manifest.yaml` declaring `tier: 2`,
+`dependencies: ["openregister"]`, the consumed shared specs, and the minimum OR version.
+
+#### Scenario: Manifest declares all consumed specs
+
+- **GIVEN** `openspec/manifest.yaml` lists `consumes`
+- **WHEN** Hydra coordination loads the manifest
+- **THEN** the consumed list SHALL include `register-resolver-service`,
+  `pluggable-integration-registry`, `i18n-source-of-truth`,
+  `i18n-api-language-negotiation`, `multi-tenancy-context`.
+
+### Requirement: openconnector consumes shared multi-tenancy + i18n specs
+
+openconnector SHALL consume `multi-tenancy-context`, `i18n-source-of-truth`, and
+`i18n-api-language-negotiation`. Tenant scoping and translation infrastructure SHALL NOT
+be re-implemented.
+
+#### Scenario: API respects Accept-Language
+
+- **GIVEN** a client sends `Accept-Language: nl-NL` to openconnector
+- **WHEN** the response includes a translatable label or description
+- **THEN** the field SHALL return the Dutch translation per OR's negotiation spec.
+
+## See Also
+
+- `openspec/specs/prometheus-metrics/spec.md` — current; not rewritten by this change.
+- `openspec/changes/ibabs-notubiz-connector/` — protocol-specific integration; stays
+  app-local.
+- `openspec/changes/dso-omgevingsloket/` — protocol-specific integration; stays app-local.
+- `openspec/changes/stuf-adapter/` — protocol-specific integration; stays app-local.

--- a/openspec/changes/openconnector-adopt-or-abstractions/tasks.md
+++ b/openspec/changes/openconnector-adopt-or-abstractions/tasks.md
@@ -1,0 +1,132 @@
+# Tasks — openconnector: adopt OR abstractions
+
+Spec-only change. Code paths listed are implementation hints for the apply phase.
+
+## Phase 1 — register-resolver consumption
+
+openconnector reads register/schema config in multiple places (RuleService, source/mapping
+loaders). Route through `RegisterResolverService` once OR ships the spec.
+
+- [ ] 1.1 Inventory all `IAppConfig::getValueString(APP_ID, 'register'|'schema', '')` reads
+      and route through `RegisterResolverService`.
+- [ ] 1.2 Replace eight schema-property GUID constants in
+      `lib/Service/RuleService.php:125-131` (`PROP_*`) with slug-based lookups via
+      `RegisterResolverService::resolveProperty($schemaSlug, $propertySlug)`. Brittle GUIDs
+      removed.
+
+## Phase 2 — lifecycle annotation migration
+
+Audit flagged inline status writes in two controllers/services and a state-enum smell in
+two more controllers. Migrate per ADR-022, with a per-value review of filter-vs-state.
+
+- [ ] 2.1 `lib/Controller/DSOController.php:115` — `'status' => 'ontvangen'` migrate to
+      lifecycle transition. Define lifecycle states on the dso-message schema.
+- [ ] 2.2 `lib/Service/EventService.php:170,256` — `'status' => 'pending'` migrate to
+      lifecycle transition on the event schema.
+- [ ] 2.3 `lib/Controller/SynchronizationContractsController.php:366-368` — review
+      `'status' => 'active'|'inactive'|'error'` filter values:
+      - `active` / `inactive` are LIFECYCLE → migrate to lifecycle annotation.
+      - `error` is LIFECYCLE → already covered by lifecycle's error state.
+- [ ] 2.4 `lib/Controller/SynchronizationsController.php:510-514` — review
+      `'status' => 'success'|'warning'|'info'|'debug'` filter values:
+      - These are LOG-LEVEL filters, NOT lifecycle. Keep as filter whitelist; document why
+        in the spec's scenario list.
+
+## Phase 3 — notification annotation migration
+
+openconnector fires NC notifications on synchronization-failed, contract-broken, and
+job-failed events. Migrate to `x-openregister-notifications` per ADR-025.
+
+- [ ] 3.1 Identify all direct `notificationManager->notify()` / `setSubject()` call sites
+      in `lib/Service/`. Replace with declarative `x-openregister-notifications` triggers.
+
+## Phase 4 — archival annotation
+
+The audit's biggest archival finding: triplicated retention constants across three
+services. Migrate to `x-openregister-archival` per ADR-024.
+
+- [ ] 4.1 `lib/Service/JobService.php:60-61`,
+      `lib/Service/CallService.php:66-67`,
+      `lib/Service/SynchronizationService.php:83-84` — three identical
+      `DEFAULT_SUCCESS_LOG_RETENTION = 3600000` and
+      `DEFAULT_ERROR_LOG_RETENTION = 2592000000` constants. Declare
+      `x-openregister-archival.retention` ONCE on the relevant log schema (success
+      retention `PT1H`, error retention `P30D` — match current values). Remove all three
+      sets of source constants.
+- [ ] 4.2 Verify retention values match the legal retention table (sync error logs may need
+      longer retention for audit purposes — confirm with the DPO during apply).
+
+## Phase 5 — calculation annotation
+
+openconnector's existing `prometheus-metrics` spec already declares computed metrics. No
+new calculation annotation work required for this change.
+
+- [ ] 5.1 Cross-check `openspec/specs/prometheus-metrics/spec.md` for any inline
+      computations that should be `x-openregister-calculations` rather than ad-hoc service
+      methods. Flag for follow-up if found.
+
+## Phase 6 — spec rewrites (stream 2)
+
+The audit (stream 2) finds `prometheus-metrics/spec.md` CURRENT, and the
+`ibabs-notubiz-connector` + `stuf-adapter` change folders represent legitimate per-protocol
+integrations. NO rewrites required for this change.
+
+- [ ] 6.1 Add a `## See Also` block in this change's spec citing
+      `openspec/specs/prometheus-metrics/spec.md` (current) and the `ibabs-notubiz-connector`
+      and `stuf-adapter` change folders so downstream readers can find the integration
+      patterns.
+- [ ] 6.2 Verify `prometheus-metrics/spec.md` still reflects current code (drift check, no
+      rewrite).
+
+## Phase 7 — hardcoded magic-number cleanup + naming
+
+All paths per `.claude/audit-2026-05-03/04-hardcoded.md` plus stream 1's rename.
+
+- [ ] 7.1 Rename `lib/Service/ObjectService.php` to `lib/Service/SourceMappingService.php`.
+      Update all call sites. Add a deprecated PHP class alias `OCA\OpenConnector\Service\ObjectService`
+      that extends `SourceMappingService` for one minor version.
+- [ ] 7.2 `lib/Service/EndpointCacheService.php:41` — `CACHE_TTL = 3600` → admin-config
+      `openconnector.endpoint_cache.ttl_seconds` (default `3600`).
+- [ ] 7.3 `lib/Service/SoftwareCatalogueService.php:52` — `SUFFIX = '-sc'` → admin-config
+      `openconnector.software_catalogue.suffix` (default `-sc`).
+- [ ] 7.4 Drop eight `PROP_*` GUID constants in `lib/Service/RuleService.php:125-131`
+      (already covered functionally in 1.2; this task confirms the constants are deleted).
+- [ ] 7.5 Drop triplicated retention constants in `JobService`, `CallService`,
+      `SynchronizationService` (already covered functionally in 4.1; this task confirms
+      deletion).
+
+## Phase 8 — manifest adoption
+
+Cite `hydra/openspec/changes/adopt-app-manifest/`.
+
+- [ ] 8.1 Create `openspec/manifest.yaml` with: `tier: 2`,
+      `dependencies: ["openregister"]`,
+      `consumes: [register-resolver-service, pluggable-integration-registry,
+      i18n-source-of-truth, i18n-api-language-negotiation, multi-tenancy-context]`.
+- [ ] 8.2 Pin minimum OR version in the manifest. openconnector currently has no version
+      floor constant (unlike docudesk); this is the first time the floor is declared
+      machine-readably.
+- [ ] 8.3 Validate the manifest with the Hydra manifest schema once it ships.
+
+## Phase 9 — multi-tenancy + i18n adoption
+
+Gated on nc-vue `multi-tenancy-context` and OR `i18n-source-of-truth` /
+`i18n-api-language-negotiation` shipping.
+
+- [ ] 9.1 Adopt `multi-tenancy-context` in the openconnector frontend: read
+      `currentTenant` from the nc-vue composable in every store. The 20+ domain-specific
+      stores are KEPT but each must read tenant scope from the shared composable.
+- [ ] 9.2 Adopt `i18n-source-of-truth` for translatable fields on source, mapping, endpoint,
+      rule, contract, and webhook schemas (label, description, error message templates).
+- [ ] 9.3 Adopt `i18n-api-language-negotiation` for the openconnector API: respect the
+      `Accept-Language` header on read responses.
+- [ ] 9.4 Document in the spec's scenario list that the 20+ Pinia modules are intentionally
+      domain-specific and not subject to the `createObjectStore` exemplar pattern.
+
+## Phase 10 — spec note: domain-specific stores stay
+
+Distinct from the apply work; recorded as a Phase so it's not lost.
+
+- [ ] 10.1 Add an explicit "stores stay app-local" requirement (and its scenario) to the
+      capability spec, so future audits don't re-flag the 20+ Pinia modules as duplication.
+- [ ] 10.2 Add an explicit "mapping/rule engine stays app-local" requirement and scenario.


### PR DESCRIPTION
## Summary

Phase 3 of the OR-abstraction audit (2026-05-03). Per-app adoption openspec change for **openconnector** — spec-only, no code changes.

## Auto-merge rationale

Markdown-only PR per `feedback_pr-merge-authority.md` — admin-merged on creation.