### PR TITLE
fix(ci): point Documentation workflow at docs/ not docusaurus/

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,4 +13,4 @@ jobs:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
       cname: openconnector.conduction.nl
-      source-folder: docusaurus
+      source-folder: docs


### PR DESCRIPTION
One-liner: source-folder docusaurus -> docs. The rename from PR #779 landed but the workflow file on documentation still pointed at the old path, so every deploy fails with 'cd: docusaurus: No such file or directory'.