### PR TITLE
feat(sync): cherry-pick Twig endpoint templating + event-trigger guard from #745

### DIFF
--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -1135,8 +1135,11 @@ class EndpointService
 
                 $data['flowToken'] = $flowToken->__serialize();
 
+                $conditionsPassed = $this->checkRuleConditions(rule: $rule, data: $data, logicResult: $logicResult);
+                $timingMatches    = (($ruleData['timing'] ?? 'before') === $timing);
+
                 // Check rule conditions
-                if ($this->checkRuleConditions(rule: $rule, data: $data, logicResult:  $logicResult) === false || ($ruleData['timing'] ?? 'before') !== $timing) {
+                if ($conditionsPassed === false || $timingMatches === false) {
                     $this->logger->info('Rule condition check failed for endpoint '.($endpointData['name'] ?? '').' and rule '.($ruleData['name'] ?? '').' of type: '.($ruleData['type'] ?? ''));
 
                     continue;
@@ -1644,12 +1647,16 @@ class EndpointService
             $synchronizationId = $config['synchronization'];
         }
 
+        $this->logger->debug('[EndpointService] processSyncRule ruleId='.$rule->getUuid().' synchronizationId='.$synchronizationId);
+
         // Fetch the synchronization.
         if (is_numeric($synchronizationId) === true) {
             $synchronization = $this->synchronizationService->getSynchronization(id: (int) $synchronizationId);
         } else {
             $synchronization = $this->synchronizationService->getSynchronization(filters: ['reference' => $synchronizationId]);
         }
+
+        $this->logger->debug('[EndpointService] processSyncRule synchronization fetched id='.$synchronization->getUuid().' name='.$synchronization->getName());
 
         // Check if the synchronization should be in test mode.
         if (isset($data['body']['isTest']) === true) {
@@ -1708,7 +1715,9 @@ class EndpointService
             $mutationType = 'delete';
         }
 
+        $this->logger->debug('[EndpointService] processSyncRule calling synchronize syncId='.$synchronization->getUuid().' isTest='.var_export($test, true).' force='.var_export($force, true).' mutationType='.var_export($mutationType, true));
         $log = $this->synchronizationService->synchronize(synchronization: $synchronization, isTest: $test, force: $force, object: $fetchedObject, mutationType: $mutationType, data: $object, flowToken: $flowToken);
+        $this->logger->debug('[EndpointService] processSyncRule synchronize complete syncId='.$synchronization->getUuid());
 
         // $object got updated through reference.
         $returnedObject = $object;

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -118,6 +118,24 @@ class MappingService
     }//end encodeArrayKeys()
 
     /**
+     * Renders a Twig template string using the mapping Twig environment.
+     *
+     * @param string $template The Twig template to render.
+     * @param array  $context  The context available inside the template.
+     *
+     * @return string The rendered template result.
+     *
+     * @throws LoaderError|SyntaxError Twig exceptions.
+     *
+     * @psalm-param array<string, mixed> $context
+     */
+    public function renderTemplateString(string $template, array $context=[]): string
+    {
+        return html_entity_decode($this->twig->createTemplate($template)->render($context));
+
+    }//end renderTemplateString()
+
+    /**
      * Maps (transforms) an array (input) to a different array (output).
      *
      * Delegates to OpenRegister's MappingService when available, otherwise
@@ -219,7 +237,7 @@ class MappingService
             }
 
             try {
-                $dotArray->set($key, html_entity_decode($this->twig->createTemplate($value)->render($originalInput)));
+                $dotArray->set($key, $this->renderTemplateString($value, $originalInput));
             } catch (Throwable $e) {
                 throw new Exception("Error for mapping: {$mapping->getName()}, key: $key, value: $value and with message thrown: {$e->getMessage()}");
             }

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -62,6 +62,9 @@ class SynchronizationService
     const KEY_FOR_EXTRA_DATA_LOCATION          = 'keyToSetExtraData';
     const MERGE_EXTRA_DATA_OBJECT_LOCATION     = 'mergeExtraData';
     const UNSET_CONFIG_KEY_LOCATION            = 'unsetConfigKey';
+
+    const EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION = 'endpointTemplate';
+
     const EXTRA_DATA_BEFORE_CONDITIONS_LOCATION = 'fetchExtraDataBeforeConditions';
     const EXTEND_BEFORE_CONDITIONS_LOCATION     = 'extendInputBeforeConditions';
     const EXTEND_BEFORE_CONDITIONS_FETCH_OBJECT = 'extendInputFetchObjectBeforeConditions';
@@ -157,6 +160,10 @@ class SynchronizationService
 
         $directSynchronizations = $this->findAllBySourceId(register: $register, schema: $schema);
         foreach ($directSynchronizations as $synchronization) {
+            if ($this->shouldTriggerOnEvent(synchronization: $synchronization, eventMutationType: $eventMutationType) === false) {
+                continue;
+            }
+
             try {
                 if ($eventMutationType === 'delete') {
                     $this->synchronize(
@@ -195,6 +202,10 @@ class SynchronizationService
                 continue;
             }
 
+            if ($this->shouldTriggerOnEvent(synchronization: $synchronization, eventMutationType: $eventMutationType) === false) {
+                continue;
+            }
+
             try {
                 $parentObjectArray = $this->resolveParentObjectForRelatedObjectTrigger(
                  synchronization: $synchronization,
@@ -226,6 +237,32 @@ class SynchronizationService
             }//end try
         }//end foreach
     }//end handleObjectEventSynchronization()
+
+    /**
+     * Determines whether a synchronization should run for the given mutation type.
+     *
+     * Checks sourceConfig['triggerOnlyOnEvents'] (case-insensitive). When the key
+     * is absent or empty the synchronization always runs; when present it runs only
+     * if $eventMutationType is listed.
+     *
+     * @param ObjectEntity $synchronization   The synchronization to evaluate.
+     * @param string       $eventMutationType One of create|update|delete.
+     *
+     * @return bool True when the synchronization should run, false when it should be skipped.
+     */
+    private function shouldTriggerOnEvent(ObjectEntity $synchronization, string $eventMutationType): bool
+    {
+        $sourceConfig  = (array) ($synchronization->getSourceConfig() ?? []);
+        $allowedEvents = ($sourceConfig['triggerOnlyOnEvents'] ?? []);
+
+        if (empty($allowedEvents) === true) {
+            return true;
+        }
+
+        $normalised = array_map('strtolower', (array) $allowedEvents);
+        return in_array(strtolower($eventMutationType), $normalised, true);
+
+    }//end shouldTriggerOnEvent()
 
     /**
      * Resolve and fetch the parent object for a related-object trigger.
@@ -989,6 +1026,21 @@ class SynchronizationService
                 }
             }
         }//end if
+
+        if (isset($extraDataConfig[$this::EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION]) === true
+            && is_string($extraDataConfig[$this::EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION]) === true
+            && $extraDataConfig[$this::EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION] !== ''
+        ) {
+            $endpoint = $this->mappingService->renderTemplateString(
+                template: $extraDataConfig[$this::EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION],
+                context: [
+                    'endpoint'        => ($endpoint ?? null),
+                    'object'          => $object,
+                    'originId'        => $originId,
+                    'extraDataConfig' => $extraDataConfig,
+                ]
+            );
+        }
 
         if (!$endpoint) {
             throw new Exception(
@@ -1870,8 +1922,25 @@ class SynchronizationService
         $this->checkRateLimit($source);
 
         // Extract source configuration
-        $sourceConfig   = $this->callService->applyConfigDot($syncData['sourceConfig'] ?? []); // TODO; This is the second time this function is called in the synchonysation flow, needs further refactoring investigation
-        $endpoint       = $sourceConfig['endpoint'] ?? '';
+        $sourceConfig = $this->callService->applyConfigDot($syncData['sourceConfig'] ?? []); // TODO; This is the second time this function is called in the synchonysation flow, needs further refactoring investigation
+        $endpoint     = $sourceConfig['endpoint'] ?? '';
+        if (is_string($endpoint) === true
+            && str_contains($endpoint, '{{') === true
+            && str_contains($endpoint, '}}') === true
+        ) {
+            $contextData = ($data ?? []);
+            // After-rule responses pass the OR object (`{id, @self}`) here; lift @self.relations
+            // to the top level so simple `{{ data.zaaknummer }}` lookups still resolve.
+            if (isset($contextData['@self']['relations']) === true && is_array($contextData['@self']['relations']) === true) {
+                $contextData = array_merge($contextData['@self']['relations'], $contextData);
+            }
+
+            $endpoint = $this->mappingService->renderTemplateString(
+                template: $endpoint,
+                context: ['data' => $contextData]
+            );
+        }
+
         $headers        = $sourceConfig['headers'] ?? [];
         $query          = $sourceConfig['query'] ?? [];
         $usesPagination = true;


### PR DESCRIPTION
## Summary

Cherry-picks the 4 surviving backend strands from @bbrands02's #745 onto the post-cutover `feature/i18n-complete-translations` tip. Closes the carry-forward gap from the REFACTOR triage.

### Ported
- **`SynchronizationService::shouldTriggerOnEvent`** — guards both direct- and related-object trigger loops in `handleObjectEventSynchronization` so a `sourceConfig.triggerOnlyOnEvents` allowlist actually filters create/update/delete events.
- **`MappingService::renderTemplateString`** — factored out of `executeMappingLocal` so the Twig environment can be reused.
- **`SynchronizationService` Twig templating**:
  - New `EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION = 'endpointTemplate'` constant.
  - `fetchExtraDataForObject` renders the new template (when set) with `endpoint`, `object`, `originId`, `extraDataConfig` in scope.
  - `getAllObjectsFromApi` renders `sourceConfig.endpoint` when it contains `{{ }}`. `@self.relations` is lifted to the top of the Twig `data` context so simple `{{ data.zaaknummer }}` references resolve correctly from after-rule OR responses.
- **`EndpointService::processRules`** — splits `checkRuleConditions` + timing into named `\$conditionsPassed`/`\$timingMatches` variables; `processSyncRule` gains three debug log lines around the `synchronize()` call.

### Skipped (per triage)
- `src/modals/Synchronization/EditSynchronization.vue` — eslint-ignored extraction reference post-#827; the manifest flow replaces it.
- `appinfo/routes.php` SPA catch-all regex — already fixed by chain-E commit `2b044f9f` (`(?!api(/|$)).*`, stricter than the PR's `(?!api/).+`).
- Debug `echo` / `var_dump` removal — already cleaned up separately during the cutover.

### Quality
- PHPCS strict pass on the three modified backend files (via the in-container vendor).

Credit @bbrands02 for the original implementation in #745.

## Test plan

- [ ] Post an object create event to `cloudevents/rx` — a sync with `triggerOnlyOnEvents: [create]` runs; the same sync skips on `update`/`delete`.
- [ ] Configure an extraData rule with `endpointTemplate: "/foo/{{ object.id }}"` — verify Twig renders and the call hits the templated URL.
- [ ] Configure a sourceConfig.endpoint with `{{ data.zaaknummer }}`, fire an after-rule on a `register/schema` OR payload — verify the value resolves from `@self.relations`.
- [ ] Check `data/nextcloud.log` for the new `[EndpointService] processSyncRule …` debug lines on a rule-driven sync.