### PR TITLE
feat(actions): row-level Run/Test handlers for Sources/Jobs/Synchronizations

### DIFF
--- a/src/handlers/actionHandlers.js
+++ b/src/handlers/actionHandlers.js
@@ -29,52 +29,100 @@ import { showSuccess, showError } from '@nextcloud/dialogs'
 import { translate as t } from '@nextcloud/l10n'
 
 /**
- * Build a handler that POSTs to `url` and shows a toast on success/error.
+ * Extract a stable id from a row. OR returns rows with `id` set; legacy
+ * call-sites sometimes only carry `uuid`. Prefer `id`, fall back to `uuid`.
  *
- * @param {(item: object) => string} buildUrl Resolves the target URL from the row.
- * @param {string} successMessage              i18n key (in the openconnector domain).
- * @param {string} errorMessage                i18n key (in the openconnector domain).
- * @return {(ctx: {actionId: string, item: object}) => Promise<void>}
+ * @param {object} item Row payload from the index page.
+ * @return {string|number}
  */
-function makePostHandler(buildUrl, successMessage, errorMessage) {
-	return async ({ item }) => {
-		const url = generateUrl(buildUrl(item))
-		try {
-			await axios.post(url)
-			showSuccess(t('openconnector', successMessage))
-		} catch (err) {
-			const detail = err?.response?.data?.message || err?.message || ''
-			showError(t('openconnector', errorMessage) + (detail ? `: ${detail}` : ''))
-		}
+function rowId(item) {
+	return item.id || item.uuid
+}
+
+/**
+ * Build the toast detail suffix from an axios error. Surfaces the server's
+ * `message` when available so the user gets actionable feedback rather than
+ * a bare "request failed".
+ *
+ * @param {unknown} err Axios error or anything throwable.
+ * @return {string} Empty when nothing useful to show.
+ */
+function errorDetail(err) {
+	const detail = err?.response?.data?.message || err?.message || ''
+	return detail ? `: ${detail}` : ''
+}
+
+// Each handler keeps the t() argument a literal string so the
+// translation extractor picks it up. A `makePostHandler` factory
+// would lose that — at the cost of ~5 lines per handler, this stays
+// extractable.
+
+/**
+ * Test a source's connection by POSTing to /api/sources/test/{id}.
+ *
+ * @param {{ actionId: string, item: object }} ctx Row-action context from CnIndexPage.
+ */
+export async function testSourceHandler({ item }) {
+	try {
+		await axios.post(generateUrl(`/apps/openconnector/api/sources/test/${rowId(item)}`))
+		showSuccess(t('openconnector', 'Source connection test triggered'))
+	} catch (err) {
+		showError(t('openconnector', 'Source connection test failed') + errorDetail(err))
 	}
 }
 
-export const testSourceHandler = makePostHandler(
-	(item) => `/apps/openconnector/api/sources/test/${item.id || item.uuid}`,
-	'Source connection test triggered',
-	'Source connection test failed',
-)
+/**
+ * Trigger a job to run now via POST /api/jobs/run/{id}.
+ *
+ * @param {{ actionId: string, item: object }} ctx Row-action context from CnIndexPage.
+ */
+export async function runJobHandler({ item }) {
+	try {
+		await axios.post(generateUrl(`/apps/openconnector/api/jobs/run/${rowId(item)}`))
+		showSuccess(t('openconnector', 'Job run triggered'))
+	} catch (err) {
+		showError(t('openconnector', 'Job run failed') + errorDetail(err))
+	}
+}
 
-export const runJobHandler = makePostHandler(
-	(item) => `/apps/openconnector/api/jobs/run/${item.id || item.uuid}`,
-	'Job run triggered',
-	'Job run failed',
-)
+/**
+ * Test a job (dry run) via POST /api/jobs/test/{id}.
+ *
+ * @param {{ actionId: string, item: object }} ctx Row-action context from CnIndexPage.
+ */
+export async function testJobHandler({ item }) {
+	try {
+		await axios.post(generateUrl(`/apps/openconnector/api/jobs/test/${rowId(item)}`))
+		showSuccess(t('openconnector', 'Job test (dry run) triggered'))
+	} catch (err) {
+		showError(t('openconnector', 'Job test failed') + errorDetail(err))
+	}
+}
 
-export const testJobHandler = makePostHandler(
-	(item) => `/apps/openconnector/api/jobs/test/${item.id || item.uuid}`,
-	'Job test (dry run) triggered',
-	'Job test failed',
-)
+/**
+ * Trigger a synchronization run via POST /api/synchronizations/{id}/run.
+ *
+ * @param {{ actionId: string, item: object }} ctx Row-action context from CnIndexPage.
+ */
+export async function runSynchronizationHandler({ item }) {
+	try {
+		await axios.post(generateUrl(`/apps/openconnector/api/synchronizations/${rowId(item)}/run`))
+		showSuccess(t('openconnector', 'Synchronization run triggered'))
+	} catch (err) {
+		showError(t('openconnector', 'Synchronization run failed') + errorDetail(err))
+	}
+}
 
-export const runSynchronizationHandler = makePostHandler(
-	(item) => `/apps/openconnector/api/synchronizations/${item.id || item.uuid}/run`,
-	'Synchronization run triggered',
-	'Synchronization run failed',
-)
-
-export const testSynchronizationHandler = makePostHandler(
-	(item) => `/apps/openconnector/api/synchronizations/${item.id || item.uuid}/test`,
-	'Synchronization test (dry run) triggered',
-	'Synchronization test failed',
-)
+/**
+ * Test a synchronization (dry run) via POST /api/synchronizations/{id}/test.
+ *
+ * @param {{ actionId: string, item: object }} ctx Row-action context from CnIndexPage.
+ */
+export async function testSynchronizationHandler({ item }) {
+	try {
+		await axios.post(generateUrl(`/apps/openconnector/api/synchronizations/${rowId(item)}/test`))
+		showSuccess(t('openconnector', 'Synchronization test (dry run) triggered'))
+	} catch (err) {
+		showError(t('openconnector', 'Synchronization test failed') + errorDetail(err))
+	}
+}

--- a/src/handlers/actionHandlers.js
+++ b/src/handlers/actionHandlers.js
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Row-action handlers — wired to manifest `config.actions[].handler` names.
+//
+// Each handler is a plain function `({ actionId, item }) => Promise<void>` that
+// CnIndexPage's `resolveHandler` calls when the user clicks the matching row
+// action. Behaviour is kept lean: hit the backend endpoint, show a toast on
+// success/error, let the user check the corresponding *Logs page for details.
+//
+// The legacy chain-A pre-refactor modals (RunJob.vue, TestJob.vue,
+// RunSynchronization.vue, TestSynchronization.vue, TestMapping.vue,
+// TestSource.vue) showed a richer in-modal run/result panel. That UX is
+// preserved in git history under src/modals/ for the future bespoke
+// extraction PR series (see src/modals/README.md); this thin handler set
+// restores the basic ability to trigger those backend actions from the UI
+// while the richer modals are reborn.
+//
+// All endpoints are stable post chain-C and declared in appinfo/routes.php:
+//   POST /api/sources/test/{id}             — sources#test
+//   POST /api/jobs/run/{id}                 — jobs#run
+//   POST /api/jobs/test/{id}                — jobs#test
+//   POST /api/synchronizations/{id}/run     — synchronizations#run
+//   POST /api/synchronizations/{id}/test    — synchronizations#test
+
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { showSuccess, showError } from '@nextcloud/dialogs'
+import { translate as t } from '@nextcloud/l10n'
+
+/**
+ * Build a handler that POSTs to `url` and shows a toast on success/error.
+ *
+ * @param {(item: object) => string} buildUrl Resolves the target URL from the row.
+ * @param {string} successMessage              i18n key (in the openconnector domain).
+ * @param {string} errorMessage                i18n key (in the openconnector domain).
+ * @return {(ctx: {actionId: string, item: object}) => Promise<void>}
+ */
+function makePostHandler(buildUrl, successMessage, errorMessage) {
+	return async ({ item }) => {
+		const url = generateUrl(buildUrl(item))
+		try {
+			await axios.post(url)
+			showSuccess(t('openconnector', successMessage))
+		} catch (err) {
+			const detail = err?.response?.data?.message || err?.message || ''
+			showError(t('openconnector', errorMessage) + (detail ? `: ${detail}` : ''))
+		}
+	}
+}
+
+export const testSourceHandler = makePostHandler(
+	(item) => `/apps/openconnector/api/sources/test/${item.id || item.uuid}`,
+	'Source connection test triggered',
+	'Source connection test failed',
+)
+
+export const runJobHandler = makePostHandler(
+	(item) => `/apps/openconnector/api/jobs/run/${item.id || item.uuid}`,
+	'Job run triggered',
+	'Job run failed',
+)
+
+export const testJobHandler = makePostHandler(
+	(item) => `/apps/openconnector/api/jobs/test/${item.id || item.uuid}`,
+	'Job test (dry run) triggered',
+	'Job test failed',
+)
+
+export const runSynchronizationHandler = makePostHandler(
+	(item) => `/apps/openconnector/api/synchronizations/${item.id || item.uuid}/run`,
+	'Synchronization run triggered',
+	'Synchronization run failed',
+)
+
+export const testSynchronizationHandler = makePostHandler(
+	(item) => `/apps/openconnector/api/synchronizations/${item.id || item.uuid}/test`,
+	'Synchronization test (dry run) triggered',
+	'Synchronization test failed',
+)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
-  "version": "1.0.0",
+  "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+  "version": "2.0.0",
   "dependencies": [
     "openregister"
   ],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -119,6 +119,7 @@
         "includeFields": ["name", "description", "type", "isEnabled"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
+          { "id": "test", "label": "Test connection", "icon": "icon-checkmark", "handler": "testSourceHandler" },
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SourceLogs" }
         ]
       }
@@ -227,6 +228,8 @@
         "includeFields": ["name", "description", "jobClass", "interval", "isEnabled"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
+          { "id": "run", "label": "Run now", "icon": "icon-play", "handler": "runJobHandler" },
+          { "id": "test", "label": "Test (dry run)", "icon": "icon-checkmark", "handler": "testJobHandler" },
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "JobLogs" }
         ]
       }
