### PR TITLE
feat(manifest-v2): LogIndex typed-primitive wrapper for /sources/logs

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
-	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
-	"version": "1.0.0",
+	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+	"version": "2.0.0",
 	"dependencies": ["openregister"],
 	"menu": [
 		{ "id": "Dashboard",      "label": "Dashboard",      "icon": "icon-category-dashboard",  "route": "Dashboard",      "order": 10 },
@@ -49,8 +49,9 @@
 			"route": "/sources/logs",
 			"type": "custom",
 			"title": "Source logs",
-			"component": "SourceLogIndex",
-			"_note": "Filterable call-log table scoped to a source; pairs with a log-detail sidebar."
+			"component": "LogIndex",
+			"config": { "logType": "source" },
+			"_note": "Tier-4 wrapper: thin shim over CnIndexPage driven by config.logType. The bespoke SourceLogIndex view is retained in the registry until the wrapper covers the legacy log-detail sidebar interaction; falls back via npm bundle for unreferenced backup."
 		},
 		{
 			"id": "Endpoints",

--- a/src/registry.js
+++ b/src/registry.js
@@ -3,22 +3,28 @@
 //
 // Custom-component registry for openconnector's manifest-driven app shell.
 //
-// Every entry here is the "escape hatch" — pages that don't fit one of the
-// manifest's built-in types/widgets. OpenConnector's surfaces are heavily
-// interactive (connection testing, drag-and-drop mapping editors, cron
-// builders, visual rule conditions, CloudEvent subscription management)
-// which exceed what declarative index/detail manifest types can express
-// today. ALL entries below are therefore genuine exceptions rather than
-// deferred migrations.
+// Two flavors of entry live here, per Tier-4 manifest-v2 (ADR-024/036):
+//
+// 1. **Typed-primitive wrappers** (preferred) — thin shims like `LogIndex`
+//    that wrap CnIndexPage / CnDetailPage from @conduction/nextcloud-vue
+//    and drive store + column selection from `page.config`. Manifest pages
+//    still declare `type: "custom"` (the type enum doesn't yet express
+//    "custom-shim-over-primitive"), but the implementation IS the typed
+//    primitive.
+//
+// 2. **Genuine custom views** — pages whose interaction model exceeds what
+//    declarative index/detail manifest types can express today: connection
+//    testing, drag-and-drop mapping editors, cron builders, visual rule
+//    conditions, CloudEvent subscription management. These are flagged with
+//    a `_note` on the manifest entry explaining why.
 //
 // Resolution order at runtime:
 //   1. Built-in page types          (CnIndexPage, CnDetailPage, …)
 //   2. Built-in widget types        (version-info, register-mapping, …)
 //   3. customComponents (this file) ← consumer-injected components
-//
-// See:
-//   - src/manifest.json for the `_note` on each page entry explaining why
-//     custom type was chosen over a built-in type.
+
+// --- Typed-primitive wrappers (thin shims over CnIndexPage / CnDetailPage) ---
+import LogIndex from './views/wrappers/LogIndex.vue'
 
 // --- Main surfaces ---
 import DashboardView from './views/dashboard/DashboardIndex.vue'
@@ -41,6 +47,11 @@ import ImportIndex from './views/Import/ImportIndex.vue'
 import SettingsView from './views/settings/Settings.vue'
 
 export default {
+	// --- Generic typed-primitive wrappers ---
+	// Single component, runtime-discriminated by `config.logType`. Each log
+	// type added here removes one bespoke index view from the bundle.
+	LogIndex,
+
 	// --- Integration definition editors (connection testing + auth UI) ---
 	DashboardView,
 	SourcesIndex,

--- a/src/views/wrappers/LogIndex.vue
+++ b/src/views/wrappers/LogIndex.vue
@@ -1,0 +1,174 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl> -->
+
+<!--
+ Generic log-index wrapper around CnIndexPage (Tier-4 manifest-v2 pattern).
+
+ Drives runtime store + column selection from `config.logType`. Manifest
+ entries reference this wrapper via `component: "LogIndex"` and pass
+ `config: { logType: "source" | "endpoint" | "job" | "synchronization" | "event" }`.
+
+ This is the larpingapp generic-wrapper pattern (a thin shim over a typed
+ primitive). Each `logType` plugs in the matching pinia store + a manual
+ column-definition list (CnIndexPage's `columns` prop instead of schema mode,
+ because openconnector log entries are not registered as OpenRegister
+ schemas yet — they come from app-owned tables).
+
+ As of this commit only `logType: "source"` is wired up. The other four
+ log routes are tracked in issue #814 as a follow-up.
+
+ @see openspec/changes — Tier-4 manifest-v2 pattern
+ @see ConductionNL/openconnector#814 — wrapper rollout to other 4 log types
+-->
+<template>
+	<CnIndexPage
+		:title="title"
+		:description="description"
+		:columns="columns"
+		:objects="rows"
+		:loading="loading"
+		:pagination="paginationProp"
+		:selectable="true"
+		:row-key="'id'"
+		@refresh="refresh"
+		@row-click="openDetail"
+		@page-changed="onPageChanged"
+		@page-size-changed="onPageSizeChanged" />
+</template>
+
+<script>
+import { CnIndexPage } from '@conduction/nextcloud-vue'
+import { logStore, navigationStore, sourceStore } from '../../store/store.js'
+
+/**
+ * Per-logType configuration: store key, fetch action, list selector.
+ * Add new entries here as more log routes adopt the wrapper.
+ */
+const LOG_TYPE_CONFIG = {
+	source: {
+		titleKey: 'Source logs',
+		descriptionKey: 'Monitor and analyze source API call logs',
+		fetch: (filters) => sourceStore.refreshSourceLogs(filters),
+		list: () => sourceStore.sourceLogs?.results ?? [],
+		total: () => sourceStore.sourceLogs?.total ?? 0,
+		modalName: 'viewSourceLog',
+	},
+}
+
+export default {
+	name: 'LogIndex',
+	components: { CnIndexPage },
+
+	props: {
+		/**
+		 * Log type discriminator. Must match a key in LOG_TYPE_CONFIG above.
+		 * Manifest-driven: pages[].config.logType.
+		 */
+		logType: {
+			type: String,
+			required: true,
+			validator: (v) => Object.prototype.hasOwnProperty.call(LOG_TYPE_CONFIG, v),
+		},
+	},
+
+	data() {
+		return {
+			page: 1,
+			limit: 20,
+		}
+	},
+
+	computed: {
+		config() {
+			return LOG_TYPE_CONFIG[this.logType]
+		},
+		title() {
+			return t('openconnector', this.config.titleKey)
+		},
+		description() {
+			return t('openconnector', this.config.descriptionKey)
+		},
+		rows() {
+			return this.config.list()
+		},
+		total() {
+			return this.config.total()
+		},
+		loading() {
+			return logStore.loading || false
+		},
+		paginationProp() {
+			return {
+				page: this.page,
+				limit: this.limit,
+				total: this.total,
+				pages: Math.max(1, Math.ceil(this.total / this.limit)),
+			}
+		},
+		/**
+		 * Manual column definitions. CnIndexPage uses these when no `schema`
+		 * is provided (openconnector log records are not OpenRegister-backed).
+		 */
+		columns() {
+			return [
+				{
+					key: 'statusCode',
+					label: t('openconnector', 'Status'),
+					sortable: true,
+					formatter: (row) => `${row.statusCode || '-'} ${row.statusMessage || ''}`.trim(),
+				},
+				{
+					key: 'request.method',
+					label: t('openconnector', 'Method'),
+					sortable: false,
+					formatter: (row) => row.request?.method || '-',
+				},
+				{
+					key: 'request.url',
+					label: t('openconnector', 'Endpoint'),
+					sortable: false,
+					formatter: (row) => row.request?.url || '-',
+				},
+				{
+					key: 'response.responseTime',
+					label: t('openconnector', 'Response Time'),
+					sortable: true,
+					formatter: (row) => {
+						const ms = row.response?.responseTime
+						return ms ? `${(ms / 1000).toFixed(3)}s` : '-'
+					},
+				},
+				{
+					key: 'created',
+					label: t('openconnector', 'Created'),
+					sortable: true,
+					formatter: (row) => row.created ? new Date(row.created).toLocaleString() : '-',
+				},
+			]
+		},
+	},
+
+	mounted() {
+		this.refresh()
+	},
+
+	methods: {
+		refresh() {
+			return this.config.fetch(logStore.logFilters || {})
+		},
+		openDetail(row) {
+			logStore.setViewLogItem(row)
+			navigationStore.setModal(this.config.modalName)
+		},
+		onPageChanged(page) {
+			this.page = page
+			this.refresh()
+		},
+		onPageSizeChanged(limit) {
+			this.limit = limit
+			this.page = 1
+			this.refresh()
+		},
+	},
+}
+</script>


### PR DESCRIPTION
## Summary
- Introduces `src/views/wrappers/LogIndex.vue` — a thin shim over `CnIndexPage` that drives store + column selection from manifest `config.logType` (Tier-4 manifest-v2 pattern, ADR-024/036).
- Wires `/sources/logs` to LogIndex with `config: { logType: \"source\" }`; type stays `\"custom\"` until the enum grows a `\"custom-shim-over-primitive\"` value.
- Bumps manifest to v2.0.0 / `app-manifest-v2.schema.json`.
- Rewrites the `registry.js` header to document the two-flavor model: typed-primitive wrappers vs genuine bespoke views (mapping editor, cron builder, rule conditions, CloudEvent subs).

Only `logType: \"source\"` is wired up. Endpoint / Job / Synchronization / Event log routes still resolve to bespoke views — tracked as follow-ups under #814.

Refs #814

## Test plan
- [ ] Navigate to a source → Logs tab; LogIndex renders the source-log table.
- [ ] Pagination, filtering, row click work as before.
- [ ] No console errors / no regressions on Endpoint/Job/Sync/Event log routes (still bespoke).