### PR TITLE
chore(manifest): polish menu icons + enable index sidebar + docs link

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,7 @@
     {
       "id": "Sources",
       "label": "Sources",
-      "icon": "icon-server",
+      "icon": "icon-link",
       "route": "Sources",
       "order": 20
     },
@@ -50,7 +50,7 @@
     {
       "id": "Webhooks",
       "label": "Webhooks",
-      "icon": "icon-category-social",
+      "icon": "icon-mail",
       "route": "Webhooks",
       "order": 50
     },
@@ -85,7 +85,7 @@
     {
       "id": "Synchronizations",
       "label": "Synchronizations",
-      "icon": "icon-shared",
+      "icon": "icon-history",
       "route": "Synchronizations",
       "order": 90
     },
@@ -103,6 +103,14 @@
       "route": "Import",
       "section": "settings",
       "order": 10
+    },
+    {
+      "id": "Documentation",
+      "label": "Documentation",
+      "icon": "icon-info",
+      "href": "https://openconnector.conduction.nl",
+      "section": "settings",
+      "order": 15
     },
     {
       "id": "Settings",
@@ -127,7 +135,8 @@
       "title": "Sources",
       "config": {
         "register": "openconnector",
-        "schema": "source"
+        "schema": "source",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {
@@ -157,7 +166,8 @@
       "title": "Endpoints",
       "config": {
         "register": "openconnector",
-        "schema": "endpoint"
+        "schema": "endpoint",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {
@@ -187,7 +197,8 @@
       "title": "Consumers",
       "config": {
         "register": "openconnector",
-        "schema": "consumer"
+        "schema": "consumer",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {
@@ -207,7 +218,8 @@
       "title": "Webhooks",
       "config": {
         "register": "openconnector",
-        "schema": "consumer"
+        "schema": "consumer",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {
@@ -217,7 +229,8 @@
       "title": "Jobs",
       "config": {
         "register": "openconnector",
-        "schema": "job"
+        "schema": "job",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {
@@ -237,7 +250,8 @@
       "title": "Mappings",
       "config": {
         "register": "openconnector",
-        "schema": "mapping"
+        "schema": "mapping",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {
@@ -257,7 +271,8 @@
       "title": "Rules",
       "config": {
         "register": "openconnector",
-        "schema": "rule"
+        "schema": "rule",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {
@@ -277,7 +292,8 @@
       "title": "Synchronizations",
       "config": {
         "register": "openconnector",
-        "schema": "synchronization"
+        "schema": "synchronization",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {
@@ -287,7 +303,8 @@
       "title": "Contracts",
       "config": {
         "register": "openconnector",
-        "schema": "synchronization_contract"
+        "schema": "synchronization_contract",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {
@@ -307,7 +324,8 @@
       "title": "Cloud events",
       "config": {
         "register": "openconnector",
-        "schema": "event"
+        "schema": "event",
+        "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
     {


### PR DESCRIPTION
## Summary

Stacked on top of #717 (chain-E manifest-v2). Three small manifest-only polish changes.

### 1. Fix 3 broken / misleading menu icons

| Menu | Was | Now | Why |
|---|---|---|---|
| Sources | `icon-server` | `icon-link` | `icon-server` is not in NC core CSS — entry rendered with no icon |
| Webhooks | `icon-category-social` | `icon-mail` | Social rendered as 3 people; mail communicates outbound notification |
| Synchronizations | `icon-shared` | `icon-history` | Shared rendered as account-plus; history is the rotate/sync arrows glyph |

Rules keeps `icon-toggle` — renders fine.

### 2. Documentation footer link

Adds a `Documentation` entry in the `settings` section pointing at https://openconnector.conduction.nl — same pattern decidesk uses.

### 3. Default search/filter sidebar on every index page

All 10 index pages (Sources, Endpoints, Consumers, Webhooks, Jobs, Mappings, Rules, Synchronizations, SynchronizationContracts, CloudEvents) declare `"sidebar": { "enabled": true, "showMetadata": true }` — same shape decidesk uses. CnLogsPage owns its own filter UI, so log pages are untouched.

## Out of scope (separate follow-ups)

- Menu-item trim (Source/Endpoint/Job logs → Actions-menu entry on parent index)
- Curated column set per index
- Reintroducing bespoke Mapping / Synchronisation / Rule modals
- Dashboard time-series widgets (waiting on OR GraphQL + REST groupBy primitive — opsx in flight)

## Test plan

- [ ] After #717 merges, this PR auto-retargets to `development`
- [ ] Confirm Sources / Webhooks / Synchronizations icons render
- [ ] Confirm filter sidebar visible by default on every index page
- [ ] Confirm Documentation link in settings section opens the docs site