@@ -299,6 +302,8 @@
         "includeFields": ["name", "description", "sourceType", "targetType"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
+          { "id": "run", "label": "Run now", "icon": "icon-play", "handler": "runSynchronizationHandler" },
+          { "id": "test", "label": "Test (dry run)", "icon": "icon-checkmark", "handler": "testSynchronizationHandler" },
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SynchronizationLogs" },
           { "id": "view-contracts", "label": "View contracts", "icon": "icon-file", "handler": "navigate", "route": "SynchronizationContracts" }
         ]

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
 //
-// Custom-component registry for openconnector's manifest-driven app shell.
+// Custom-component + custom-handler registry for openconnector's
+// manifest-driven app shell.
 //
 // Post chain-C cutover: the 16 per-schema index/detail/log views previously
 // registered here have been deleted in favour of nc-vue's built-in
@@ -15,7 +16,13 @@
 //      exceeds nc-vue v2 form/wizard capability; revisit when CnWizardPage
 //      ships. The Import manifest page carries `type: "custom"` + `_note`
 //      documenting this gap.
-//   2. (future) Custom **widgets** for the genuinely-custom interactive
+//      (To be removed once #829 lands; the chain-C `POST /api/import`
+//      backend endpoint was already deleted, so the page is broken anyway.)
+//   2. Row-action handlers — small function entries called by
+//      CnIndexPage when the user clicks a row Actions item whose
+//      manifest `handler:` field matches one of the names below.
+//      See src/handlers/actionHandlers.js for the implementations.
+//   3. (future) Custom **widgets** for the genuinely-custom interactive
 //      surfaces: MappingEditorWidget (drag-drop transformation),
 //      RuleConditionsWidget (visual condition builder), CronBuilderWidget
 //      (job-interval editor), EventSubscriptionsManagerWidget,
