### PR TITLE
chore(docs): @conduction/docusaurus-preset 2.6.1

### DIFF
--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openconnector-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.5.1",
+        "@conduction/docusaurus-preset": "^2.6.1",
         "@docusaurus/core": "^3.10.0",
         "@docusaurus/preset-classic": "^3.10.0",
         "@docusaurus/theme-mermaid": "^3.10.0",
@@ -2043,9 +2043,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.7.0.tgz",
-      "integrity": "sha512-JH7aXaRGZCvkHZTLTLRh3gDWhj/2zAc8S4eBGS67hCfDIwzP5SK+Uj5BidoqbSi0FEEnekEoya2AVVLXbNv/OQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.6.1.tgz",
+      "integrity": "sha512-hOkS2XAj3p1wfaZWjvIqKzwC5cbTSLUPm+DJxUp7TePbnU37kaHGegjLjfVOnQ312G8an+0M5VWIhmg/YhRVyA==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -15,7 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.5.1",
+    "@conduction/docusaurus-preset": "^2.6.1",
     "@docusaurus/core": "^3.10.0",
     "@docusaurus/preset-classic": "^3.10.0",
     "@docusaurus/theme-mermaid": "^3.10.0",


### PR DESCRIPTION
Bumps the docs preset from ^1.x to ^2.6.1 (latest published). Build verified locally; no 2.x adaptation needed.