### PR TITLE
ci(docs): deploy from documentation branch (not development)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,10 +3,10 @@ name: Documentation
 on:
   push:
     branches:
-      - development
+      - documentation
   pull_request:
     branches:
-      - development
+      - documentation
 
 jobs:
   deploy:


### PR DESCRIPTION
Reverts the earlier flip to `[development]` — docs should deploy from `documentation` so the docs site can be updated independently of the code CI/CD on `development`.