@@ -26,11 +33,24 @@
 // Resolution order at runtime:
 //   1. Built-in page types          (CnIndexPage, CnDetailPage, …) — WIN for 23 pages
 //   2. Built-in widget types        (version-info, register-mapping, …)
-//   3. customComponents (this file) — escape hatch for Import + future widgets
+//   3. customComponents (this file) — escape hatch for Import + handlers + future widgets
 
 import ImportIndex from './views/Import/ImportIndex.vue'
+import {
+	testSourceHandler,
+	runJobHandler,
+	testJobHandler,
+	runSynchronizationHandler,
+	testSynchronizationHandler,
+} from './handlers/actionHandlers.js'
 
 export default {
 	// Multi-step file-upload + dry-run preview UX (manifest page id: "Import"; type: "custom").
 	ImportIndex,
+	// Row-action handlers — referenced by manifest `config.actions[].handler` strings.
+	testSourceHandler,
+	runJobHandler,
+	testJobHandler,
+	runSynchronizationHandler,
+	testSynchronizationHandler,
 }


### PR DESCRIPTION
## Summary

Stacked on #828. Restores the ability to **trigger backend Run/Test actions from the UI** — post chain-C the per-schema action modals were orphaned and unreachable, leaving no way to run a job or test a source from the index pages.

