### PR TITLE
fix(sync): cleanup loop scope-checks via ObjectService::find instead of broken openregister_objects JOIN

### DIFF
--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -27,6 +27,7 @@ use Psr\Log\LoggerInterface;
 use React\Promise\Timer;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\Uid\Uuid;
+use Throwable;
 use Twig\Error\LoaderError;
 use Twig\Error\SyntaxError;
 
@@ -1119,8 +1120,20 @@ class SynchronizationService
         switch ($type) {
             case 'register/schema':
 
-                $targetIdsToDelete       = [];
-                [$registerId, $schemaId] = explode(separator: '/', string: ($syncData['targetId'] ?? '/'));
+                $targetIdsToDelete = [];
+                $rawTargetId       = $syncData['targetId'] ?? null;
+                if (is_string($rawTargetId) === false || str_contains($rawTargetId, '/') === false) {
+                    $this->logger->warning(
+                        'deleteInvalidObjects: targetId not in register/schema format; skipping cleanup',
+                        [
+                            'synchronizationId' => $synchronization->getUuid(),
+                            'targetId'          => $rawTargetId,
+                        ]
+                    );
+                    break;
+                }
+
+                [$registerId, $schemaId] = explode(separator: '/', string: $rawTargetId, limit: 2);
                 $contractMatches         = $this->orObjectService->findAll(config: ['filters' => ['register' => 'openconnector', 'schema' => 'synchronization_contract', 'synchronizationId' => $synchronization->getUuid()]]);
                 $allContracts            = $contractMatches['results'] ?? $contractMatches;
                 $allContractTargetIds    = [];
@@ -1152,18 +1165,76 @@ class SynchronizationService
                 }
 
                 foreach ($targetIdsToDelete as $targetIdToDelete) {
-                    $contractSearch = $this->orObjectService->findAll(config: ['filters' => ['register' => 'openconnector', 'schema' => 'synchronization_contract', 'synchronizationId' => $synchronization->getUuid(), 'targetId' => $targetIdToDelete]]);
-                    $contractList   = $contractSearch['results'] ?? $contractSearch;
-                    if (empty($contractList) === true) {
+                    // Scope-check the cleanup candidate before deleting it. `updateTargetOpenRegister`'s
+                    // `delete` branch calls `$objectService->delete(['id' => $uuid])` with no
+                    // register/schema scope, so a contract whose `targetId` UUID accidentally
+                    // collides with an object living in a foreign register/schema would otherwise
+                    // delete that foreign object. We verify here that the object actually lives in
+                    // this sync's register/schema before invoking the unscoped delete path.
+                    //
+                    // _rbac / _multitenancy are off because the previous SQL-level guard this
+                    // replaces (the JOIN against `openregister_objects` in the pre-cutover code)
+                    // did not apply RBAC either — the safety property being restored is scope, not
+                    // permission. Ported from #733 (author @rjzondervan).
+                    try {
+                        $existingObject = $this->orObjectService->find(
+                            id: $targetIdToDelete,
+                            register: $registerId,
+                            schema: $schemaId,
+                            _rbac: false,
+                            _multitenancy: false
+                        );
+                    } catch (DoesNotExistException $e) {
+                        // Expected scope-miss: target lives outside this register/schema or is gone.
+                        continue;
+                    } catch (Throwable $e) {
+                        $this->logger->warning(
+                            'Scope check failed for sync cleanup candidate; skipping',
+                            [
+                                'synchronizationId' => $synchronization->getUuid(),
+                                'targetId'          => $targetIdToDelete,
+                                'class'             => get_class($e),
+                                'error'             => $e->getMessage(),
+                            ]
+                        );
+                        continue;
+                    }//end try
+
+                    if ($existingObject === null) {
                         continue;
                     }
 
-                    $synchronizationContract = $contractList[0];
-                    $synchronizationContract = $this->updateTarget(synchronizationContract: $synchronizationContract, action: 'delete');
-                    $contractData            = $synchronizationContract->getObject();
-                    $this->orObjectService->saveObject(object: $contractData, register: 'openconnector', schema: 'synchronization_contract', uuid: $synchronizationContract->getUuid());
-                    $deletedObjectsCount++;
-                }
+                    try {
+                        $contractSearch = $this->orObjectService->findAll(config: ['filters' => ['register' => 'openconnector', 'schema' => 'synchronization_contract', 'synchronizationId' => $synchronization->getUuid(), 'targetId' => $targetIdToDelete]]);
+                        $contractList   = $contractSearch['results'] ?? $contractSearch;
+                        if (empty($contractList) === true) {
+                            $this->logger->warning(
+                                'Contract not found on second lookup during sync cleanup; continuing',
+                                [
+                                    'synchronizationId' => $synchronization->getUuid(),
+                                    'targetId'          => $targetIdToDelete,
+                                ]
+                            );
+                            continue;
+                        }
+
+                        $synchronizationContract = $contractList[0];
+                        $synchronizationContract = $this->updateTarget(synchronizationContract: $synchronizationContract, action: 'delete');
+                        $contractData            = $synchronizationContract->getObject();
+                        $this->orObjectService->saveObject(object: $contractData, register: 'openconnector', schema: 'synchronization_contract', uuid: $synchronizationContract->getUuid());
+                        $deletedObjectsCount++;
+                    } catch (Throwable $e) {
+                        $this->logger->warning(
+                            'Sync cleanup failed for candidate; continuing',
+                            [
+                                'synchronizationId' => $synchronization->getUuid(),
+                                'targetId'          => $targetIdToDelete,
+                                'class'             => get_class($e),
+                                'error'             => $e->getMessage(),
+                            ]
+                        );
+                    }//end try
+                }//end foreach
                 break;
         }//end switch
 

