### PR TITLE
chore(manifest): trim log menu + curate row actions + columns + form fields

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
-  "version": "1.0.0",
+  "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+  "version": "2.0.0",
   "dependencies": [
     "openregister"
   ],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -115,6 +115,7 @@
       "config": {
         "register": "openconnector",
         "schema": "source",
+        "columns": ["name", "type", "status", "isEnabled", "lastSync", "dateModified"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SourceLogs" }
@@ -149,6 +150,7 @@
       "config": {
         "register": "openconnector",
         "schema": "endpoint",
+        "columns": ["name", "method", "endpoint", "targetType", "updated"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "EndpointLogs" }
@@ -183,6 +185,7 @@
       "config": {
         "register": "openconnector",
         "schema": "consumer",
+        "columns": ["name", "authorizationType", "domains", "updated"],
         "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
@@ -204,6 +207,7 @@
       "config": {
         "register": "openconnector",
         "schema": "consumer",
+        "columns": ["name", "authorizationType", "domains", "updated"],
         "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
@@ -215,6 +219,7 @@
       "config": {
         "register": "openconnector",
         "schema": "job",
+        "columns": ["name", "jobClass", "interval", "isEnabled", "lastRun", "status"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "JobLogs" }
@@ -239,6 +244,7 @@
       "config": {
         "register": "openconnector",
         "schema": "mapping",
+        "columns": ["name", "description", "passThrough", "dateModified"],
         "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
@@ -260,6 +266,7 @@
       "config": {
         "register": "openconnector",
         "schema": "rule",
+        "columns": ["name", "action", "timing", "type", "order"],
         "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
@@ -281,6 +288,7 @@
       "config": {
         "register": "openconnector",
         "schema": "synchronization",
+        "columns": ["name", "sourceType", "targetType", "status", "sourceLastSynced"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SynchronizationLogs" },
@@ -296,6 +304,7 @@
       "config": {
         "register": "openconnector",
         "schema": "synchronization_contract",
+        "columns": ["synchronization", "originId", "targetId", "sourceLastSynced", "updated"],
         "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
@@ -317,6 +326,7 @@
       "config": {
         "register": "openconnector",
         "schema": "event",
+        "columns": ["source", "type", "subject", "status", "time"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "CloudEventLogs" }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -116,6 +116,7 @@
         "register": "openconnector",
         "schema": "source",
         "columns": ["name", "type", "status", "isEnabled", "lastSync", "dateModified"],
+        "includeFields": ["name", "description", "type", "isEnabled"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SourceLogs" }
@@ -151,6 +152,7 @@
         "register": "openconnector",
         "schema": "endpoint",
         "columns": ["name", "method", "endpoint", "targetType", "updated"],
+        "includeFields": ["name", "description", "endpoint", "method", "targetType"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "EndpointLogs" }
@@ -186,6 +188,7 @@
         "register": "openconnector",
         "schema": "consumer",
         "columns": ["name", "authorizationType", "domains", "updated"],
+        "includeFields": ["name", "description", "authorizationType"],
         "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
@@ -208,6 +211,7 @@
         "register": "openconnector",
         "schema": "consumer",
         "columns": ["name", "authorizationType", "domains", "updated"],
+        "includeFields": ["name", "description", "authorizationType"],
         "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
@@ -220,6 +224,7 @@
         "register": "openconnector",
         "schema": "job",
         "columns": ["name", "jobClass", "interval", "isEnabled", "lastRun", "status"],
+        "includeFields": ["name", "description", "jobClass", "interval", "isEnabled"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "JobLogs" }
@@ -245,6 +250,7 @@
         "register": "openconnector",
         "schema": "mapping",
         "columns": ["name", "description", "passThrough", "dateModified"],
+        "includeFields": ["name", "description"],
         "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
@@ -267,6 +273,7 @@
         "register": "openconnector",
         "schema": "rule",
         "columns": ["name", "action", "timing", "type", "order"],
+        "includeFields": ["name", "description", "action", "timing", "type"],
         "sidebar": { "enabled": true, "showMetadata": true }
       }
     },
@@ -289,6 +296,7 @@
         "register": "openconnector",
         "schema": "synchronization",
         "columns": ["name", "sourceType", "targetType", "status", "sourceLastSynced"],
+        "includeFields": ["name", "description", "sourceType", "targetType"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SynchronizationLogs" },
@@ -327,6 +335,7 @@
         "register": "openconnector",
         "schema": "event",
         "columns": ["source", "type", "subject", "status", "time"],
+        "includeFields": ["source", "type", "subject", "data"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "CloudEventLogs" }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,25 +20,11 @@
       "order": 20
     },
     {
-      "id": "SourceLogs",
-      "label": "Source logs",
-      "icon": "icon-history",
-      "route": "SourceLogs",
-      "order": 25
-    },
-    {
       "id": "Endpoints",
       "label": "Endpoints",
       "icon": "icon-category-integration",
       "route": "Endpoints",
       "order": 30
-    },
-    {
-      "id": "EndpointLogs",
-      "label": "Endpoint logs",
-      "icon": "icon-history",
-      "route": "EndpointLogs",
-      "order": 35
     },
     {
       "id": "Consumers",
@@ -60,13 +46,6 @@
       "icon": "icon-category-workflow",
       "route": "Jobs",
       "order": 60
-    },
-    {
-      "id": "JobLogs",
-      "label": "Job logs",
-      "icon": "icon-history",
-      "route": "JobLogs",
-      "order": 65
     },
     {
       "id": "Mappings",
@@ -136,7 +115,10 @@
       "config": {
         "register": "openconnector",
         "schema": "source",
-        "sidebar": { "enabled": true, "showMetadata": true }
+        "sidebar": { "enabled": true, "showMetadata": true },
+        "actions": [
+          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SourceLogs" }
+        ]
       }
     },
     {
@@ -167,7 +149,10 @@
       "config": {
         "register": "openconnector",
         "schema": "endpoint",
-        "sidebar": { "enabled": true, "showMetadata": true }
+        "sidebar": { "enabled": true, "showMetadata": true },
+        "actions": [
+          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "EndpointLogs" }
+        ]
       }
     },
     {
@@ -230,7 +215,10 @@
       "config": {
         "register": "openconnector",
         "schema": "job",
-        "sidebar": { "enabled": true, "showMetadata": true }
+        "sidebar": { "enabled": true, "showMetadata": true },
+        "actions": [
+          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "JobLogs" }
+        ]
       }
     },
     {
@@ -293,7 +281,11 @@
       "config": {
         "register": "openconnector",
         "schema": "synchronization",
-        "sidebar": { "enabled": true, "showMetadata": true }
+        "sidebar": { "enabled": true, "showMetadata": true },
+        "actions": [
+          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SynchronizationLogs" },
+          { "id": "view-contracts", "label": "View contracts", "icon": "icon-file", "handler": "navigate", "route": "SynchronizationContracts" }
+        ]
       }
     },
     {
@@ -325,7 +317,10 @@
       "config": {
         "register": "openconnector",
         "schema": "event",
-        "sidebar": { "enabled": true, "showMetadata": true }
+        "sidebar": { "enabled": true, "showMetadata": true },
+        "actions": [
+          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "CloudEventLogs" }
+        ]
       }
     },
     {


### PR DESCRIPTION
## Summary

Stacked on #826. Four manifest-only commits that polish per-index UX.

### Commit 1 — Trim log items from menu + add View-logs row action

Removes the 3 `*Logs` menu entries (Source / Endpoint / Job). Access lives on parent index pages' row actions:

| Index page | Row action `View logs` → |
|---|---|
| Sources | `SourceLogs` |
| Endpoints | `EndpointLogs` |
| Jobs | `JobLogs` |
| Synchronizations | `SynchronizationLogs` |
| CloudEvents | `CloudEventLogs` |

Synchronizations also gains a `View contracts` row action.

### Commit 2 — Curate column set per index

Hand-picked columns per index so the table doesn't surface every schema property (`accept`, `apikey`, `authorizationHeader`, ...). Users can still toggle other columns via the sidebar.

### Commit 3 — (merge from chain-E route fix)

Pulls 2b044f9f (SPA catch-all regex `.+` → `.*` so `/apps/openconnector/` resolves) into this branch so CI runs against the latest base.

### Commit 4 — Curate create/edit form fields per index

The user-reported bug: the auto-generated Create Mapping modal exposed every schema property — `configurations`, `dateCreated`, `dateModified`, `passThrough`, `slug`, `reference`, `unset`. Pin per-index `includeFields[]` whitelists to keep create/edit forms minimal:

| Index | Fields exposed in Create/Edit |
|---|---|
| Sources | name, description, type, isEnabled |
| Endpoints | name, description, endpoint, method, targetType |
| Consumers | name, description, authorizationType |
| Webhooks | name, description, authorizationType |
| Jobs | name, description, jobClass, interval, isEnabled |
| Mappings | name, description |
| Rules | name, description, action, timing, type |
| Synchronizations | name, description, sourceType, targetType |
| CloudEvents | source, type, subject, data |

This addresses the user's screenshot of the broken Create Mapping modal **without the originally-scoped bespoke-modal rewrite work** (which would have meant rewriting 1537-LoC `EditMapping.vue` + 1076-LoC `EditSynchronization.vue` + 1888-LoC `EditRule.vue`).

The larger bespoke-modal effort can land later as separate per-schema PRs **only if the curated form turns out to be insufficient** for the advanced editing use cases (Mapping rules / cast / unset editor, Sync source/target config editor, Rule condition builder).

## Test plan

- [ ] Main menu no longer shows Source/Endpoint/Job logs
- [ ] Each parent index page row Actions menu shows `View logs`
- [ ] Index pages show curated columns by default
- [ ] Create dialog on each index shows only the curated `includeFields` (verify against screenshot ref: Mapping should now show just name + description, not the legacy 8-field auto form)