The legacy modals (RunJob 175 LoC, TestJob 176 LoC, TestSource 193 LoC, RunSynchronization 345 LoC, TestSynchronization 222 LoC) had rich in-modal progress/result panels. Re-creating those bespoke modals stays scoped as a future follow-up (see [src/modals/README.md](src/modals/README.md)).

This PR ships the **lean version**: manifest-declared row actions that resolve to small POST handlers showing a success/error toast. Users check the corresponding `*Logs` page (one Actions-menu click away after #828) for run details.

## Wiring

- New `src/handlers/actionHandlers.js` — 5 handler functions, ~10 LoC each, built via a shared `makePostHandler` factory:
  - `testSourceHandler` → `POST /api/sources/test/{id}`
  - `runJobHandler` → `POST /api/jobs/run/{id}`
  - `testJobHandler` → `POST /api/jobs/test/{id}`
  - `runSynchronizationHandler` → `POST /api/synchronizations/{id}/run`
  - `testSynchronizationHandler` → `POST /api/synchronizations/{id}/test`
- `src/registry.js` — exports the handlers alongside the existing `ImportIndex`. `CnIndexPage`'s `resolveHandler` looks up function entries in this registry by name.
- `src/manifest.json` — three index pages gain new row actions before their existing `View logs` entry:
  - **Sources**: + `Test connection`
  - **Jobs**: + `Run now`, + `Test (dry run)`
  - **Synchronizations**: + `Run now`, + `Test (dry run)`

Backend endpoints are all post-chain-C live entries from `appinfo/routes.php`, untouched.

## Out of scope

- `Test mapping` row action — needs an in-dialog input picker (legacy `TestMapping.vue` was 142 LoC + 3 sub-components). Bespoke modal follow-up.
- `Add rule` to endpoint row action — needs a rule selector dialog (legacy `AddEndpointRule.vue` was 172 LoC). Bespoke modal follow-up.
- Rich in-modal result panel — would re-introduce the chain-A modal pattern. Toast + log-page navigation is the leaner replacement.

## Test plan

- [ ] After #828 + chain-E merge, this PR auto-retargets to `development`
- [ ] On Sources index, click row Actions → `Test connection` → toast appears, source log gains a new entry
- [ ] On Jobs index, click row Actions → `Run now` → toast appears, job log gains a new entry
- [ ] On Synchronizations index, click row Actions → `Test (dry run)` → toast appears
- [ ] CI: build, lint, phpcs/phpmd/psalm/phpstan
