### PR TITLE
fix(docs): descriptive homepage title (#80)

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -237,7 +237,7 @@ const WIDGETS = [
 export default function Home() {
   return (
     <Layout
-      title="OpenConnector"
+      title="OpenConnector, the integration layer for Nextcloud"
       description="The integration layer for Nextcloud. REST, SOAP, GraphQL, file drops, message queues. Pulls data into typed registers without writing glue code."
     >
       <main className="marketing-page">


### PR DESCRIPTION
Part of the SEO epic (ConductionNL/.github#75) and closes ConductionNL/.github#80.

Replaces the bare-brand Layout title with a descriptive form so SERPs surface the keyword payload before the site-title suffix Docusaurus appends. No copy or component changes beyond the title prop.