### PR TITLE
sync: development → documentation (meta descriptions #81)

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Get started with OpenConnector, the integration layer for Nextcloud. Connect REST, SOAP, GraphQL, files, and queues to typed OpenRegister stores.
 ---
 
 # Introduction to OpenConnector


### PR DESCRIPTION
Sync development → documentation so the meta-description deploy fires.