### PR TITLE
fix(docs): hand-written meta descriptions (#81)

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Get started with OpenConnector, the integration layer for Nextcloud. Connect REST, SOAP, GraphQL, files, and queues to typed OpenRegister stores.
 ---
 
 # Introduction to OpenConnector


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic and ConductionNL/.github#81.

Hand-written meta descriptions on the highest-traffic pages of this site (homepage + intro + install where applicable). 140-160 chars, keyword-loaded, no em-dashes per Conduction brand rules. Docusaurus auto-emits these as both `<meta name=description>` and `<meta property=og:description>`.