--- a/tests/Unit/Service/SynchronizationServiceCleanupTest.php
+++ b/tests/Unit/Service/SynchronizationServiceCleanupTest.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ * Unit tests for SynchronizationService::deleteInvalidObjects scope-check guard.
+ *
+ * Ported from openconnector PR #733 (author @rjzondervan), adapted to the
+ * post-cutover OR-object-based contract layer. The original test mocked the
+ * deleted SynchronizationContractMapper; here we mock the OR ObjectService
+ * which the cleanup path uses to look up contract and target objects.
+ *
+ * @category Test
+ * @package  OCA\OpenConnector\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenConnector\Tests\Unit\Service;
+
+use OCA\OpenConnector\Service\CallService;
+use OCA\OpenConnector\Service\MappingService;
+use OCA\OpenConnector\Service\ObjectService;
+use OCA\OpenConnector\Service\StorageService;
+use OCA\OpenConnector\Service\SynchronizationService;
+use OCA\OpenConnector\Tests\Helpers\ObjectServiceMockBuilder;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService as ORObjectService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * Tests the scope-checked cleanup behaviour in deleteInvalidObjects.
+ *
+ * The cleanup pass must verify each candidate target lives in the sync's
+ * register/schema before invoking the unscoped `objectService->delete(['id' => $uuid])`
+ * inside `updateTargetOpenRegister`. Without this guard a UUID collision
+ * across magic tables would silently delete a foreign-scope object.
+ */
+class SynchronizationServiceCleanupTest extends TestCase
+{
+
+    private const SYNC_UUID = 'sync-uuid-1';
+    private const REGISTER_ID = '1';
+    private const SCHEMA_ID = '2';
+    private const TARGET_IN_SCOPE = 'object-in-scope-uuid';
+    private const TARGET_OUT_OF_SCOPE = 'object-out-of-scope-uuid';
+
+    /**
+     * @var SynchronizationService&MockObject
+     */
+    private $service;
+
+    /**
+     * @var ORObjectService&MockObject
+     */
+    private $orObjectService;
+
+    /**
+     * @var LoggerInterface&MockObject
+     */
+    private $logger;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->orObjectService = ObjectServiceMockBuilder::make($this);
+        $this->logger          = $this->createMock(LoggerInterface::class);
+
+        $callService    = $this->createMock(CallService::class);
+        $mappingService = $this->createMock(MappingService::class);
+        $container      = $this->createMock(ContainerInterface::class);
+        $objectService  = $this->createMock(ObjectService::class);
+        $storageService = $this->createMock(StorageService::class);
+        $appConfig      = $this->createMock(IAppConfig::class);
+        $appConfig->method('hasKey')->willReturn(false);
+
+        // Partial-mock `updateTarget` so we can assert whether the delete path
+        // is reached without exercising the deep OR delete chain underneath.
+        $this->service = $this->getMockBuilder(SynchronizationService::class)
+            ->setConstructorArgs(
+                [
+                    $callService,
+                    $mappingService,
+                    $container,
+                    $this->orObjectService,
+                    $objectService,
+                    $storageService,
+                    $this->logger,
+                    $appConfig,
+                ]
+            )
+            ->onlyMethods(['updateTarget'])
+            ->getMock();
+    }//end setUp()
+
+
+    /**
+     * Build a Synchronization OR-object stub with `targetType: register/schema`
+     * and `targetId: {registerId}/{schemaId}`.
+     *
+     * @return ObjectEntity&MockObject
+     */
+    private function makeSync(): MockObject
+    {
+        return ObjectServiceMockBuilder::objectEntity(
+            $this,
+            [
+                'targetType' => 'register/schema',
+                'targetId'   => self::REGISTER_ID.'/'.self::SCHEMA_ID,
+            ],
+            self::SYNC_UUID
+        );
+    }//end makeSync()
+
+
+    /**
+     * Build a SynchronizationContract OR-object stub bound to this sync.
+     *
+     * @param string $targetId The targetId UUID on the contract.
+     * @param string $originId The originId on the contract.
+     *
+     * @return ObjectEntity&MockObject
+     */
+    private function makeContract(string $targetId, string $originId='origin-x'): MockObject
+    {
+        return ObjectServiceMockBuilder::objectEntity(
+            $this,
+            [
+                'synchronizationId' => self::SYNC_UUID,
+                'targetId'          => $targetId,
+                'originId'          => $originId,
+            ],
+            'contract-uuid-'.substr(md5($targetId), 0, 8)
+        );
+    }//end makeContract()
+
+
+    /**
+     * Map ORObjectService::find parameter names to positional indices.
+     *
+     * Production calls find() with named arguments; PHPUnit's stub receives
+     * positional arguments after the runtime expansion. Using reflection here
+     * keeps assertions robust against signature changes.
+     *
+     * @return array<string, int>
+     */
+    private function findParamPositions(): array
+    {
+        $rm        = new ReflectionMethod(ORObjectService::class, 'find');
+        $positions = [];
+        foreach ($rm->getParameters() as $i => $p) {
+            $positions[$p->getName()] = $i;
+        }
+
+        return $positions;
+    }//end findParamPositions()
+
+
+    /**
+     * In-scope orphan: target object lives in this sync's register/schema → delete proceeds.
+     *
+     * @return void
+     */
+    public function testInScopeOrphanIsDeleted(): void
+    {
+        $sync     = $this->makeSync();
+        $contract = $this->makeContract(self::TARGET_IN_SCOPE);
+        $pos      = $this->findParamPositions();
+        $targetEntity = ObjectServiceMockBuilder::objectEntity($this, [], self::TARGET_IN_SCOPE);
+
+        // First findAll: enumerate contracts for the sync. Second findAll: re-lookup by targetId.
+        $this->orObjectService->method('findAll')
+            ->willReturn(['results' => [$contract], 'total' => 1]);
+
+        // find() is the scope-check call — assert it carries the correct scope flags.
+        $this->orObjectService->expects($this->once())
+            ->method('find')
+            ->willReturnCallback(
+                function (...$args) use ($pos, $targetEntity) {
+                    $this->assertSame(self::TARGET_IN_SCOPE, $args[$pos['id']]);
+                    $this->assertSame(self::REGISTER_ID, $args[$pos['register']]);
+                    $this->assertSame(self::SCHEMA_ID, $args[$pos['schema']]);
+                    $this->assertFalse($args[$pos['_rbac']], '_rbac must be false to match prior unscoped-JOIN behaviour');
+                    $this->assertFalse($args[$pos['_multitenancy']], '_multitenancy must be false to match prior unscoped-JOIN behaviour');
+                    return $targetEntity;
+                }
+            );
+
+        $this->service->expects($this->once())
+            ->method('updateTarget')
+            ->willReturn($contract);
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(1, $deleted, 'In-scope orphan should be deleted');
+    }//end testInScopeOrphanIsDeleted()
+
+
+    /**
+     * Cross-scope contract: target UUID does NOT live in this sync's register/schema → skip delete.
+     *
+     * Without the scope check the unscoped delete inside `updateTargetOpenRegister`
+     * would happily delete the foreign-scope object that happens to share the UUID.
+     *
+     * @return void
+     */
+    public function testCrossScopeContractIsSkipped(): void
+    {
+        $sync     = $this->makeSync();
+        $contract = $this->makeContract(self::TARGET_OUT_OF_SCOPE);
+
+        $this->orObjectService->method('findAll')
+            ->willReturn(['results' => [$contract], 'total' => 1]);
+
+        // Scope-check find returns null — object is in a different register/schema or gone.
+        $this->orObjectService->method('find')->willReturn(null);
+
+        $this->service->expects($this->never())->method('updateTarget');
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(0, $deleted, 'Out-of-scope contract must not trigger deletion');
+    }//end testCrossScopeContractIsSkipped()
+
+
+    /**
+     * Scope-check throws DoesNotExistException → swallowed silently, no delete.
+     *
+     * @return void
+     */
+    public function testDoesNotExistExceptionIsSwallowed(): void
+    {
+        $sync     = $this->makeSync();
+        $contract = $this->makeContract(self::TARGET_OUT_OF_SCOPE);
+
+        $this->orObjectService->method('findAll')
+            ->willReturn(['results' => [$contract], 'total' => 1]);
+
+        $this->orObjectService->method('find')
+            ->willThrowException(new DoesNotExistException('object gone'));
+
+        $this->service->expects($this->never())->method('updateTarget');
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(0, $deleted);
+    }//end testDoesNotExistExceptionIsSwallowed()
+
+
+    /**
+     * Scope-check throws an unexpected Throwable → warning logged, candidate skipped, loop continues.
+     *
+     * @return void
+     */
+    public function testUnexpectedThrowableLogsWarningAndContinues(): void
+    {
+        $sync     = $this->makeSync();
+        $contract = $this->makeContract(self::TARGET_IN_SCOPE);
+
+        $this->orObjectService->method('findAll')
+            ->willReturn(['results' => [$contract], 'total' => 1]);
+
+        $this->orObjectService->method('find')
+            ->willThrowException(new \RuntimeException('database connection lost'));
+
+        $this->logger->expects($this->atLeastOnce())
+            ->method('warning')
+            ->with(
+                $this->stringContains('Scope check failed'),
+                $this->callback(
+                    function ($context) {
+                        return isset($context['synchronizationId'])
+                            && isset($context['targetId'])
+                            && isset($context['error']);
+                    }
+                )
+            );
+
+        $this->service->expects($this->never())->method('updateTarget');
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(0, $deleted);
+    }//end testUnexpectedThrowableLogsWarningAndContinues()
+
+
+    /**
+     * Malformed targetId (no `/` separator) → warning logged, no contracts inspected.
+     *
+     * @return void
+     */
+    public function testMalformedTargetIdLogsWarningAndBails(): void
+    {
+        $sync = ObjectServiceMockBuilder::objectEntity(
+            $this,
+            [
+                'targetType' => 'register/schema',
+                'targetId'   => 'not-a-slash-separated-string',
+            ],
+            self::SYNC_UUID
+        );
+
+        $this->orObjectService->expects($this->never())->method('findAll');
+        $this->orObjectService->expects($this->never())->method('find');
+        $this->service->expects($this->never())->method('updateTarget');
+
+        $this->logger->expects($this->atLeastOnce())
+            ->method('warning')
+            ->with($this->stringContains('targetId not in register/schema format'));
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(0, $deleted);
+    }//end testMalformedTargetIdLogsWarningAndBails()
+
+
+    /**
+     * Mixed batch: one in-scope, one out-of-scope → only in-scope orphan deleted.
+     *
+     * @return void
+     */
+    public function testInScopeAndOutOfScopeMixedBatch(): void
+    {
+        $sync       = $this->makeSync();
+        $inScope    = $this->makeContract(self::TARGET_IN_SCOPE, 'origin-a');
+        $outOfScope = $this->makeContract(self::TARGET_OUT_OF_SCOPE, 'origin-b');
+        $pos        = $this->findParamPositions();
+        $targetEntity = ObjectServiceMockBuilder::objectEntity($this, [], self::TARGET_IN_SCOPE);
+
+        // First findAll: list of contracts. Subsequent findAlls: per-target re-lookup.
+        $this->orObjectService->method('findAll')
+            ->willReturnOnConsecutiveCalls(
+                ['results' => [$inScope, $outOfScope], 'total' => 2],
+                ['results' => [$inScope], 'total' => 1]
+            );
+
+        $this->orObjectService->method('find')
+            ->willReturnCallback(
+                function (...$args) use ($pos, $targetEntity) {
+                    return $args[$pos['id']] === self::TARGET_IN_SCOPE ? $targetEntity : null;
+                }
+            );
+
+        $this->service->expects($this->once())
+            ->method('updateTarget')
+            ->willReturn($inScope);
+
+        $deleted = $this->service->deleteInvalidObjects($sync, []);
+
+        $this->assertSame(1, $deleted, 'Only in-scope orphan should be deleted in mixed batch');
+    }//end testInScopeAndOutOfScopeMixedBatch()
+
+
+}//end class


