### PR TITLE
fix(backend): cross-DB SQL + dropped ObjectService::getRegisters

### DIFF
--- a/lib/Controller/MappingsController.php
+++ b/lib/Controller/MappingsController.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 use OCA\OpenConnector\Service\ObjectService;
 use OCA\OpenConnector\Service\SearchService;
 use OCA\OpenConnector\Service\MappingService;
+use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenConnector\Db\Mapping;
 use OCA\OpenConnector\Db\MappingMapper;
 use OCP\AppFramework\Controller;
@@ -367,7 +368,14 @@ class MappingsController extends Controller
         $data['openRegisters'] = false;
         if ($openRegisters !== null) {
             $data['openRegisters']      = true;
-            $data['availableRegisters'] = $openRegisters->getRegisters();
+            // OpenRegister's ObjectService no longer exposes getRegisters();
+            // fetch the register list via the mapper directly.
+            try {
+                $registerMapper = \OC::$server->get(RegisterMapper::class);
+                $data['availableRegisters'] = $registerMapper->findAll();
+            } catch (\Throwable $e) {
+                $data['availableRegisters'] = [];
+            }
         }
 
         return new JSONResponse($data);

--- a/lib/Db/CallLogMapper.php
+++ b/lib/Db/CallLogMapper.php
@@ -183,7 +183,7 @@ class CallLogMapper extends QBMapper
         $qb = $this->db->getQueryBuilder();
 
         // Select the hour part of the created timestamp and count of logs
-        $qb->select($qb->createFunction('HOUR(created) as hour'), $qb->createFunction('COUNT(*) as count'))
+        $qb->select($qb->createFunction('EXTRACT(HOUR FROM created) as hour'), $qb->createFunction('COUNT(*) as count'))
             ->from('openconnector_call_logs')
             ->groupBy('hour')
             ->orderBy('hour', 'ASC');
@@ -312,7 +312,7 @@ class CallLogMapper extends QBMapper
         $qb = $this->db->getQueryBuilder();
 
         $qb->select(
-                $qb->createFunction('HOUR(created) as hour'),
+                $qb->createFunction('EXTRACT(HOUR FROM created) as hour'),
                 $qb->createFunction('SUM(CASE WHEN status_code >= 200 AND status_code < 300 THEN 1 ELSE 0 END) as success'),
                 $qb->createFunction('SUM(CASE WHEN status_code < 200 OR status_code >= 300 THEN 1 ELSE 0 END) as error')
             )

--- a/lib/Db/JobLogMapper.php
+++ b/lib/Db/JobLogMapper.php
@@ -225,7 +225,7 @@ class JobLogMapper extends QBMapper
         $qb = $this->db->getQueryBuilder();
 
         $qb->select(
-                $qb->createFunction('HOUR(created) as hour'),
+                $qb->createFunction('EXTRACT(HOUR FROM created) as hour'),
                 $qb->createFunction('SUM(CASE WHEN level = \'INFO\' THEN 1 ELSE 0 END) as info'),
                 $qb->createFunction('SUM(CASE WHEN level = \'WARNING\' THEN 1 ELSE 0 END) as warning'),
                 $qb->createFunction('SUM(CASE WHEN level = \'ERROR\' THEN 1 ELSE 0 END) as error'),

--- a/lib/Db/SynchronizationContractLogMapper.php
+++ b/lib/Db/SynchronizationContractLogMapper.php
@@ -202,7 +202,7 @@ class SynchronizationContractLogMapper extends QBMapper
         $qb = $this->db->getQueryBuilder();
 
         $qb->select(
-                $qb->createFunction('HOUR(created) as hour'),
+                $qb->createFunction('EXTRACT(HOUR FROM created) as hour'),
                 $qb->createFunction('COUNT(*) as executions')
             )
             ->from('openconnector_synchronization_contract_logs')


### PR DESCRIPTION
Two unrelated 500s on the dashboard and mappings UI that block every non-MySQL deploy:

1. **MySQL-only HOUR() function** — `CallLogMapper`/`JobLogMapper`/`SynchronizationContractLogMapper` used `HOUR(created)`. Replaced with portable `EXTRACT(HOUR FROM created)`, which both MySQL 5.5+ and PostgreSQL support.
2. **Dropped `ObjectService::getRegisters()`** — `MappingsController::getObjects()` called `$openRegisters->getRegisters()` on OpenRegister's `ObjectService`. That method was removed in the OR refactor and now throws `Call to undefined method`. Resolve `RegisterMapper` directly from the service container and use `findAll()` so the mapping editor's object-picker keeps working.

Verified against the live dev container: `/api/dashboard/callstats`, `/api/dashboard/jobstats`, `/api/dashboard/syncstats` and `/api/mappings/objects` all return JSON instead of 500.