### PR DESCRIPTION
## Summary

Ports the surviving safety guard from #733 (author @rjzondervan) to the post-cutover tip. The original PR fixed two things:

1. The broken `INNER JOIN openregister_objects` in the cleanup query (silently returned zero rows under OR's magic-table architecture → orphans never deleted).
2. The unscoped-delete safety hole: `updateTargetOpenRegister`'s `delete` branch calls `$objectService->delete(['id' => $uuid])` with no register/schema scope. If a contract's `targetId` UUID happens to collide with an object in a foreign magic table, that foreign object is deleted.

The OR cutover (chain-B/C) deleted the `SynchronizationContractMapper` and re-implemented the cleanup over OR-object queries, so item (1) is now structurally fixed — there's no JOIN anymore. **However, item (2) is still vulnerable** — the unscoped `delete()` call inside `updateTargetOpenRegister` is unchanged on this branch, and `deleteInvalidObjects` enumerates candidates with no per-candidate scope check.

This PR restores the per-candidate scope guard:

- Before invoking `updateTarget(..., 'delete')`, call `$this->orObjectService->find(id: $targetIdToDelete, register: $registerId, schema: $schemaId, _rbac: false, _multitenancy: false)`.
- `DoesNotExistException` → silent skip (expected scope-miss — UUID lives in a foreign register/schema or is gone).
- Other `Throwable` → `LoggerInterface::warning` + skip; loop continues.
- Malformed `targetId` (no `/` separator) → warning log + early break out of the case.
- Second-lookup empty contract list → warning log instead of silent skip.
- Entire delete block wrapped so per-candidate failures don't abort the batch.

`_rbac` / `_multitenancy` are off because the SQL-level guard this replaces (the pre-cutover JOIN against `openregister_objects`) did not apply RBAC either — the safety property being restored is **scope**, not permission.

## What is NOT ported from #733

- `lib/Db/*Mapper.php` hunks — those classes were deleted by the OR cutover.
- The "merge 60+ commits from main" half — stale, irrelevant to this branch.
- `info.xml` version bump / `release.yml` / `composer.json` — separate concerns.
- The original openspec change folder under `openspec/changes/fix-sync-cleanup-scope-check/` — recreate fresh via opsx flow if/when this lands.
- Unrelated changes in the original PR (Mapping renderTemplateString, extra-data endpoint templates, write-file FlowToken support, `findByUuid` → `find` migrations, sourceConfig `triggerOnlyOnEvents`, etc.) — out of scope; many already done in chain work.

## Tests

Adds `tests/Unit/Service/SynchronizationServiceCleanupTest.php` covering:

- In-scope orphan → deleted (and asserts `find()` is invoked with the correct scope + `_rbac: false, _multitenancy: false`).
- Cross-scope contract → `find()` returns null → skipped.
- `DoesNotExistException` from `find()` → silently swallowed.
- Unexpected `Throwable` from `find()` → warning logged, candidate skipped.
- Malformed `targetId` → warning logged, no `findAll`/`find` called.
- Mixed in-scope + out-of-scope batch → only in-scope deleted.

The test is adapted from the original (`SynchronizationContractMapper` is gone; mocks the OR `ObjectService` instead) and follows the existing `ObjectServiceMockBuilder` pattern under `tests/Helpers/`.

## Quality gates

- `php -l lib/Service/SynchronizationService.php` — clean
- `php -l tests/Unit/Service/SynchronizationServiceCleanupTest.php` — clean
- `vendor/bin/phpcs --standard=phpcs.xml lib/Service/SynchronizationService.php` — clean (after adding `//end try` / `//end foreach` comments PEAR's long-condition rule requires)
- PHPUnit not exercised on this branch — see follow-up (pre-existing harness gap, not introduced by this PR).

## Follow-ups discovered

- **Unit-test harness is broken on `feature/i18n-complete-translations`**: no `tests/bootstrap.php`, no `autoload-dev` PSR-4 mapping for `OCA\OpenConnector\Tests\*` in `composer.json`, and `phpunit.xml` testsuite points at `tests/unit` (lowercase) while actual tests live in `tests/Unit`. Even existing tests like `SynchronizationServiceTest` can't run. Worth a separate small PR.
- **Unscoped delete at the API boundary**: `updateTargetOpenRegister`'s `delete` branch still calls `$objectService->delete(['id' => $uuid])` with no register/schema. The original PR also noted this as a follow-up — an OR-side scoped `deleteObject($uuid, $register, $schema)` that refuses cross-scope would let callers drop their per-call scope guards.
- **Wider audit**: other openconnector callers (and other Conduction apps) may still hold unscoped delete calls. Original PR's task 4.3 audited openconnector's `lib/` for `openregister_objects` JOIN references and was clean.

Refs #733, #732 (don't close — original PR author will close after this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)