### PR TITLE
chore: sync canonical root configs + mechanical phpmd cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.3"
+			"php": "8.2"
 		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cb07cfca8f6c3fe1ed4b31624af9d16",
+    "content-hash": "65d007eb0817885db452b19a57819f33",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
-            "version": "3.3.0",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/adbario/php-dot-notation.git",
-                "reference": "a94ce4493d19ea430baa8d7d210a2c9bd7129fc2"
+                "reference": "aa09db5a7a365a8d2d8dd7edfa3cd501d1a8acb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/adbario/php-dot-notation/zipball/a94ce4493d19ea430baa8d7d210a2c9bd7129fc2",
-                "reference": "a94ce4493d19ea430baa8d7d210a2c9bd7129fc2",
+                "url": "https://api.github.com/repos/adbario/php-dot-notation/zipball/aa09db5a7a365a8d2d8dd7edfa3cd501d1a8acb0",
+                "reference": "aa09db5a7a365a8d2d8dd7edfa3cd501d1a8acb0",
                 "shasum": ""
             },
             "require": {
@@ -25,7 +25,7 @@
                 "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.7"
             },
@@ -56,22 +56,22 @@
             ],
             "support": {
                 "issues": "https://github.com/adbario/php-dot-notation/issues",
-                "source": "https://github.com/adbario/php-dot-notation/tree/3.3.0"
+                "source": "https://github.com/adbario/php-dot-notation/tree/3.5.0"
             },
-            "time": "2023-02-24T20:27:50+00:00"
+            "time": "2026-04-04T04:29:49+00:00"
         },
         {
             "name": "azjezz/psl",
-            "version": "4.3.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-standard-library/php-standard-library.git",
-                "reference": "74c95be0214eb7ea39146ed00ac4eb71b45d787b"
+                "reference": "78078f2c505473d2a28319ffe426b2a82ac76790"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-standard-library/php-standard-library/zipball/74c95be0214eb7ea39146ed00ac4eb71b45d787b",
-                "reference": "74c95be0214eb7ea39146ed00ac4eb71b45d787b",
+                "url": "https://api.github.com/repos/php-standard-library/php-standard-library/zipball/78078f2c505473d2a28319ffe426b2a82ac76790",
+                "reference": "78078f2c505473d2a28319ffe426b2a82ac76790",
                 "shasum": ""
             },
             "require": {
@@ -80,15 +80,17 @@
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "ext-sodium": "*",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "revolt/event-loop": "^1.0.7"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "revolt/event-loop": "^1.0.6"
             },
             "require-dev": {
-                "carthage-software/mago": "^1.6.0",
-                "infection/infection": "^0.31.2",
+                "carthage-software/mago": "~0.13.1",
                 "php-coveralls/php-coveralls": "^2.7.0",
-                "phpbench/phpbench": "^1.4.0",
-                "phpunit/phpunit": "^9.6.22"
+                "php-standard-library/psalm-plugin": "^2.3.0",
+                "phpbench/phpbench": "^1.2.15",
+                "phpunit/phpunit": "^9.6.18",
+                "roave/infection-static-analysis-plugin": "^1.36.0",
+                "vimeo/psalm": "^6.0.0"
             },
             "suggest": {
                 "php-standard-library/phpstan-extension": "PHPStan integration",
@@ -121,8 +123,8 @@
             ],
             "description": "PHP Standard Library",
             "support": {
-                "issues": "https://github.com/azjezz/psl/issues",
-                "source": "https://github.com/azjezz/psl/tree/4.3.0"
+                "issues": "https://github.com/php-standard-library/php-standard-library/issues",
+                "source": "https://github.com/php-standard-library/php-standard-library/tree/3.3.0"
             },
             "funding": [
                 {
@@ -134,7 +136,8 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-24T01:58:53+00:00"
+            "abandoned": "php-standard-library/php-standard-library",
+            "time": "2025-03-03T00:07:00+00:00"
         },
         {
             "name": "bamarni/composer-bin-plugin",
@@ -436,16 +439,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "47ba23c7a55247e2e1b7407aca90e9bbed0d9d86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/47ba23c7a55247e2e1b7407aca90e9bbed0d9d86",
+                "reference": "47ba23c7a55247e2e1b7407aca90e9bbed0d9d86",
                 "shasum": ""
             },
             "require": {
@@ -463,8 +466,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.3.2",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -542,7 +546,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.3"
             },
             "funding": [
                 {
@@ -558,20 +562,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-05-20T22:59:19+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/09e8a212562fb1fb6a512c4156ed71525969d6c2",
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2",
                 "shasum": ""
             },
             "require": {
@@ -579,7 +583,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -625,7 +629,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.4.1"
             },
             "funding": [
                 {
@@ -641,20 +645,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-05-20T22:57:30+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/73ab136360b5dfd858006eae9795e8fe43c80361",
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361",
                 "shasum": ""
             },
             "require": {
@@ -669,9 +673,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -742,7 +746,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.1"
             },
             "funding": [
                 {
@@ -758,7 +762,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-05-20T09:27:36+00:00"
         },
         {
             "name": "jwadhams/json-logic-php",
@@ -805,20 +809,20 @@
         },
         {
             "name": "league/uri",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/4436c6ec8d458e4244448b069cc572d088230b76",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.8",
+                "league/uri-interfaces": "^7.8.1",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -891,7 +895,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -899,24 +903,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-14T17:24:56+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-components",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-components.git",
-                "reference": "8b5ffcebcc0842b76eb80964795bd56a8333b2ba"
+                "reference": "848ff9db2f0be06229d6034b7c2e33d41b4fd675"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/8b5ffcebcc0842b76eb80964795bd56a8333b2ba",
-                "reference": "8b5ffcebcc0842b76eb80964795bd56a8333b2ba",
+                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/848ff9db2f0be06229d6034b7c2e33d41b4fd675",
+                "reference": "848ff9db2f0be06229d6034b7c2e33d41b4fd675",
                 "shasum": ""
             },
             "require": {
-                "league/uri": "^7.8",
+                "league/uri": "^7.8.1",
                 "php": "^8.1"
             },
             "suggest": {
@@ -975,7 +979,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-components/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri-components/tree/7.8.1"
             },
             "funding": [
                 {
@@ -983,20 +987,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-14T17:24:56+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
@@ -1059,7 +1063,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1067,20 +1071,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-15T06:54:53+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "open-telemetry/api",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/api.git",
-                "reference": "df5197c6fd0ddd8e9883b87de042d9341300e2ad"
+                "reference": "6f8d237ce2c304ca85f31970f788e7f074d147be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/df5197c6fd0ddd8e9883b87de042d9341300e2ad",
-                "reference": "df5197c6fd0ddd8e9883b87de042d9341300e2ad",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/6f8d237ce2c304ca85f31970f788e7f074d147be",
+                "reference": "6f8d237ce2c304ca85f31970f788e7f074d147be",
                 "shasum": ""
             },
             "require": {
@@ -1137,20 +1141,20 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2026-01-21T04:14:03+00:00"
+            "time": "2026-02-25T13:24:05+00:00"
         },
         {
             "name": "open-telemetry/context",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/context.git",
-                "reference": "d4c4470b541ce72000d18c339cfee633e4c8e0cf"
+                "reference": "3c414b246e0dabb7d6145404e6a5e4536ca18d07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/d4c4470b541ce72000d18c339cfee633e4c8e0cf",
-                "reference": "d4c4470b541ce72000d18c339cfee633e4c8e0cf",
+                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/3c414b246e0dabb7d6145404e6a5e4536ca18d07",
+                "reference": "3c414b246e0dabb7d6145404e6a5e4536ca18d07",
                 "shasum": ""
             },
             "require": {
@@ -1192,11 +1196,11 @@
             ],
             "support": {
                 "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
-                "docs": "https://opentelemetry.io/docs/php",
+                "docs": "https://opentelemetry.io/docs/languages/php",
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-09-19T00:05:49+00:00"
+            "time": "2025-10-19T06:44:33+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -1689,28 +1693,27 @@
         },
         {
             "name": "php-soap/engine",
-            "version": "2.18.0",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-soap/engine.git",
-                "reference": "f2c04747ffa9143a9ba5f8950a455b78d718ddce"
+                "reference": "c19daa91254f64513c87bbafb257eb2da55cefca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-soap/engine/zipball/f2c04747ffa9143a9ba5f8950a455b78d718ddce",
-                "reference": "f2c04747ffa9143a9ba5f8950a455b78d718ddce",
+                "url": "https://api.github.com/repos/php-soap/engine/zipball/c19daa91254f64513c87bbafb257eb2da55cefca",
+                "reference": "c19daa91254f64513c87bbafb257eb2da55cefca",
                 "shasum": ""
             },
             "require": {
-                "azjezz/psl": "^3.0 || ^4.0 || ^5.0",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "php-soap/xml": "^1.9.0"
+                "azjezz/psl": "^3.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php-soap/xml": "^1.8.0"
             },
             "require-dev": {
-                "php-cs-fixer/shim": "^3.88",
                 "php-standard-library/psalm-plugin": "^2.2",
-                "phpunit/phpunit": "^12.3",
-                "vimeo/psalm": "^6.13"
+                "phpunit/phpunit": "^10.5",
+                "vimeo/psalm": "^5.26"
             },
             "type": "library",
             "autoload": {
@@ -1731,7 +1734,7 @@
             "description": "SOAP engine design",
             "support": {
                 "issues": "https://github.com/php-soap/engine/issues",
-                "source": "https://github.com/php-soap/engine/tree/2.18.0"
+                "source": "https://github.com/php-soap/engine/tree/2.15.0"
             },
             "funding": [
                 {
@@ -1739,37 +1742,35 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-03-11T13:20:54+00:00"
+            "time": "2025-01-03T09:16:20+00:00"
         },
         {
             "name": "php-soap/ext-soap-engine",
-            "version": "1.10.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-soap/ext-soap-engine.git",
-                "reference": "66a35ea255a3f4a9483a4c4e63a9a6af7bb5e350"
+                "reference": "b11e1949f4654f27f997b6e2bb44c1bd14735340"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-soap/ext-soap-engine/zipball/66a35ea255a3f4a9483a4c4e63a9a6af7bb5e350",
-                "reference": "66a35ea255a3f4a9483a4c4e63a9a6af7bb5e350",
+                "url": "https://api.github.com/repos/php-soap/ext-soap-engine/zipball/b11e1949f4654f27f997b6e2bb44c1bd14735340",
+                "reference": "b11e1949f4654f27f997b6e2bb44c1bd14735340",
                 "shasum": ""
             },
             "require": {
-                "azjezz/psl": "^3.0 || ^4.0 || ^5.0",
+                "azjezz/psl": "^3.0",
                 "ext-dom": "*",
                 "ext-soap": "*",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "php-soap/engine": "^2.16",
-                "php-soap/wsdl": "^1.14",
-                "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php-soap/engine": "^2.13",
+                "php-soap/wsdl": "^1.12",
+                "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0"
             },
             "require-dev": {
-                "php-cs-fixer/shim": "~3.88",
-                "php-soap/engine-integration-tests": "^1.10",
-                "php-soap/xml": "^1.9",
-                "phpunit/phpunit": "~12.3",
-                "vimeo/psalm": "~6.13"
+                "php-soap/engine-integration-tests": "^1.9",
+                "php-soap/xml": "^1.8",
+                "phpunit/phpunit": "^10.0.19"
             },
             "type": "library",
             "autoload": {
@@ -1790,7 +1791,7 @@
             "description": "An ext-soap engine implementation",
             "support": {
                 "issues": "https://github.com/php-soap/ext-soap-engine/issues",
-                "source": "https://github.com/php-soap/ext-soap-engine/tree/1.10.0"
+                "source": "https://github.com/php-soap/ext-soap-engine/tree/1.7.0"
             },
             "funding": [
                 {
@@ -1798,30 +1799,30 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-03-11T15:08:22+00:00"
+            "time": "2024-10-25T08:37:25+00:00"
         },
         {
             "name": "php-soap/psr18-transport",
-            "version": "1.8.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-soap/psr18-transport.git",
-                "reference": "fee4be6b02bd2d0fb3886c98d72b2ae97564cee4"
+                "reference": "1c0a42924ac39d8fadb9e4196f5f7b5e8e68d0a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-soap/psr18-transport/zipball/fee4be6b02bd2d0fb3886c98d72b2ae97564cee4",
-                "reference": "fee4be6b02bd2d0fb3886c98d72b2ae97564cee4",
+                "url": "https://api.github.com/repos/php-soap/psr18-transport/zipball/1c0a42924ac39d8fadb9e4196f5f7b5e8e68d0a9",
+                "reference": "1c0a42924ac39d8fadb9e4196f5f7b5e8e68d0a9",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
                 "php-http/client-common": "^2.3",
                 "php-http/discovery": "^1.12",
-                "php-soap/engine": "^2.16",
-                "php-soap/wsdl": "^1.14",
-                "php-soap/xml": "^1.9",
+                "php-soap/engine": "^2.13",
+                "php-soap/wsdl": "^1.12",
+                "php-soap/xml": "^1.8",
                 "psr/http-client-implementation": "^1.0",
                 "psr/http-factory-implementation": "^1.0",
                 "psr/http-message": "^1.0.1|^2.0",
@@ -1832,12 +1833,10 @@
                 "ext-soap": "*",
                 "guzzlehttp/guzzle": "^7.5",
                 "nyholm/psr7": "^1.5",
-                "php-cs-fixer/shim": "~3.88",
                 "php-http/mock-client": "^1.5",
-                "php-soap/engine-integration-tests": "^1.10",
+                "php-soap/engine-integration-tests": "^1.9",
                 "php-soap/ext-soap-engine": "^1.7",
-                "phpunit/phpunit": "~12.3",
-                "vimeo/psalm": "~6.13"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "autoload": {
@@ -1858,7 +1857,7 @@
             "description": "PSR-18 HTTP Client transport for SOAP",
             "support": {
                 "issues": "https://github.com/php-soap/psr18-transport/issues",
-                "source": "https://github.com/php-soap/psr18-transport/tree/1.8.0"
+                "source": "https://github.com/php-soap/psr18-transport/tree/1.7.0"
             },
             "funding": [
                 {
@@ -1866,37 +1865,36 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-10-20T10:43:29+00:00"
+            "time": "2024-10-25T08:43:55+00:00"
         },
         {
             "name": "php-soap/wsdl",
-            "version": "1.17.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-soap/wsdl.git",
-                "reference": "68f5d0f565a614e02c29e74cabf5a54d46d32dcf"
+                "reference": "0c5a1afe7ab648c227ed23a612b8c69509a22eb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-soap/wsdl/zipball/68f5d0f565a614e02c29e74cabf5a54d46d32dcf",
-                "reference": "68f5d0f565a614e02c29e74cabf5a54d46d32dcf",
+                "url": "https://api.github.com/repos/php-soap/wsdl/zipball/0c5a1afe7ab648c227ed23a612b8c69509a22eb4",
+                "reference": "0c5a1afe7ab648c227ed23a612b8c69509a22eb4",
                 "shasum": ""
             },
             "require": {
-                "azjezz/psl": "^3.0 || ^4.0 || ^5.0",
+                "azjezz/psl": "^3.0",
                 "ext-dom": "*",
                 "league/uri": "^7.0",
                 "league/uri-components": "^7.0",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "php-soap/xml": "^1.9",
-                "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php-soap/xml": "^1.8",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
                 "veewee/xml": "~3.0"
             },
             "require-dev": {
-                "php-cs-fixer/shim": "^3.88",
-                "phpunit/phpunit": "^12.3",
+                "phpunit/phpunit": "^10.5",
                 "psalm/plugin-symfony": "^5.0",
-                "vimeo/psalm": "^6.13"
+                "vimeo/psalm": "^5.26.0"
             },
             "bin": [
                 "bin/wsdl"
@@ -1920,7 +1918,7 @@
             "description": "Deals with WSDLs",
             "support": {
                 "issues": "https://github.com/php-soap/wsdl/issues",
-                "source": "https://github.com/php-soap/wsdl/tree/1.17.0"
+                "source": "https://github.com/php-soap/wsdl/tree/1.13.0"
             },
             "funding": [
                 {
@@ -1928,31 +1926,29 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-03-11T14:47:12+00:00"
+            "time": "2025-01-24T10:35:01+00:00"
         },
         {
             "name": "php-soap/xml",
-            "version": "1.9.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-soap/xml.git",
-                "reference": "c7f702640b97bcd608ef6bc2d2300d20775f0191"
+                "reference": "7aa20a359f67b18dc3bdb0f52c9065cc54492bc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-soap/xml/zipball/c7f702640b97bcd608ef6bc2d2300d20775f0191",
-                "reference": "c7f702640b97bcd608ef6bc2d2300d20775f0191",
+                "url": "https://api.github.com/repos/php-soap/xml/zipball/7aa20a359f67b18dc3bdb0f52c9065cc54492bc3",
+                "reference": "7aa20a359f67b18dc3bdb0f52c9065cc54492bc3",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "veewee/xml": "^3.4"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "veewee/xml": "^3.0"
             },
             "require-dev": {
-                "php-cs-fixer/shim": "^3.88",
-                "phpunit/phpunit": "~12.3",
-                "vimeo/psalm": "~6.13"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "autoload": {
@@ -1973,7 +1969,7 @@
             "description": "XML wrappers for SOAP",
             "support": {
                 "issues": "https://github.com/php-soap/xml/issues",
-                "source": "https://github.com/php-soap/xml/tree/1.9.0"
+                "source": "https://github.com/php-soap/xml/tree/1.8.0"
             },
             "funding": [
                 {
@@ -1981,7 +1977,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-10-20T09:03:44+00:00"
+            "time": "2024-10-25T06:49:38+00:00"
         },
         {
             "name": "psr/cache",
@@ -2659,16 +2655,16 @@
         },
         {
             "name": "revolt/event-loop",
-            "version": "v1.0.8",
+            "version": "v1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
                 "shasum": ""
             },
             "require": {
@@ -2678,7 +2674,7 @@
                 "ext-json": "*",
                 "jetbrains/phpstorm-stubs": "^2019.3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.15"
+                "psalm/phar": "6.16.*"
             },
             "type": "library",
             "extra": {
@@ -2725,9 +2721,9 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
             },
-            "time": "2025-08-27T21:33:23+00:00"
+            "time": "2026-05-16T17:55:38+00:00"
         },
         {
             "name": "spomky-labs/aes-key-wrap",
@@ -2807,40 +2803,41 @@
         },
         {
             "name": "spomky-labs/pki-framework",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Spomky-Labs/pki-framework.git",
-                "reference": "f0e9a548df4e3942886adc9b7830581a46334631"
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/f0e9a548df4e3942886adc9b7830581a46334631",
-                "reference": "f0e9a548df4e3942886adc9b7830581a46334631",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14",
+                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
                 "ext-mbstring": "*",
-                "php": ">=8.1"
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
             },
             "require-dev": {
                 "ekino/phpstan-banned-code": "^1.0|^2.0|^3.0",
                 "ext-gmp": "*",
                 "ext-openssl": "*",
-                "infection/infection": "^0.28|^0.29|^0.31",
+                "infection/infection": "^0.28|^0.29|^0.31|^0.32",
                 "php-parallel-lint/php-parallel-lint": "^1.3",
                 "phpstan/extension-installer": "^1.3|^2.0",
                 "phpstan/phpstan": "^1.8|^2.0",
                 "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
                 "phpstan/phpstan-phpunit": "^1.1|^2.0",
                 "phpstan/phpstan-strict-rules": "^1.3|^2.0",
-                "phpunit/phpunit": "^10.1|^11.0|^12.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0|^13.0",
                 "rector/rector": "^1.0|^2.0",
                 "roave/security-advisories": "dev-latest",
                 "symfony/string": "^6.4|^7.0|^8.0",
                 "symfony/var-dumper": "^6.4|^7.0|^8.0",
-                "symplify/easy-coding-standard": "^12.0"
+                "symplify/easy-coding-standard": "^12.0|^13.0"
             },
             "suggest": {
                 "ext-bcmath": "For better performance (or GMP)",
@@ -2900,7 +2897,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
-                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.4.1"
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.4.2"
             },
             "funding": [
                 {
@@ -2912,20 +2909,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-12-20T12:57:40+00:00"
+            "time": "2026-03-23T22:56:56+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.7",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "6c17162555bfb58957a55bb0e43e00035b6ae3d5"
+                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/6c17162555bfb58957a55bb0e43e00035b6ae3d5",
-                "reference": "6c17162555bfb58957a55bb0e43e00035b6ae3d5",
+                "url": "https://api.github.com/repos/symfony/config/zipball/d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
+                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
                 "shasum": ""
             },
             "require": {
@@ -2971,7 +2968,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.7"
+                "source": "https://github.com/symfony/config/tree/v7.4.10"
             },
             "funding": [
                 {
@@ -2991,7 +2988,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T10:41:14+00:00"
+            "time": "2026-05-03T14:20:49+00:00"
         },
         {
             "name": "symfony/console",
@@ -3094,16 +3091,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.7",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db"
+                "reference": "4eb0d9dfa9d4f7c59216baf49b3ed6b1fb72293d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db",
-                "reference": "0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/4eb0d9dfa9d4f7c59216baf49b3ed6b1fb72293d",
+                "reference": "4eb0d9dfa9d4f7c59216baf49b3ed6b1fb72293d",
                 "shasum": ""
             },
             "require": {
@@ -3154,7 +3151,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.7"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.10"
             },
             "funding": [
                 {
@@ -3174,20 +3171,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-03T07:48:48+00:00"
+            "time": "2026-05-06T11:55:30+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -3200,7 +3197,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3225,7 +3222,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3237,24 +3234,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8"
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8da531f364ddfee53e36092a7eebbbd0b775f6b8",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
                 "shasum": ""
             },
             "require": {
@@ -3303,7 +3304,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.4"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -3323,20 +3324,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-20T16:42:42+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.4",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746"
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/dc2c0eba1af673e736bb851d747d266108aea746",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
                 "shasum": ""
             },
             "require": {
@@ -3388,7 +3389,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.4"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -3408,20 +3409,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T11:45:34+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -3435,7 +3436,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3468,7 +3469,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3480,24 +3481,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.6",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3ebc794fa5315e59fd122561623c2e2e4280538e"
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3ebc794fa5315e59fd122561623c2e2e4280538e",
-                "reference": "3ebc794fa5315e59fd122561623c2e2e4280538e",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
                 "shasum": ""
             },
             "require": {
@@ -3534,7 +3539,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.6"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -3554,20 +3559,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.7",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "1010624285470eb60e88ed10035102c75b4ea6af"
+                "reference": "7e941c6abf4e3bf7dca160bf0e11ef36a9f832f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/1010624285470eb60e88ed10035102c75b4ea6af",
-                "reference": "1010624285470eb60e88ed10035102c75b4ea6af",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/7e941c6abf4e3bf7dca160bf0e11ef36a9f832f6",
+                "reference": "7e941c6abf4e3bf7dca160bf0e11ef36a9f832f6",
                 "shasum": ""
             },
             "require": {
@@ -3635,7 +3640,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.7"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -3655,20 +3660,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-05T11:16:58+00:00"
+            "time": "2026-04-29T13:25:15+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
                 "shasum": ""
             },
             "require": {
@@ -3681,7 +3686,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3717,7 +3722,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3729,24 +3734,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T11:18:49+00:00"
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81"
+                "reference": "9381209597ec66c25be154cbf2289076e64d1eab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
-                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9381209597ec66c25be154cbf2289076e64d1eab",
+                "reference": "9381209597ec66c25be154cbf2289076e64d1eab",
                 "shasum": ""
             },
             "require": {
@@ -3795,7 +3804,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.7"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -3815,20 +3824,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T13:15:18+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.35",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "ece1a0da7745a5243683f178155c0412c92691eb"
+                "reference": "41dff5c3d03b3fa20947c552c5f6ba74ca43fa28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/ece1a0da7745a5243683f178155c0412c92691eb",
-                "reference": "ece1a0da7745a5243683f178155c0412c92691eb",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/41dff5c3d03b3fa20947c552c5f6ba74ca43fa28",
+                "reference": "41dff5c3d03b3fa20947c552c5f6ba74ca43fa28",
                 "shasum": ""
             },
             "require": {
@@ -3913,7 +3922,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.35"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -3933,20 +3942,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T16:28:07+00:00"
+            "time": "2026-05-20T08:55:59+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.4.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "b38026df55197f9e39a44f3215788edf83187b80"
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b38026df55197f9e39a44f3215788edf83187b80",
-                "reference": "b38026df55197f9e39a44f3215788edf83187b80",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
                 "shasum": ""
             },
             "require": {
@@ -3984,7 +3993,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.4.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4004,20 +4013,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:39:26+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -4067,7 +4076,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4087,20 +4096,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
                 "shasum": ""
             },
             "require": {
@@ -4149,7 +4158,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4169,11 +4178,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-04-26T13:13:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -4234,7 +4243,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4258,16 +4267,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -4319,7 +4328,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4339,11 +4348,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -4399,7 +4408,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4423,16 +4432,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -4483,7 +4492,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4503,20 +4512,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php82",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php82.git",
-                "reference": "5d2ed36f7734637dacc025f179698031951b1692"
+                "reference": "34808efe3e68f69685796f7c253a2f1d8ea9df59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/5d2ed36f7734637dacc025f179698031951b1692",
-                "reference": "5d2ed36f7734637dacc025f179698031951b1692",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/34808efe3e68f69685796f7c253a2f1d8ea9df59",
+                "reference": "34808efe3e68f69685796f7c253a2f1d8ea9df59",
                 "shasum": ""
             },
             "require": {
@@ -4563,7 +4572,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php82/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4583,20 +4592,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
                 "shasum": ""
             },
             "require": {
@@ -4643,7 +4652,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4663,20 +4672,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91"
+                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/fcfa4973a9917cef23f2e38774da74a2b7d115ee",
+                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee",
                 "shasum": ""
             },
             "require": {
@@ -4723,7 +4732,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4743,20 +4752,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-23T16:12:55+00:00"
+            "time": "2026-04-26T13:10:57+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -4806,7 +4815,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4826,20 +4835,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -4857,7 +4866,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -4893,7 +4902,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -4913,20 +4922,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.34",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432"
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/2adaf4106f2ef4c67271971bde6d3fe0a6936432",
-                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432",
+                "url": "https://api.github.com/repos/symfony/string/zipball/62e3c927de664edadb5bef260987eb047a17a113",
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113",
                 "shasum": ""
             },
             "require": {
@@ -4982,7 +4991,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.34"
+                "source": "https://github.com/symfony/string/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -5002,7 +5011,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-08T20:44:54+00:00"
+            "time": "2026-05-12T11:44:19+00:00"
         },
         {
             "name": "symfony/uid",
@@ -5084,16 +5093,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.4.32",
+            "version": "v6.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "131fc9915e0343052af5ed5040401b481ca192aa"
+                "reference": "7c8ad9ce4faf6c8a99948e70ce02b601a0439782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/131fc9915e0343052af5ed5040401b481ca192aa",
-                "reference": "131fc9915e0343052af5ed5040401b481ca192aa",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/7c8ad9ce4faf6c8a99948e70ce02b601a0439782",
+                "reference": "7c8ad9ce4faf6c8a99948e70ce02b601a0439782",
                 "shasum": ""
             },
             "require": {
@@ -5148,7 +5157,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.4.32"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.36"
             },
             "funding": [
                 {
@@ -5168,20 +5177,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-01T13:34:06+00:00"
+            "time": "2026-03-30T15:36:00+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.4.0",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f"
+                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/03a60f169c79a28513a78c967316fbc8bf17816f",
-                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/22e03a49c95ef054a43601cd159b222bfab1c701",
+                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701",
                 "shasum": ""
             },
             "require": {
@@ -5229,7 +5238,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.4.0"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -5249,20 +5258,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T10:15:23+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.34",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7bca30dabed7900a08c5ad4f1d6483f881a64d0f"
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7bca30dabed7900a08c5ad4f1d6483f881a64d0f",
-                "reference": "7bca30dabed7900a08c5ad4f1d6483f881a64d0f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/68dcd1f1602dac9d9221e25729683e0ce8733f3b",
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b",
                 "shasum": ""
             },
             "require": {
@@ -5305,7 +5314,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.34"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -5325,20 +5334,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T18:32:11+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.23.0",
+            "version": "v3.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9"
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
                 "shasum": ""
             },
             "require": {
@@ -5348,7 +5357,8 @@
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^2.0",
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
                 "psr/container": "^1.0|^2.0",
                 "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
@@ -5392,7 +5402,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.23.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
             },
             "funding": [
                 {
@@ -5404,41 +5414,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-23T21:00:41+00:00"
+            "time": "2026-05-20T07:31:59+00:00"
         },
         {
             "name": "veewee/xml",
-            "version": "3.5.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/veewee/xml.git",
-                "reference": "05d8539c3c166cbf872b38fa1f0ff00e3a410959"
+                "reference": "6ae6b154d64d427bf1b2840b40c23131eb1feba5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/veewee/xml/zipball/05d8539c3c166cbf872b38fa1f0ff00e3a410959",
-                "reference": "05d8539c3c166cbf872b38fa1f0ff00e3a410959",
+                "url": "https://api.github.com/repos/veewee/xml/zipball/6ae6b154d64d427bf1b2840b40c23131eb1feba5",
+                "reference": "6ae6b154d64d427bf1b2840b40c23131eb1feba5",
                 "shasum": ""
             },
             "require": {
-                "azjezz/psl": "^3.0 || ^4.0 || ^5.0",
+                "azjezz/psl": "^3.0",
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xml": "*",
                 "ext-xmlreader": "*",
                 "ext-xmlwriter": "*",
                 "ext-xsl": "*",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
                 "webmozart/assert": "^1.10"
             },
             "require-dev": {
-                "infection/infection": "^0.31.7",
-                "php-cs-fixer/shim": "~3.88",
                 "php-standard-library/psalm-plugin": "^2.2",
-                "phpunit/phpunit": "~12.3",
-                "symfony/finder": "^6.1 || ^7.0",
+                "symfony/finder": "^6.1",
                 "veewee/composer-run-parallel": "^1.0.0",
-                "vimeo/psalm": "~6.13"
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -5476,7 +5483,7 @@
             ],
             "support": {
                 "issues": "https://github.com/veewee/xml/issues",
-                "source": "https://github.com/veewee/xml/tree/3.5.0"
+                "source": "https://github.com/veewee/xml/tree/3.3.0"
             },
             "funding": [
                 {
@@ -5484,7 +5491,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-11T13:15:00+00:00"
+            "time": "2024-10-25T06:12:30+00:00"
         },
         {
             "name": "web-token/jwt-framework",
@@ -6028,24 +6035,24 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.5.9",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "edf364cefe8c43501e21e88110aac10b284c3c9f"
+                "reference": "5ecd0cb4177696f9fd48f1605dda81db3dee7889"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/edf364cefe8c43501e21e88110aac10b284c3c9f",
-                "reference": "edf364cefe8c43501e21e88110aac10b284c3c9f",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/5ecd0cb4177696f9fd48f1605dda81db3dee7889",
+                "reference": "5ecd0cb4177696f9fd48f1605dda81db3dee7889",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.11",
-                "symfony/phpunit-bridge": "^3 || ^7"
+                "symfony/phpunit-bridge": "^6.4.25 || ^7.3.3 || ^8.0"
             },
             "type": "library",
             "extra": {
@@ -6088,7 +6095,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/spdx-licenses/issues",
-                "source": "https://github.com/composer/spdx-licenses/tree/1.5.9"
+                "source": "https://github.com/composer/spdx-licenses/tree/1.6.0"
             },
             "funding": [
                 {
@@ -6098,13 +6105,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-05-12T21:07:07+00:00"
+            "time": "2026-04-08T20:18:39+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -6390,16 +6393,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -6482,7 +6485,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -6808,16 +6811,16 @@
         },
         {
             "name": "kubawerlos/php-cs-fixer-custom-fixers",
-            "version": "v3.36.1",
+            "version": "v3.37.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
-                "reference": "ec9776e80f5ea9bf0d8ec16d662e431bfab19a24"
+                "reference": "678df979ce743466b42ddb6eea46b3f4c9a7bade"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/ec9776e80f5ea9bf0d8ec16d662e431bfab19a24",
-                "reference": "ec9776e80f5ea9bf0d8ec16d662e431bfab19a24",
+                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/678df979ce743466b42ddb6eea46b3f4c9a7bade",
+                "reference": "678df979ce743466b42ddb6eea46b3f4c9a7bade",
                 "shasum": ""
             },
             "require": {
@@ -6827,7 +6830,7 @@
                 "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6.24 || ^10.5.51 || ^11.5.44"
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55"
             },
             "type": "library",
             "autoload": {
@@ -6848,7 +6851,7 @@
             "description": "A set of custom fixers for PHP CS Fixer",
             "support": {
                 "issues": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues",
-                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.36.1"
+                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.37.2"
             },
             "funding": [
                 {
@@ -6856,7 +6859,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-07T11:35:13+00:00"
+            "time": "2026-05-12T16:22:19+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -6971,16 +6974,16 @@
         },
         {
             "name": "nextcloud/coding-standard",
-            "version": "v1.4.0",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/coding-standard.git",
-                "reference": "8e06808c1423e9208d63d1bd205b9a38bd400011"
+                "reference": "80547a93236fbb9c783e05f0f0899043851b0dba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/8e06808c1423e9208d63d1bd205b9a38bd400011",
-                "reference": "8e06808c1423e9208d63d1bd205b9a38bd400011",
+                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/80547a93236fbb9c783e05f0f0899043851b0dba",
+                "reference": "80547a93236fbb9c783e05f0f0899043851b0dba",
                 "shasum": ""
             },
             "require": {
@@ -7010,9 +7013,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nextcloud/coding-standard/issues",
-                "source": "https://github.com/nextcloud/coding-standard/tree/v1.4.0"
+                "source": "https://github.com/nextcloud/coding-standard/tree/v1.5.0"
             },
-            "time": "2025-06-19T12:27:27+00:00"
+            "time": "2026-05-19T18:30:09+00:00"
         },
         {
             "name": "nextcloud/ocp",
@@ -7020,12 +7023,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6e97cdf621ae674246fec9efc7d12c9130346a60"
+                "reference": "54c7a351d557960075f64014d4bfa451e86f3236"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6e97cdf621ae674246fec9efc7d12c9130346a60",
-                "reference": "6e97cdf621ae674246fec9efc7d12c9130346a60",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/54c7a351d557960075f64014d4bfa451e86f3236",
+                "reference": "54c7a351d557960075f64014d4bfa451e86f3236",
                 "shasum": ""
             },
             "require": {
@@ -7056,7 +7059,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable29"
             },
-            "time": "2026-02-20T01:07:13+00:00"
+            "time": "2026-04-28T01:53:23+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -7548,16 +7551,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.94.2",
+            "version": "v3.95.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "80fd29f44a736136a2f05bae5464816a444b91d1"
+                "reference": "319bd80c8db64ab5f7b79a19178299045bdb9957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/80fd29f44a736136a2f05bae5464816a444b91d1",
-                "reference": "80fd29f44a736136a2f05bae5464816a444b91d1",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/319bd80c8db64ab5f7b79a19178299045bdb9957",
+                "reference": "319bd80c8db64ab5f7b79a19178299045bdb9957",
                 "shasum": ""
             },
             "require": {
@@ -7594,9 +7597,9 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.94.2"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.95.2"
             },
-            "time": "2026-02-20T16:14:17+00:00"
+            "time": "2026-05-15T09:21:09+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -7828,16 +7831,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.6",
+            "version": "5.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8"
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/5cee1d3dfc2d2aa6599834520911d246f656bcb8",
-                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
                 "shasum": ""
             },
             "require": {
@@ -7886,9 +7889,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.6"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
             },
-            "time": "2025-12-22T21:13:58+00:00"
+            "time": "2026-03-18T20:47:46+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -8692,18 +8695,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "ed005b7ebb25c82bb29af88d634357073f3b7a33"
+                "reference": "d0e81e9fd3e2a978df5d2af0922cba0b872595fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/ed005b7ebb25c82bb29af88d634357073f3b7a33",
-                "reference": "ed005b7ebb25c82bb29af88d634357073f3b7a33",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/d0e81e9fd3e2a978df5d2af0922cba0b872595fc",
+                "reference": "d0e81e9fd3e2a978df5d2af0922cba0b872595fc",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adaptcms/adaptcms": "<=1.3",
-                "admidio/admidio": "<5.0.6",
+                "admidio/admidio": "<=5.0.8",
                 "adodb/adodb-php": "<=5.22.9",
                 "aheinze/cockpit": "<2.2",
                 "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.07.2",
@@ -8720,6 +8723,7 @@
                 "alextselegidis/easyappointments": "<=1.5.2",
                 "alexusmai/laravel-file-manager": "<=3.3.1",
                 "algolia/algoliasearch-magento-2": "<=3.16.1|>=3.17.0.0-beta1,<=3.17.1",
+                "almirhodzic/nova-toggle-5": "<1.3",
                 "alt-design/alt-redirect": "<1.6.4",
                 "altcha-org/altcha": "<1.3.1",
                 "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
@@ -8745,28 +8749,30 @@
                 "athlon1600/php-proxy": "<=5.1",
                 "athlon1600/php-proxy-app": "<=3",
                 "athlon1600/youtube-downloader": "<=4",
+                "aureuserp/aureuserp": "<1.3.0.0-beta1",
                 "austintoddj/canvas": "<=3.4.2",
-                "auth0/auth0-php": ">=3.3,<8.18",
-                "auth0/login": "<7.20",
-                "auth0/symfony": "<=5.5",
-                "auth0/wordpress": "<=5.4",
+                "auth0/auth0-php": ">=3.3,<=8.18",
+                "auth0/login": "<=7.20",
+                "auth0/symfony": "<=5.7",
+                "auth0/wordpress": "<=5.5",
                 "automad/automad": "<2.0.0.0-alpha5",
                 "automattic/jetpack": "<9.8",
                 "awesome-support/awesome-support": "<=6.0.7",
-                "aws/aws-sdk-php": "<3.368",
-                "azuracast/azuracast": "<=0.23.3",
+                "aws/aws-sdk-php": "<=3.371.3",
+                "ayacoo/redirect-tab": "<2.1.2|>=3,<3.1.7|>=4,<4.0.5",
+                "azuracast/azuracast": "<=0.23.5",
                 "b13/seo_basics": "<0.8.2",
                 "backdrop/backdrop": "<=1.32",
                 "backpack/crud": "<3.4.9",
                 "backpack/filemanager": "<2.0.2|>=3,<3.0.9",
                 "bacula-web/bacula-web": "<9.7.1",
                 "badaso/core": "<=2.9.11",
-                "bagisto/bagisto": "<2.3.10",
+                "bagisto/bagisto": "<=2.3.15",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
                 "barryvdh/laravel-translation-manager": "<0.6.8",
                 "barzahlen/barzahlen-php": "<2.0.1",
-                "baserproject/basercms": "<=5.1.1",
+                "baserproject/basercms": "<=5.2.2",
                 "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
                 "bbpress/bbpress": "<2.6.5",
                 "bcit-ci/codeigniter": "<3.1.3",
@@ -8809,13 +8815,13 @@
                 "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
                 "chriskacerguis/codeigniter-restserver": "<=2.7.1",
                 "chrome-php/chrome": "<1.14",
-                "ci4-cms-erp/ci4ms": "<0.28.5",
+                "ci4-cms-erp/ci4ms": "<=0.31.8",
                 "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
                 "ckeditor/ckeditor": "<4.25",
                 "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
                 "co-stack/fal_sftp": "<0.2.6",
-                "cockpit-hq/cockpit": "<2.11.4",
-                "code16/sharp": "<9.11.1",
+                "cockpit-hq/cockpit": "<2.14",
+                "code16/sharp": "<9.22",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.10",
                 "codeigniter4/framework": "<4.6.2",
@@ -8825,7 +8831,7 @@
                 "codingms/modules": "<4.3.11|>=5,<5.7.4|>=6,<6.4.2|>=7,<7.5.5",
                 "commerceteam/commerce": ">=0.9.6,<0.9.9",
                 "components/jquery": ">=1.0.3,<3.5",
-                "composer/composer": "<1.10.27|>=2,<2.2.26|>=2.3,<2.9.3",
+                "composer/composer": "<2.2.28|>=2.3,<2.9.8",
                 "concrete5/concrete5": "<9.4.8",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
@@ -8835,15 +8841,19 @@
                 "contao/core-bundle": "<4.13.57|>=5,<5.3.42|>=5.4,<5.6.5",
                 "contao/listing-bundle": ">=3,<=3.5.30|>=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
-                "coreshop/core-shop": "<4.1.9",
+                "coreshop/core-shop": "<4.1.9|==5",
                 "corveda/phpsandbox": "<1.3.5",
                 "cosenary/instagram": "<=2.3",
                 "couleurcitron/tarteaucitron-wp": "<0.3",
-                "cpsit/typo3-mailqueue": "<0.4.3|>=0.5,<0.5.1",
-                "craftcms/cms": "<=4.17.3|>=5,<=5.9.8",
+                "cpsit/typo3-mailqueue": "<0.4.5|>=0.5,<0.5.2",
+                "craftcms/aws-s3": ">=2.0.2,<=2.2.4",
+                "craftcms/azure-blob": ">=2.0.0.0-beta1,<=2.1",
+                "craftcms/cms": "<4.17.12|>=5,<5.9.18",
                 "craftcms/commerce": ">=4,<4.11|>=5,<5.6",
                 "craftcms/composer": ">=4.0.0.0-RC1-dev,<=4.10|>=5.0.0.0-RC1-dev,<=5.5.1",
                 "craftcms/craft": ">=3.5,<=4.16.17|>=5.0.0.0-RC1-dev,<=5.8.21",
+                "craftcms/google-cloud": ">=2.0.0.0-beta1,<=2.2",
+                "craftcms/webhooks": ">=3,<3.2",
                 "croogo/croogo": "<=4.0.7",
                 "cuyz/valinor": "<0.12",
                 "czim/file-handling": "<1.5|>=2,<2.3",
@@ -8857,11 +8867,12 @@
                 "david-garcia/phpwhois": "<=4.3.1",
                 "dbrisinajumi/d2files": "<1",
                 "dcat/laravel-admin": "<=2.1.3|==2.2.0.0-beta|==2.2.2.0-beta",
+                "dedoc/scramble": ">=0.13.2,<0.13.22",
                 "derhansen/fe_change_pwd": "<2.0.5|>=3,<3.0.3",
                 "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1|>=7,<7.4",
                 "desperado/xml-bundle": "<=0.1.7",
                 "dev-lancer/minecraft-motd-parser": "<=1.0.5",
-                "devcode-it/openstamanager": "<=2.9.8",
+                "devcode-it/openstamanager": "<=2.10.1",
                 "devgroup/dotplant": "<2020.09.14-dev",
                 "digimix/wp-svg-upload": "<=1",
                 "directmailteam/direct-mail": "<6.0.3|>=7,<7.0.3|>=8,<9.5.2",
@@ -8878,9 +8889,10 @@
                 "doctrine/mongodb-odm": "<1.0.2",
                 "doctrine/mongodb-odm-bundle": "<3.0.1",
                 "doctrine/orm": ">=1,<1.2.4|>=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
-                "dolibarr/dolibarr": "<21.0.3",
+                "dolibarr/dolibarr": "<=23.0.2",
                 "dompdf/dompdf": "<2.0.4",
                 "doublethreedigital/guest-entries": "<3.1.2",
+                "dreamfactory/df-core": "<1.0.4",
                 "drupal-pattern-lab/unified-twig-extensions": "<=0.1",
                 "drupal/access_code": "<2.0.5",
                 "drupal/acquia_dam": "<1.1.5",
@@ -8956,7 +8968,7 @@
                 "ezsystems/repository-forms": ">=2.3,<2.3.2.1-dev|>=2.5,<2.5.15",
                 "ezyang/htmlpurifier": "<=4.2",
                 "facade/ignition": "<1.16.15|>=2,<2.4.2|>=2.5,<2.5.2",
-                "facturascripts/facturascripts": "<2025.81",
+                "facturascripts/facturascripts": "<=2025.92|>=2026,<=2026.1",
                 "fastly/magento2": "<1.2.26",
                 "feehi/cms": "<=2.1.1",
                 "feehi/feehicms": "<=2.1.1",
@@ -8964,7 +8976,7 @@
                 "filament/actions": ">=3.2,<3.2.123",
                 "filament/filament": ">=4,<4.3.1",
                 "filament/infolists": ">=3,<3.2.115",
-                "filament/tables": ">=3,<3.2.115",
+                "filament/tables": ">=3,<3.2.115|>=4,<4.8.5|>=5,<5.3.5",
                 "filegator/filegator": "<7.8",
                 "filp/whoops": "<2.1.13",
                 "fineuploader/php-traditional-server": "<=1.2.2",
@@ -8972,13 +8984,14 @@
                 "fisharebest/webtrees": "<=2.1.18",
                 "fixpunkt/fp-masterquiz": "<2.2.1|>=3,<3.5.2",
                 "fixpunkt/fp-newsletter": "<1.1.1|>=1.2,<2.1.2|>=2.2,<3.2.6",
-                "flarum/core": "<1.8.10",
+                "flarum/core": "<=1.8.15|>=2.0.0.0-beta1,<=2.0.0.0-beta8",
                 "flarum/flarum": "<0.1.0.0-beta8",
                 "flarum/framework": "<1.8.10",
                 "flarum/mentions": "<1.6.3",
                 "flarum/nicknames": "<1.8.3",
                 "flarum/sticky": ">=0.1.0.0-beta14,<=0.1.0.0-beta15",
                 "flarum/tags": "<=0.1.0.0-beta13",
+                "flightphp/core": "<3.18.1",
                 "floriangaerber/magnesium": "<0.3.1",
                 "fluidtypo3/vhs": "<5.1.1",
                 "fof/byobu": ">=0.3.0.0-beta2,<1.1.7",
@@ -8999,17 +9012,19 @@
                 "friendsoftypo3/openid": ">=4.5,<4.5.31|>=4.7,<4.7.16|>=6,<6.0.11|>=6.1,<6.1.6",
                 "froala/wysiwyg-editor": "<=4.3",
                 "frosh/adminer-platform": "<2.2.1",
-                "froxlor/froxlor": "<=2.3.3",
+                "froxlor/froxlor": "<2.3.6",
                 "frozennode/administrator": "<=5.0.12",
                 "fuel/core": "<1.8.1",
-                "funadmin/funadmin": "<=7.1.0.0-RC4",
+                "funadmin/funadmin": "<=7.1.0.0-RC6",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
-                "georgringer/news": "<1.3.3",
+                "georgringer/news": "<11.4.4|>=12,<12.3.2|>=13,<13.0.2|>=14,<14.0.3",
                 "geshi/geshi": "<=1.0.9.1",
                 "getformwork/formwork": "<=2.3.3",
-                "getgrav/grav": "<1.11.0.0-beta1",
-                "getkirby/cms": "<3.9.8.3-dev|>=3.10,<3.10.1.2-dev|>=4,<4.7.1|>=5,<=5.2.1",
+                "getgrav/grav": "<=2.0.0.0-RC1",
+                "getgrav/grav-plugin-api": "<1.0.0.0-beta15",
+                "getgrav/grav-plugin-form": "<9.1",
+                "getkirby/cms": "<4.9|>=5,<5.4",
                 "getkirby/kirby": "<3.9.8.3-dev|>=3.10,<3.10.1.2-dev|>=4,<4.7.1",
                 "getkirby/panel": "<2.5.14",
                 "getkirby/starterkit": "<=3.7.0.2",
@@ -9018,7 +9033,8 @@
                 "globalpayments/php-sdk": "<2",
                 "goalgorilla/open_social": "<12.3.11|>=12.4,<12.4.10|>=13.0.0.0-alpha1,<13.0.0.0-alpha11",
                 "gogentooss/samlbase": "<1.2.7",
-                "google/protobuf": "<3.4",
+                "goodoneuz/pay-uz": "<=2.2.24",
+                "google/protobuf": "<4.33.6",
                 "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
                 "gp247/core": "<1.1.24",
                 "gree/jose": "<2.2.1",
@@ -9038,6 +9054,7 @@
                 "hjue/justwriting": "<=1",
                 "hov/jobfair": "<1.0.13|>=2,<2.0.2",
                 "httpsoft/http-message": "<1.0.12",
+                "hybridauth/hybridauth": "<=3.12.2",
                 "hyn/multi-tenant": ">=5.6,<5.7.2",
                 "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.25|>=5,<5.0.3",
                 "ibexa/admin-ui-assets": ">=4.6.0.0-alpha1,<4.6.21",
@@ -9066,10 +9083,13 @@
                 "innologi/typo3-appointments": "<2.0.6",
                 "intelliants/subrion": "<4.2.2",
                 "inter-mediator/inter-mediator": "==5.5",
-                "ipl/web": "<0.10.1",
+                "intercom/intercom-php": "==5.0.2",
+                "invoiceninja/invoiceninja": "<5.13.4",
+                "ipl/web": "<=0.13",
                 "islandora/crayfish": "<4.1",
                 "islandora/islandora": ">=2,<2.4.1",
                 "ivankristianto/phpwhois": "<=4.3",
+                "j0k3r/graby": "<=2.5",
                 "jackalope/jackalope-doctrine-dbal": "<1.7.4",
                 "jambagecom/div2007": "<0.10.2",
                 "james-heinrich/getid3": "<1.9.21",
@@ -9077,7 +9097,9 @@
                 "jasig/phpcas": "<1.3.3",
                 "jbartels/wec-map": "<3.0.3",
                 "jcbrand/converse.js": "<3.3.3",
+                "joedolson/my-calendar": "<3.7.7",
                 "joelbutcher/socialstream": "<5.6|>=6,<6.2",
+                "johnbillion/query-monitor": "<3.20.4",
                 "johnbillion/wp-crontrol": "<1.16.2|>=1.17,<1.19.2",
                 "joomla/application": "<1.0.13",
                 "joomla/archive": "<1.1.12|>=2,<2.0.1",
@@ -9095,20 +9117,23 @@
                 "juzaweb/cms": "<=3.4.2",
                 "jweiland/events2": "<8.3.8|>=9,<9.0.6",
                 "jweiland/kk-downloader": "<1.2.2",
+                "kantorge/yaffa": "<=2",
                 "kazist/phpwhois": "<=4.2.6",
+                "kelvinmo/simplejwt": "<=1.1",
                 "kelvinmo/simplexrd": "<3.1.1",
                 "kevinpapst/kimai2": "<1.16.7",
-                "khodakhah/nodcms": "<=3",
-                "kimai/kimai": "<=2.50",
+                "khodakhah/nodcms": "<=3.4.1",
+                "kimai/kimai": "<=2.55",
                 "kitodo/presentation": "<3.2.3|>=3.3,<3.3.4",
                 "klaviyo/magento2-extension": ">=1,<3",
                 "knplabs/knp-snappy": "<=1.4.2",
                 "kohana/core": "<3.3.3",
                 "koillection/koillection": "<1.6.12",
-                "krayin/laravel-crm": "<=1.3",
+                "krayin/laravel-crm": "<=2.2",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
                 "kumbiaphp/kumbiapp": "<=1.1.1",
                 "la-haute-societe/tcpdf": "<6.2.22",
+                "laktak/hjson": "<2.3",
                 "laminas/laminas-diactoros": "<2.18.1|==2.19|==2.20|==2.21|==2.22|==2.23|>=2.24,<2.24.2|>=2.25,<2.25.2",
                 "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
                 "laminas/laminas-http": "<2.14.2",
@@ -9117,6 +9142,7 @@
                 "laravel/fortify": "<1.11.1",
                 "laravel/framework": "<10.48.29|>=11,<11.44.1|>=12,<12.1.1",
                 "laravel/laravel": ">=5.4,<5.4.22",
+                "laravel/passport": ">=13,<13.7.1",
                 "laravel/pulse": "<1.3.1",
                 "laravel/reverb": "<1.7",
                 "laravel/socialite": ">=1,<2.0.10",
@@ -9124,13 +9150,13 @@
                 "lavalite/cms": "<=10.1",
                 "lavitto/typo3-form-to-database": "<2.2.5|>=3,<3.2.2|>=4,<4.2.3|>=5,<5.0.2",
                 "lcobucci/jwt": ">=3.4,<3.4.6|>=4,<4.0.4|>=4.1,<4.1.5",
-                "league/commonmark": "<=2.8",
+                "league/commonmark": "<=2.8.1",
                 "league/flysystem": "<1.1.4|>=2,<2.1.1",
                 "league/oauth2-server": ">=8.3.2,<8.4.2|>=8.5,<8.5.3",
                 "leantime/leantime": "<3.3",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
                 "libreform/libreform": ">=2,<=2.0.8",
-                "librenms/librenms": "<26.2",
+                "librenms/librenms": "<26.3",
                 "liftkit/database": "<2.13.2",
                 "lightsaml/lightsaml": "<1.3.5",
                 "limesurvey/limesurvey": "<6.15.4",
@@ -9156,8 +9182,9 @@
                 "maikuolan/phpmussel": ">=1,<1.6",
                 "mainwp/mainwp": "<=4.4.3.3",
                 "manogi/nova-tiptap": "<=3.2.6",
-                "mantisbt/mantisbt": "<2.27.2",
+                "mantisbt/mantisbt": "<2.28.2",
                 "marcwillmann/turn": "<0.3.3",
+                "markhuot/craftql": "<=1.3.7",
                 "marshmallow/nova-tiptap": "<5.7",
                 "matomo/matomo": "<1.11",
                 "matyhtf/framework": "<3.0.6",
@@ -9165,6 +9192,7 @@
                 "mautic/core-lib": ">=1.0.0.0-beta,<4.4.13|>=5.0.0.0-alpha,<5.1.1",
                 "mautic/grapes-js-builder-bundle": ">=4,<4.4.18|>=5,<5.2.9|>=6,<6.0.7",
                 "maximebf/debugbar": "<1.19",
+                "mckenziearts/livewire-markdown-editor": "<1.3",
                 "mdanter/ecc": "<2",
                 "mediawiki/abuse-filter": "<1.39.9|>=1.40,<1.41.3|>=1.42,<1.42.2",
                 "mediawiki/cargo": "<3.8.3",
@@ -9187,7 +9215,9 @@
                 "mikehaertl/php-shellcommand": "<1.6.1",
                 "mineadmin/mineadmin": "<=3.0.9",
                 "miniorange/miniorange-saml": "<1.4.3",
+                "miraheze/ts-portal": "<=33",
                 "mittwald/typo3_forum": "<1.2.1",
+                "mix/mix": ">=2,<=2.2.17",
                 "mobiledetect/mobiledetectlib": "<2.8.32",
                 "modx/revolution": "<=3.1",
                 "mojo42/jirafeau": "<4.4",
@@ -9207,6 +9237,7 @@
                 "munkireport/softwareupdate": "<1.6",
                 "mustache/mustache": ">=2,<2.14.1",
                 "mwdelaney/wp-enable-svg": "<=0.2",
+                "nabeel/phpvms": "<7.0.6",
                 "namshi/jose": "<2.2",
                 "nasirkhan/laravel-starter": "<11.11",
                 "nategood/httpful": "<1",
@@ -9237,9 +9268,9 @@
                 "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
                 "october/backend": "<1.1.2",
                 "october/cms": "<1.0.469|==1.0.469|==1.0.471|==1.1.1",
-                "october/october": "<3.7.5",
-                "october/rain": "<1.0.472|>=1.1,<1.1.2",
-                "october/system": "<=3.7.12|>=4,<=4.0.11",
+                "october/october": "<3.7.14|>=4,<4.1.10",
+                "october/rain": "<=3.7.13|>=4,<=4.1.9",
+                "october/system": "<3.7.16|>=4,<4.1.16",
                 "oliverklee/phpunit": "<3.5.15",
                 "omeka/omeka-s": "<4.0.3",
                 "onelogin/php-saml": "<2.21.1|>=3,<3.8.1|>=4,<4.3.1",
@@ -9247,9 +9278,9 @@
                 "open-web-analytics/open-web-analytics": "<1.8.1",
                 "opencart/opencart": ">=0",
                 "openid/php-openid": "<2.3",
-                "openmage/magento-lts": "<20.16.1",
+                "openmage/magento-lts": "<=20.17",
                 "opensolutions/vimbadmin": "<=3.0.15",
-                "opensource-workshop/connect-cms": "<1.8.7|>=2,<2.4.7",
+                "opensource-workshop/connect-cms": "<1.41.1|>=2,<2.41.1",
                 "orchid/platform": ">=8,<14.43",
                 "oro/calendar-bundle": ">=4.2,<=4.2.6|>=5,<=5.0.6|>=5.1,<5.1.1",
                 "oro/commerce": ">=4.1,<5.0.11|>=5.1,<5.1.1",
@@ -9290,16 +9321,16 @@
                 "phpmailer/phpmailer": "<6.5",
                 "phpmussel/phpmussel": ">=1,<1.6",
                 "phpmyadmin/phpmyadmin": "<5.2.2",
-                "phpmyfaq/phpmyfaq": "<=4.0.16",
+                "phpmyfaq/phpmyfaq": "<4.1.3",
                 "phpoffice/common": "<0.2.9",
                 "phpoffice/math": "<=0.2",
                 "phpoffice/phpexcel": "<=1.8.2",
-                "phpoffice/phpspreadsheet": "<1.30|>=2,<2.1.12|>=2.2,<2.4|>=3,<3.10|>=4,<5",
+                "phpoffice/phpspreadsheet": "<=1.30.3|>=2,<=2.1.15|>=2.2,<=2.4.4|>=3,<=3.10.4|>=4,<=5.6",
                 "phppgadmin/phppgadmin": "<=7.13",
-                "phpseclib/phpseclib": "<2.0.47|>=3,<3.0.36",
+                "phpseclib/phpseclib": "<=2.0.53|>=3,<=3.0.51",
                 "phpservermon/phpservermon": "<3.6",
                 "phpsysinfo/phpsysinfo": "<3.4.3",
-                "phpunit/phpunit": "<8.5.52|>=9,<9.6.33|>=10,<10.5.62|>=11,<11.5.50|>=12,<12.5.8",
+                "phpunit/phpunit": "<8.5.52|>=9,<9.6.33|>=10,<10.5.62|>=11,<11.5.50|>=12,<12.5.8|>=12.5.21,<12.5.22|>=13.1.5,<13.1.6",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
                 "phpxmlrpc/phpxmlrpc": "<4.9.2",
@@ -9312,13 +9343,13 @@
                 "pimcore/demo": "<10.3",
                 "pimcore/ecommerce-framework-bundle": "<1.0.10",
                 "pimcore/perspective-editor": "<1.5.1",
-                "pimcore/pimcore": "<=11.5.14.1|>=12,<12.3.3",
+                "pimcore/pimcore": "<=11.5.14.1|>=12,<12.3.3|==12.3.3",
                 "pimcore/web2print-tools-bundle": "<=5.2.1|>=6.0.0.0-RC1-dev,<=6.1",
                 "piwik/piwik": "<1.11",
                 "pixelfed/pixelfed": "<0.12.5",
                 "plotly/plotly.js": "<2.25.2",
                 "pocketmine/bedrock-protocol": "<8.0.2",
-                "pocketmine/pocketmine-mp": "<5.32.1",
+                "pocketmine/pocketmine-mp": "<5.42.1",
                 "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
@@ -9326,15 +9357,15 @@
                 "prestashop/blockwishlist": ">=2,<2.1.1",
                 "prestashop/contactform": ">=1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
-                "prestashop/prestashop": "<8.2.4|>=9.0.0.0-alpha1,<9.0.3",
+                "prestashop/prestashop": "<8.2.6|>=9,<9.1.1",
                 "prestashop/productcomments": "<5.0.2",
-                "prestashop/ps_checkout": "<4.4.1|>=5,<5.0.5",
+                "prestashop/ps_checkout": "<5.3",
                 "prestashop/ps_contactinfo": "<=3.3.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
                 "prestashop/ps_facetedsearch": "<3.4.1",
                 "prestashop/ps_linklist": "<3.1",
                 "privatebin/privatebin": "<1.4|>=1.5,<1.7.4|>=1.7.7,<2.0.3",
-                "processwire/processwire": "<=3.0.246",
+                "processwire/processwire": "<=3.0.255",
                 "propel/propel": ">=2.0.0.0-alpha1,<=2.0.0.0-alpha7",
                 "propel/propel1": ">=1,<=1.7.1",
                 "psy/psysh": "<=0.11.22|>=0.12,<=0.12.18",
@@ -9344,6 +9375,7 @@
                 "pubnub/pubnub": "<6.1",
                 "punktde/pt_extbase": "<1.5.1",
                 "pusher/pusher-php-server": "<2.2.1",
+                "putyourlightson/craft-sprig": ">=2,<2.15.2|>=3,<3.7.2",
                 "pwweb/laravel-core": "<=0.3.6.0-beta",
                 "pxlrbt/filament-excel": "<1.1.14|>=2.0.0.0-alpha,<2.3.3",
                 "pyrocms/pyrocms": "<=3.9.1",
@@ -9352,43 +9384,50 @@
                 "rainlab/blog-plugin": "<1.4.1",
                 "rainlab/debugbar-plugin": "<3.1",
                 "rainlab/user-plugin": "<=1.4.5",
+                "ralffreit/mfa-email": "<1.0.7|==2",
                 "rankmath/seo-by-rank-math": "<=1.0.95",
                 "rap2hpoutre/laravel-log-viewer": "<0.13",
                 "react/http": ">=0.7,<1.9",
                 "really-simple-plugins/complianz-gdpr": "<6.4.2",
-                "redaxo/source": "<=5.20.1",
+                "redaxo/source": "<5.21",
                 "remdex/livehelperchat": "<4.29",
                 "renolit/reint-downloadmanager": "<4.0.2|>=5,<5.0.1",
                 "reportico-web/reportico": "<=8.1",
-                "rhukster/dom-sanitizer": "<1.0.7",
+                "rhukster/dom-sanitizer": "<1.0.10",
                 "rmccue/requests": ">=1.6,<1.8",
-                "robrichards/xmlseclibs": "<=3.1.3",
+                "roadiz/documents": "<2.3.42|>=2.4,<2.5.44|>=2.6,<2.6.28|>=2.7,<2.7.9",
+                "roadiz/openid": "<2.3.43|>=2.5,<2.5.45|>=2.6,<2.6.31|>=2.7,<2.7.18",
+                "robrichards/xmlseclibs": "<3.1.5",
                 "roots/soil": "<4.1",
-                "roundcube/roundcubemail": "<1.5.10|>=1.6,<1.6.11",
+                "roundcube/roundcubemail": "<1.5.10|>=1.6,<1.6.11|>=1.7.0.0-beta,<1.7.0.0-RC5-dev",
                 "rudloff/alltube": "<3.0.3",
                 "rudloff/rtmpdump-bin": "<=2.3.1",
                 "s-cart/core": "<=9.0.5",
                 "s-cart/s-cart": "<6.9",
+                "s9y/serendipity": "<2.6",
                 "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
                 "sabre/dav": ">=1.6,<1.7.11|>=1.8,<1.8.9",
+                "saloonphp/saloon": "<4",
                 "samwilson/unlinked-wikibase": "<1.42",
                 "scheb/two-factor-bundle": "<3.26|>=4,<4.11",
                 "sensiolabs/connect": "<4.2.3",
                 "serluck/phpwhois": "<=4.2.6",
-                "setasign/fpdi": "<2.6.4",
+                "setasign/fpdi": "<2.6.7",
                 "sfroemken/url_redirect": "<=1.2.1",
                 "sheng/yiicms": "<1.2.1",
+                "shopper/cart": "<2.8",
+                "shopper/framework": "<2.8",
                 "shopware/core": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
                 "shopware/platform": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
                 "shopware/production": "<=6.3.5.2",
                 "shopware/shopware": "<=5.7.17|>=6.4.6,<6.6.10.10-dev|>=6.7,<6.7.6.1-dev",
                 "shopware/storefront": "<6.6.10.10-dev|>=6.7,<6.7.5.1-dev",
                 "shopxo/shopxo": "<=6.4",
-                "showdoc/showdoc": "<2.10.4",
+                "showdoc/showdoc": "<3.8.1",
                 "shuchkin/simplexlsx": ">=1.0.12,<1.1.13",
                 "silverstripe-australia/advancedreports": ">=1,<=2",
                 "silverstripe/admin": "<1.13.19|>=2,<2.1.8",
-                "silverstripe/assets": ">=1,<1.11.1",
+                "silverstripe/assets": "<2.4.5|>=3,<3.1.3",
                 "silverstripe/cms": "<4.11.3",
                 "silverstripe/comments": ">=1.3,<3.1.1",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
@@ -9409,11 +9448,12 @@
                 "simplesamlphp/saml2": "<=4.16.15|>=5.0.0.0-alpha1,<=5.0.0.0-alpha19",
                 "simplesamlphp/saml2-legacy": "<=4.16.15",
                 "simplesamlphp/simplesamlphp": "<1.18.6",
+                "simplesamlphp/simplesamlphp-module-casserver": "<=7.0.2",
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "simplesamlphp/simplesamlphp-module-openid": "<1",
                 "simplesamlphp/simplesamlphp-module-openidprovider": "<0.9",
                 "simplesamlphp/xml-common": "<1.20",
-                "simplesamlphp/xml-security": "==1.6.11",
+                "simplesamlphp/xml-security": "<1.13.9|>=2,<2.3.1",
                 "simplito/elliptic-php": "<1.0.6",
                 "sitegeist/fluid-components": "<3.5",
                 "sjbr/sr-feuser-register": "<2.6.2|>=5.1,<12.5",
@@ -9423,7 +9463,7 @@
                 "slim/slim": "<2.6",
                 "slub/slub-events": "<3.0.3",
                 "smarty/smarty": "<4.5.3|>=5,<5.1.1",
-                "snipe/snipe-it": "<8.3.7",
+                "snipe/snipe-it": "<8.4.1",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
                 "solspace/craft-freeform": "<4.1.29|>=5,<=5.14.6",
@@ -9441,14 +9481,14 @@
                 "starcitizentools/short-description": ">=4,<4.0.1",
                 "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2|>=3,<3.1.1",
                 "starcitizenwiki/embedvideo": "<=4",
-                "statamic/cms": "<5.73.11|>=6,<6.4",
+                "statamic/cms": "<5.73.22|>=6,<6.18.1",
                 "stormpath/sdk": "<9.9.99",
-                "studio-42/elfinder": "<=2.1.64",
+                "studio-42/elfinder": "<=2.1.67",
                 "studiomitte/friendlycaptcha": "<0.1.4",
                 "subhh/libconnect": "<7.0.8|>=8,<8.1",
                 "sukohi/surpass": "<1",
                 "sulu/form-bundle": ">=2,<2.5.3",
-                "sulu/sulu": "<1.6.44|>=2,<2.5.25|>=2.6,<2.6.9|>=3.0.0.0-alpha1,<3.0.0.0-alpha3",
+                "sulu/sulu": "<=2.6.22|>=3,<=3.0.5",
                 "sumocoders/framework-user-bundle": "<1.4",
                 "superbig/craft-audit": "<3.0.2",
                 "svewap/a21glossary": "<=0.4.10",
@@ -9466,42 +9506,51 @@
                 "symbiote/silverstripe-seed": "<6.0.3",
                 "symbiote/silverstripe-versionedfiles": "<=2.0.3",
                 "symfont/process": ">=0",
-                "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+                "symfony/cache": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/dom-crawler": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
                 "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
                 "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=5.3.14,<5.3.15|>=5.4.3,<5.4.4|>=6.0.3,<6.0.4",
+                "symfony/html-sanitizer": ">=6.1,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/http-client": ">=4.3,<5.4.47|>=6,<6.4.15|>=7,<7.1.8",
                 "symfony/http-foundation": "<5.4.50|>=6,<6.4.29|>=7,<7.3.7",
-                "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
+                "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6|>=7.4,<7.4.12|>=8,<8.0.12",
                 "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/json-path": ">=7.3,<7.4.12|>=8,<8.0.12",
+                "symfony/lox24-notifier": ">=7.1,<7.4.12|>=8,<8.0.12",
+                "symfony/mailer": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/mailjet-mailer": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/mailtrap-mailer": ">=7.2,<7.4.12|>=8,<8.0.12",
                 "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
-                "symfony/mime": ">=4.3,<4.3.8",
+                "symfony/mime": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/monolog-bridge": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/polyfill": ">=1,<1.10",
                 "symfony/polyfill-php55": ">=1,<1.10",
                 "symfony/process": "<5.4.51|>=6,<6.4.33|>=7,<7.1.7|>=7.3,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
                 "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-                "symfony/routing": ">=2,<2.0.19",
-                "symfony/runtime": ">=5.3,<5.4.46|>=6,<6.4.14|>=7,<7.1.7",
+                "symfony/routing": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/runtime": ">=5.3,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
                 "symfony/security-bundle": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.4.10|>=7,<7.0.10|>=7.1,<7.1.3",
                 "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
                 "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
-                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7|>=5.1,<5.2.8|>=5.3,<5.4.47|>=6,<6.4.15|>=7,<7.1.8",
+                "symfony/security-http": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
-                "symfony/symfony": "<5.4.51|>=6,<6.4.33|>=7,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
+                "symfony/symfony": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/translation": ">=2,<2.0.17",
-                "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8",
+                "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8|>=6.4.24,<6.4.40",
+                "symfony/twilio-notifier": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/ux-autocomplete": "<2.11.2",
                 "symfony/ux-live-component": "<2.25.1",
                 "symfony/ux-twig-component": "<2.25.1",
                 "symfony/validator": "<5.4.43|>=6,<6.4.11|>=7,<7.1.4",
                 "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
-                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4|>=7.2.9,<7.4.12|>=8,<8.0.12",
                 "symfony/webhook": ">=6.3,<6.3.8",
-                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7|>=2.2.0.0-beta1,<2.2.0.0-beta2",
+                "symfony/yaml": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symphonycms/symphony-2": "<2.6.4",
                 "t3/dce": "<0.11.5|>=2.2,<2.6.2",
                 "t3g/svg-sanitizer": "<1.0.3",
@@ -9515,7 +9564,7 @@
                 "thelia/thelia": ">=2.1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<6.0.8",
-                "thorsten/phpmyfaq": "<4.0.18|>=4.1.0.0-alpha,<=4.1.0.0-beta2",
+                "thorsten/phpmyfaq": "<4.1.3",
                 "tikiwiki/tiki-manager": "<=17.1",
                 "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
                 "tinymce/tinymce": "<7.2",
@@ -9532,10 +9581,13 @@
                 "truckersmp/phpwhois": "<=4.3.1",
                 "ttskch/pagination-service-provider": "<1",
                 "twbs/bootstrap": "<3.4.1|>=4,<4.3.1",
-                "twig/twig": "<3.11.2|>=3.12,<3.14.1|>=3.16,<3.19",
+                "twig/cssinliner-extra": ">=2.12,<3.26",
+                "twig/intl-extra": ">=2.12,<3.26",
+                "twig/markdown-extra": ">=2.12,<3.26",
+                "twig/twig": "<3.26",
                 "typicms/core": "<16.1.7",
                 "typo3/cms": "<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
-                "typo3/cms-backend": "<4.1.14|>=4.2,<4.2.15|>=4.3,<4.3.7|>=4.4,<4.4.4|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-backend": "<4.1.14|>=4.2,<4.2.15|>=4.3,<4.3.7|>=4.4,<4.4.4|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1|==14.2",
                 "typo3/cms-belog": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-beuser": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
                 "typo3/cms-core": "<=8.7.56|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
@@ -9574,7 +9626,7 @@
                 "uvdesk/core-framework": "<=1.1.1",
                 "vanilla/safecurl": "<0.9.2",
                 "verbb/comments": "<1.5.5",
-                "verbb/formie": "<=2.1.43",
+                "verbb/formie": "<2.2.20|>=3.0.0.0-beta1,<3.1.24",
                 "verbb/image-resizer": "<2.0.9",
                 "verbb/knock-knock": "<1.2.8",
                 "verot/class.upload.php": "<=2.1.6",
@@ -9588,7 +9640,7 @@
                 "wallabag/wallabag": "<2.6.11",
                 "wanglelecc/laracms": "<=1.0.3",
                 "wapplersystems/a21glossary": "<=0.4.10",
-                "web-auth/webauthn-framework": ">=3.3,<3.3.4|>=4.5,<4.9|>=5.2,<5.2.4",
+                "web-auth/webauthn-framework": ">=3.3,<3.3.4|>=4.5,<4.9|>=5.2,<5.2.4|>=5.3,<5.3.1",
                 "web-auth/webauthn-lib": ">=4.5,<4.9|>=5.2,<5.2.4",
                 "web-auth/webauthn-symfony-bundle": ">=5.2,<5.2.4",
                 "web-feet/coastercms": "==5.5",
@@ -9597,6 +9649,7 @@
                 "webcoast/deferred-image-processing": "<1.0.2",
                 "webklex/laravel-imap": "<5.3",
                 "webklex/php-imap": "<5.3",
+                "webonyx/graphql-php": "<=15.32.2",
                 "webpa/webpa": "<3.1.2",
                 "webreinvent/vaahcms": "<=2.3.1",
                 "wikibase/wikibase": "<=1.39.3",
@@ -9616,16 +9669,17 @@
                 "wpcloud/wp-stateless": "<3.2",
                 "wpglobus/wpglobus": "<=1.9.6",
                 "wpmetabox/meta-box": "<5.11.2",
-                "wwbn/avideo": "<25",
+                "wwbn/avideo": "<=29",
                 "xataface/xataface": "<3",
                 "xpressengine/xpressengine": "<3.0.15",
                 "yab/quarx": "<2.4.5",
-                "yeswiki/yeswiki": "<=4.5.4",
+                "yansongda/pay": "<=3.7.19",
+                "yeswiki/yeswiki": "<=4.6",
                 "yetiforce/yetiforce-crm": "<6.5",
                 "yidashi/yii2cmf": "<=2",
                 "yii2mod/yii2-cms": "<1.9.2",
                 "yiisoft/yii": "<1.1.31",
-                "yiisoft/yii2": "<2.0.52",
+                "yiisoft/yii2": "<2.0.55",
                 "yiisoft/yii2-authclient": "<2.2.15",
                 "yiisoft/yii2-bootstrap": "<2.0.4",
                 "yiisoft/yii2-dev": "<=2.0.45",
@@ -9635,6 +9689,7 @@
                 "yiisoft/yii2-redis": "<2.0.20",
                 "yikesinc/yikes-inc-easy-mailchimp-extender": "<6.8.6",
                 "yoast-seo-for-typo3/yoast_seo": "<7.2.3",
+                "yoast/duplicate-post": "<=4.5",
                 "yourls/yourls": "<=1.10.2",
                 "yuan1994/tpadmin": "<=1.3.12",
                 "yungifez/skuul": "<=2.6.5",
@@ -9714,7 +9769,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-12T14:21:15+00:00"
+            "time": "2026-05-21T15:09:43+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -10968,16 +11023,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.6",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf"
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
                 "shasum": ""
             },
             "require": {
@@ -11012,7 +11067,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.6"
+                "source": "https://github.com/symfony/finder/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -11032,20 +11087,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-29T09:40:50+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.5",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
+                "reference": "d9593c9efa40499eb078b81144de42cbc28a31f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d9593c9efa40499eb078b81144de42cbc28a31f0",
+                "reference": "d9593c9efa40499eb078b81144de42cbc28a31f0",
                 "shasum": ""
             },
             "require": {
@@ -11077,7 +11132,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.5"
+                "source": "https://github.com/symfony/process/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -11097,7 +11152,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-05-11T16:55:21+00:00"
         },
         {
             "name": "theseer/fdomdocument",
@@ -11324,7 +11379,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.3"
+        "php": "8.2"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -52,14 +52,14 @@ class Application extends App implements IBootstrap
           }
           );
 
-        /* @var IEventDispatcher $dispatcher */
+        // @var IEventDispatcher $dispatcher
         $dispatcher = $this->getContainer()->get(IEventDispatcher::class);
         $dispatcher->addServiceListener(eventName: ObjectCreatedEvent::class, className: ObjectCreatedEventListener::class);
         $dispatcher->addServiceListener(eventName: ObjectUpdatedEvent::class, className: ObjectUpdatedEventListener::class);
         $dispatcher->addServiceListener(eventName: ObjectDeletedEvent::class, className: ViewDeletedEventListener::class);
         $dispatcher->addServiceListener(eventName: ObjectDeletedEvent::class, className: ObjectDeletedEventListener::class);
         // @todo: remove this temporary listener to the software catalog application
-        //        $dispatcher->addServiceListener(eventName: ViewUpdatedOrCreatedEventListener::class, className: ViewUpdatedOrCreatedEventListener::class);
+        // $dispatcher->addServiceListener(eventName: ViewUpdatedOrCreatedEventListener::class, className: ViewUpdatedOrCreatedEventListener::class);
     }//end register()
 
     public function boot(IBootContext $context): void

--- a/lib/Connectors/PdokConnector.php
+++ b/lib/Connectors/PdokConnector.php
@@ -133,24 +133,22 @@ class PdokConnector
 
     }//end __construct()
 
-
     /**
      * Suggest addresses for an autocomplete query.
      *
-     * @param string $q Search query (must be non-empty).
+     * @param string $query Search query (must be non-empty).
      *
      * @return array Normalised suggestion documents.
      */
-    public function suggest(string $q): array
+    public function suggest(string $query): array
     {
-        if (trim($q) === '') {
+        if (trim($query) === '') {
             return ['docs' => [], 'numFound' => 0];
         }
 
-        return $this->fetch('suggest', ['q' => $q, 'rows' => 10], self::TTL_QUERY, false);
+        return $this->fetch('suggest', ['q' => $query, 'rows' => 10], self::TTL_QUERY, false);
 
     }//end suggest()
-
 
     /**
      * Look up a single PDOK document by id.
@@ -169,28 +167,26 @@ class PdokConnector
 
     }//end lookup()
 
-
     /**
      * Free-text search.
      *
-     * @param string $q     Search query.
+     * @param string $query Search query.
      * @param int    $rows  Page size (default 10).
      * @param int    $start Page offset (default 0).
      *
      * @return array Normalised free-search documents.
      */
-    public function free(string $q, int $rows = 10, int $start = 0): array
+    public function free(string $query, int $rows=10, int $start=0): array
     {
-        if (trim($q) === '') {
+        if (trim($query) === '') {
             return ['docs' => [], 'numFound' => 0];
         }
 
-        $params = ['q' => $q, 'rows' => $rows, 'start' => $start];
+        $params = ['q' => $query, 'rows' => $rows, 'start' => $start];
 
         return $this->fetch('free', $params, self::TTL_QUERY, false);
 
     }//end free()
-
 
     /**
      * Reverse-geocode coordinates.
@@ -207,7 +203,6 @@ class PdokConnector
         return $this->fetch('reverse', $params, self::TTL_RESOLVED, true);
 
     }//end reverse()
-
 
     /**
      * Internal: fetch a normalised PDOK response with cache + write-through.
@@ -278,7 +273,6 @@ class PdokConnector
 
     }//end fetch()
 
-
     /**
      * Issue the HTTP GET to PDOK with retry on 429 and circuit-breaker bookkeeping.
      *
@@ -320,15 +314,14 @@ class PdokConnector
                     "PDOK upstream call failed: ".$e->getMessage(),
                     503
                 );
-            }
-        }
+            }//end try
+        }//end while
 
         // 429 retries exhausted.
         $this->circuitOnFailure();
         throw new PdokUpstreamException('PDOK rate limit retries exhausted', 503);
 
     }//end callPdok()
-
 
     /**
      * Decode the JSON body from a PDOK HTTP response.
@@ -350,7 +343,6 @@ class PdokConnector
         return $json;
 
     }//end decodePdokBody()
-
 
     /**
      * Normalise an entire PDOK response into `{docs[], numFound}`.
@@ -374,7 +366,6 @@ class PdokConnector
 
     }//end normaliseResponse()
 
-
     /**
      * Map a single PDOK document to the canonical PostalAddress shape.
      *
@@ -387,9 +378,9 @@ class PdokConnector
      */
     public function normalize(array $pdokDoc): array
     {
-        $huisnummer        = ($pdokDoc['huisnummer'] ?? null);
-        $huisletter        = ($pdokDoc['huisletter'] ?? null);
-        $houseNumber       = null;
+        $huisnummer  = ($pdokDoc['huisnummer'] ?? null);
+        $huisletter  = ($pdokDoc['huisletter'] ?? null);
+        $houseNumber = null;
         if ($huisnummer !== null) {
             $houseNumber = (string) $huisnummer;
             if ($huisletter !== null && $huisletter !== '') {
@@ -415,7 +406,6 @@ class PdokConnector
         ];
 
     }//end normalize()
-
 
     /**
      * Parse a WKT POINT into a GeoJSON Point geometry.
@@ -444,7 +434,6 @@ class PdokConnector
 
     }//end parseWkt()
 
-
     /**
      * Compute the APCu cache key for a normalised query.
      *
@@ -460,7 +449,6 @@ class PdokConnector
         return self::CACHE_PREFIX.'::'.$endpoint.'::'.$hash;
 
     }//end cacheKey()
-
 
     /**
      * Fetch a previously-cached normalised response.
@@ -479,7 +467,6 @@ class PdokConnector
         return (is_array($value) === true ? $value : null);
 
     }//end cacheGet()
-
 
     /**
      * Store a normalised response in the cache.
@@ -500,7 +487,6 @@ class PdokConnector
 
     }//end cacheSet()
 
-
     /**
      * Look up an existing OR addresses record by query (lookup-by-id or reverse).
      *
@@ -511,25 +497,29 @@ class PdokConnector
      */
     private function orLookup(string $endpoint, array $params): ?array
     {
-        $or = $this->getOpenRegisterObjectService();
-        if ($or === null) {
+        $objectService = $this->getOpenRegisterObjectService();
+        if ($objectService === null) {
             return null;
         }
 
         try {
             if ($endpoint === 'lookup' && isset($params['id']) === true) {
-                $docs = $or->getMapper(register: 'openconnector', schema: 'addresses')->findAll([
-                    'limit'  => 1,
-                    'filter' => ['pdokId' => $params['id']],
-                ]);
+                $docs = $objectService->getMapper(register: 'openconnector', schema: 'addresses')->findAll(
+                        [
+                            'limit'  => 1,
+                            'filter' => ['pdokId' => $params['id']],
+                        ]
+                        );
             } else if ($endpoint === 'reverse' && isset($params['lat'], $params['lon']) === true) {
-                $docs = $or->getMapper(register: 'openconnector', schema: 'addresses')->findAll([
-                    'limit'  => 1,
-                    'geo'    => [
-                        'near'   => [(float) $params['lat'], (float) $params['lon']],
-                        'radius' => 10,
-                    ],
-                ]);
+                $docs = $objectService->getMapper(register: 'openconnector', schema: 'addresses')->findAll(
+                        [
+                            'limit' => 1,
+                            'geo'   => [
+                                'near'   => [(float) $params['lat'], (float) $params['lon']],
+                                'radius' => 10,
+                            ],
+                        ]
+                        );
             } else {
                 return null;
             }
@@ -539,7 +529,7 @@ class PdokConnector
                 ['endpoint' => $endpoint, 'exception' => $e->getMessage()]
             );
             return null;
-        }
+        }//end try
 
         if (empty($docs) === true) {
             return null;
@@ -554,7 +544,6 @@ class PdokConnector
 
     }//end orLookup()
 
-
     /**
      * Persist a normalised PDOK document into OR's `addresses` register.
      *
@@ -564,13 +553,13 @@ class PdokConnector
      */
     public function writeThrough(array $doc): void
     {
-        $or = $this->getOpenRegisterObjectService();
-        if ($or === null || ($doc['pdokId'] ?? null) === null) {
+        $objectService = $this->getOpenRegisterObjectService();
+        if ($objectService === null || ($doc['pdokId'] ?? null) === null) {
             return;
         }
 
         try {
-            $or->saveObject(
+            $objectService->saveObject(
                 register: 'openconnector',
                 schema: 'addresses',
                 object: $doc,
@@ -584,7 +573,6 @@ class PdokConnector
         }
 
     }//end writeThrough()
-
 
     /**
      * Read the current breaker state from the cache.
@@ -615,7 +603,6 @@ class PdokConnector
 
     }//end circuitState()
 
-
     /**
      * Record a successful upstream call: close breaker, reset failure count.
      *
@@ -633,7 +620,6 @@ class PdokConnector
         );
 
     }//end circuitOnSuccess()
-
 
     /**
      * Record a failed upstream call; open the breaker after threshold.
@@ -667,7 +653,6 @@ class PdokConnector
 
     }//end circuitOnFailure()
 
-
     /**
      * Sleep for the configured backoff before the next 429 retry.
      *
@@ -690,7 +675,6 @@ class PdokConnector
 
     }//end sleepBackoff()
 
-
     /**
      * Resolve OR's ObjectService if installed; null otherwise.
      *
@@ -706,17 +690,16 @@ class PdokConnector
 
     }//end getOpenRegisterObjectService()
 
-
     /**
      * Emit a single structured observability log entry per upstream call.
      *
-     * @param string   $endpoint           PDOK endpoint name.
-     * @param bool     $cacheHit           True when APCu served the call.
-     * @param bool     $orHit              True when OR served the call.
-     * @param int|null $upstreamLatencyMs  Upstream call latency (null on cache/OR hits).
-     * @param int|null $httpStatus         HTTP status code from upstream (null on cache/OR hits).
-     * @param string   $circuitState       Current breaker state.
-     * @param bool     $writeThrough       True when this call wrote to OR.
+     * @param string   $endpoint          PDOK endpoint name.
+     * @param bool     $cacheHit          True when APCu served the call.
+     * @param bool     $orHit             True when OR served the call.
+     * @param int|null $upstreamLatencyMs Upstream call latency (null on cache/OR hits).
+     * @param int|null $httpStatus        HTTP status code from upstream (null on cache/OR hits).
+     * @param string   $circuitState      Current breaker state.
+     * @param bool     $writeThrough      True when this call wrote to OR.
      *
      * @return void
      */
@@ -755,6 +738,4 @@ class PdokConnector
         }
 
     }//end logCall()
-
-
 }//end class

--- a/lib/Connectors/PdokUpstreamException.php
+++ b/lib/Connectors/PdokUpstreamException.php
@@ -33,7 +33,6 @@ use RuntimeException;
  */
 class PdokUpstreamException extends RuntimeException
 {
-
     /**
      * Constructor.
      *
@@ -48,7 +47,6 @@ class PdokUpstreamException extends RuntimeException
 
     }//end __construct()
 
-
     /**
      * Get the upstream HTTP status code attached to this exception.
      *
@@ -59,6 +57,4 @@ class PdokUpstreamException extends RuntimeException
         return $this->statusCode;
 
     }//end getStatusCode()
-
-
 }//end class

--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -59,7 +59,7 @@ class EndpointsController extends Controller
     /**
      * CORS max age
      *
-     * @var int
+     * @var integer
      */
     private int $corsMaxAge;
 
@@ -88,7 +88,7 @@ class EndpointsController extends Controller
         private EndpointCacheService $endpointCacheService,
         private LoggerInterface $logger,
         private IL10N $l,
-        //        private EndpointLogMapper $endpointLogMapper,
+        // private EndpointLogMapper $endpointLogMapper,
         $corsMethods='PUT, POST, GET, DELETE, PATCH',
         $corsAllowedHeaders='Authorization, Content-Type, Accept',
         $corsMaxAge=1728000
@@ -340,95 +340,95 @@ class EndpointsController extends Controller
      */
     public function logs(SearchService $searchService): JSONResponse
     {
-        //        try {
-        //            // Get filters from request
-        //            $filters = $this->request->getParams();
-        //            $specialFilters = [];
+        // try {
+        // Get filters from request
+        // $filters = $this->request->getParams();
+        // $specialFilters = [];
         //
-        //            // Pagination using _page and _limit
-        //            $limit = isset($filters['_limit']) ? (int)$filters['_limit'] : 20;
-        //            $page = isset($filters['_page']) ? (int)$filters['_page'] : 1;
-        //            $offset = ($page - 1) * $limit;
-        //            unset($filters['_limit'], $filters['_page']);
+        // Pagination using _page and _limit
+        // $limit = isset($filters['_limit']) ? (int)$filters['_limit'] : 20;
+        // $page = isset($filters['_page']) ? (int)$filters['_page'] : 1;
+        // $offset = ($page - 1) * $limit;
+        // unset($filters['_limit'], $filters['_page']);
         //
-        //            // Handle special filters
-        //            if (!empty($filters['date_from'])) {
-        //                $specialFilters['date_from'] = $filters['date_from'];
-        //            }
-        //            if (!empty($filters['date_to'])) {
-        //                $specialFilters['date_to'] = $filters['date_to'];
-        //            }
-        //            if (!empty($filters['method'])) {
-        //                $specialFilters['method'] = $filters['method'];
-        //            }
-        //            if (!empty($filters['status_code'])) {
-        //                $statusCodes = explode(',', $filters['status_code']);
-        //                if (count($statusCodes) === 2) {
-        //                    $specialFilters['status_code_range'] = $statusCodes;
-        //                }
-        //            }
-        //            if (!empty($filters['slow_requests'])) {
-        //                $specialFilters['slow_requests'] = 5000; // 5 seconds in milliseconds
-        //            }
+        // Handle special filters
+        // if (!empty($filters['date_from'])) {
+        // $specialFilters['date_from'] = $filters['date_from'];
+        // }
+        // if (!empty($filters['date_to'])) {
+        // $specialFilters['date_to'] = $filters['date_to'];
+        // }
+        // if (!empty($filters['method'])) {
+        // $specialFilters['method'] = $filters['method'];
+        // }
+        // if (!empty($filters['status_code'])) {
+        // $statusCodes = explode(',', $filters['status_code']);
+        // if (count($statusCodes) === 2) {
+        // $specialFilters['status_code_range'] = $statusCodes;
+        // }
+        // }
+        // if (!empty($filters['slow_requests'])) {
+        // $specialFilters['slow_requests'] = 5000; // 5 seconds in milliseconds
+        // }
         //
-        //            // Build search conditions and parameters
-        //            $searchConditions = [];
-        //            $searchParams = [];
+        // Build search conditions and parameters
+        // $searchConditions = [];
+        // $searchParams = [];
         //
-        //            if (!empty($specialFilters['date_from'])) {
-        //                $searchConditions[] = "created >= ?";
-        //                $searchParams[] = $specialFilters['date_from'];
-        //            }
+        // if (!empty($specialFilters['date_from'])) {
+        // $searchConditions[] = "created >= ?";
+        // $searchParams[] = $specialFilters['date_from'];
+        // }
         //
-        //            if (!empty($specialFilters['date_to'])) {
-        //                $searchConditions[] = "created <= ?";
-        //                $searchParams[] = $specialFilters['date_to'];
-        //            }
+        // if (!empty($specialFilters['date_to'])) {
+        // $searchConditions[] = "created <= ?";
+        // $searchParams[] = $specialFilters['date_to'];
+        // }
         //
-        //            if (!empty($specialFilters['method'])) {
-        //                $searchConditions[] = "method = ?";
-        //                $searchParams[] = $specialFilters['method'];
-        //            }
+        // if (!empty($specialFilters['method'])) {
+        // $searchConditions[] = "method = ?";
+        // $searchParams[] = $specialFilters['method'];
+        // }
         //
-        //            if (!empty($specialFilters['status_code_range'])) {
-        //                $searchConditions[] = "status_code >= ? AND status_code <= ?";
-        //                $searchParams = array_merge($searchParams, $specialFilters['status_code_range']);
-        //            }
+        // if (!empty($specialFilters['status_code_range'])) {
+        // $searchConditions[] = "status_code >= ? AND status_code <= ?";
+        // $searchParams = array_merge($searchParams, $specialFilters['status_code_range']);
+        // }
         //
-        //            if (!empty($specialFilters['slow_requests'])) {
-        //                $searchConditions[] = "JSON_EXTRACT(response, '$.responseTime') > ?";
-        //                $searchParams[] = $specialFilters['slow_requests'];
-        //            }
+        // if (!empty($specialFilters['slow_requests'])) {
+        // $searchConditions[] = "JSON_EXTRACT(response, '$.responseTime') > ?";
+        // $searchParams[] = $specialFilters['slow_requests'];
+        // }
         //
-        //            // Remove special query params from filters
-        //            $filters = $searchService->unsetSpecialQueryParams(filters: $filters);
+        // Remove special query params from filters
+        // $filters = $searchService->unsetSpecialQueryParams(filters: $filters);
         //
-        //            // Get endpoint logs with filters and pagination
-        //            $endpointLogs = $this->endpointLogMapper->findAll(
-        //                limit: $limit,
-        //                offset: $offset,
-        //                filters: $filters,
-        //                searchConditions: $searchConditions,
-        //                searchParams: $searchParams
-        //            );
+        // Get endpoint logs with filters and pagination
+        // $endpointLogs = $this->endpointLogMapper->findAll(
+        // limit: $limit,
+        // offset: $offset,
+        // filters: $filters,
+        // searchConditions: $searchConditions,
+        // searchParams: $searchParams
+        // );
         //
-        //            // Get total count for pagination
-        //            $total = $this->endpointLogMapper->getTotalCount($filters);
-        //            $pages = $limit > 0 ? ceil($total / $limit) : 1;
-        //            $currentPage = $limit > 0 ? floor($offset / $limit) + 1 : 1;
+        // Get total count for pagination
+        // $total = $this->endpointLogMapper->getTotalCount($filters);
+        // $pages = $limit > 0 ? ceil($total / $limit) : 1;
+        // $currentPage = $limit > 0 ? floor($offset / $limit) + 1 : 1;
         //
-        //            // Return flattened paginated response
-        //            return new JSONResponse([
-        //                'results' => $endpointLogs,
-        //                'page' => $currentPage,
-        //                'pages' => $pages,
-        //                'results_count' => count($endpointLogs),
-        //                'total' => $total
-        //            ]);
-        //        } catch (\Exception $e) {
+        // Return flattened paginated response
+        // return new JSONResponse([
+        // 'results' => $endpointLogs,
+        // 'page' => $currentPage,
+        // 'pages' => $pages,
+        // 'results_count' => count($endpointLogs),
+        // 'total' => $total
+        // ]);
+        // } catch (\Exception $e) {
             return new JSONResponse(['error' => $this->l->t('Failed to retrieve logs: Endpoint logging is not available at this time')], 500);
-        //            return new JSONResponse(['error' => 'Failed to retrieve logs: ' . $e->getMessage()], 500);
-        //        }
+        // return new JSONResponse(['error' => 'Failed to retrieve logs: ' . $e->getMessage()], 500);
+        // }
     }//end logs()
 
     /**
@@ -536,8 +536,8 @@ class EndpointsController extends Controller
                     $returnArray            = $result;
                     $returnArray['count']   = $result['total'];
                     $returnArray['results'] = array_map(fn($obj) => $obj->jsonSerialize(), $result['results']);
-                    unset($returnArray['total']); // Remove 'total' since we renamed it to 'count'
-
+                    unset($returnArray['total']);
+                    // Remove 'total' since we renamed it to 'count'
                     // Add pagination links if needed
                     if ($result['page'] < $result['pages']) {
                         $parameters['page']  = $result['page'] + 1;

--- a/lib/Controller/EventsController.php
+++ b/lib/Controller/EventsController.php
@@ -40,7 +40,7 @@ class EventsController extends Controller
         IRequest $request,
         private readonly IAppConfig $config,
         private readonly EventMapper $eventMapper,
-        //        private readonly EventLogMapper $eventLogMapper, // @todo
+        // private readonly EventLogMapper $eventLogMapper, // @todo
         private readonly EventService $eventService,
         private readonly EventMessageMapper $messageMapper,
         private readonly EventSubscriptionMapper $subscriptionMapper,

--- a/lib/Controller/JobsController.php
+++ b/lib/Controller/JobsController.php
@@ -247,7 +247,8 @@ class JobsController extends Controller
             }
 
             if (!empty($filters['slow_executions'])) {
-                $specialFilters['slow_executions'] = 5000; // 5 seconds in milliseconds
+                $specialFilters['slow_executions'] = 5000;
+                // 5 seconds in milliseconds
             }
 
             // Build search conditions and parameters

--- a/lib/Controller/LogsController.php
+++ b/lib/Controller/LogsController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * LogsController
  *
  * Controller for managing synchronization logs

--- a/lib/Controller/MappingsController.php
+++ b/lib/Controller/MappingsController.php
@@ -367,7 +367,7 @@ class MappingsController extends Controller
         $data          = [];
         $data['openRegisters'] = false;
         if ($openRegisters !== null) {
-            $data['openRegisters']      = true;
+            $data['openRegisters'] = true;
             // OpenRegister's ObjectService no longer exposes getRegisters();
             // fetch the register list via the mapper directly.
             try {

--- a/lib/Controller/PdokController.php
+++ b/lib/Controller/PdokController.php
@@ -40,8 +40,6 @@ use OCP\IRequest;
  */
 class PdokController extends Controller
 {
-
-
     /**
      * Constructor.
      *
@@ -58,7 +56,6 @@ class PdokController extends Controller
 
     }//end __construct()
 
-
     /**
      * Address autocomplete (PDOK Locatieserver `/suggest`).
      *
@@ -68,7 +65,7 @@ class PdokController extends Controller
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
-    public function suggestAction(string $q = ''): JSONResponse
+    public function suggestAction(string $q=''): JSONResponse
     {
         if (trim($q) === '') {
             return new JSONResponse(
@@ -81,7 +78,6 @@ class PdokController extends Controller
 
     }//end suggestAction()
 
-
     /**
      * Look up a PDOK document by id.
      *
@@ -91,7 +87,7 @@ class PdokController extends Controller
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
-    public function lookupAction(string $id = ''): JSONResponse
+    public function lookupAction(string $id=''): JSONResponse
     {
         if (trim($id) === '') {
             return new JSONResponse(
@@ -119,7 +115,6 @@ class PdokController extends Controller
 
     }//end lookupAction()
 
-
     /**
      * Free-text search.
      *
@@ -131,7 +126,7 @@ class PdokController extends Controller
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
-    public function freeAction(string $q = '', int $rows = 10, int $start = 0): JSONResponse
+    public function freeAction(string $q='', int $rows=10, int $start=0): JSONResponse
     {
         if (trim($q) === '') {
             return new JSONResponse(
@@ -144,7 +139,6 @@ class PdokController extends Controller
 
     }//end freeAction()
 
-
     /**
      * Reverse geocode coordinates.
      *
@@ -155,7 +149,7 @@ class PdokController extends Controller
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
-    public function reverseAction(?float $lat = null, ?float $lng = null): JSONResponse
+    public function reverseAction(?float $lat=null, ?float $lng=null): JSONResponse
     {
         if ($lat === null || $lng === null) {
             return new JSONResponse(
@@ -182,6 +176,4 @@ class PdokController extends Controller
         return new JSONResponse($payload);
 
     }//end reverseAction()
-
-
 }//end class

--- a/lib/Controller/SourcesController.php
+++ b/lib/Controller/SourcesController.php
@@ -238,7 +238,8 @@ class SourcesController extends Controller
             }
 
             if (empty($filters['slow_requests']) === false) {
-                $specialFilters['slow_requests'] = 5000; // 5 seconds in milliseconds
+                $specialFilters['slow_requests'] = 5000;
+                // 5 seconds in milliseconds
                 unset($filters['slow_requests']);
             }
 

--- a/lib/Controller/SynchronizationContractsController.php
+++ b/lib/Controller/SynchronizationContractsController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SynchronizationContractsController
  *
  * Controller for managing synchronization contracts

--- a/lib/Controller/SynchronizationsController.php
+++ b/lib/Controller/SynchronizationsController.php
@@ -260,7 +260,8 @@ class SynchronizationsController extends Controller
             }
 
             if (!empty($filters['slow_syncs'])) {
-                $specialFilters['slow_syncs'] = 5000; // 5 seconds in milliseconds
+                $specialFilters['slow_syncs'] = 5000;
+                // 5 seconds in milliseconds
             }
 
             // Build search conditions and parameters
@@ -608,7 +609,8 @@ class SynchronizationsController extends Controller
                     $log->getId() ?? '',
                     $log->getUuid() ?? '',
                     $log->getStatus() ?? '',
-                    str_replace('"', '""', $log->getMessage() ?? ''), // Escape quotes in message
+                    str_replace('"', '""', $log->getMessage() ?? ''),
+                // Escape quotes in message
                     $log->getSynchronizationId() ?? '',
                     $log->getSourceId() ?? '',
                     $log->getTargetId() ?? '',

--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * UserController
  *
  * This controller handles user-related API endpoints including user information
@@ -311,7 +311,8 @@ class UserController extends Controller
             if ($memoryLimitBytes > 0 && $initialMemoryUsage > ($memoryLimitBytes * 0.8)) {
                 $response = new JSONResponse(
                     data: ['error' => $this->l->t('Server memory usage too high, please try again later')],
-                    statusCode: 503 // Service Unavailable
+                    statusCode: 503
+                // Service Unavailable
                 );
                 return $this->securityService->addSecurityHeaders($response);
             }
@@ -350,7 +351,8 @@ class UserController extends Controller
                         'retry_after'   => $rateLimitCheck['delay'] ?? null,
                         'lockout_until' => $rateLimitCheck['lockout_until'] ?? null,
                     ],
-                    statusCode: 429 // Too Many Requests
+                    statusCode: 429
+                    // Too Many Requests
                 );
                 return $this->securityService->addSecurityHeaders($response);
             }
@@ -397,7 +399,8 @@ class UserController extends Controller
             $memoryIncreaseBytes = $finalMemoryUsage - $initialMemoryUsage;
 
             // Log memory usage for monitoring
-            if ($memoryIncreaseBytes > 10 * 1024 * 1024) { // 10MB threshold
+            if ($memoryIncreaseBytes > 10 * 1024 * 1024) {
+                // 10MB threshold
                 $this->logger->warning(
                         'High memory usage during login',
                         [

--- a/lib/Db/CallLog.php
+++ b/lib/Db/CallLog.php
@@ -15,7 +15,7 @@ class CallLog extends Entity implements JsonSerializable
     protected ?string $uuid = null;
 
     /**
-     * @var int|null $statusCode HTTP status code returned from the API call
+     * @var integer|null $statusCode HTTP status code returned from the API call
      */
     protected ?int $statusCode = null;
 
@@ -35,17 +35,17 @@ class CallLog extends Entity implements JsonSerializable
     protected ?array $response = null;
 
     /**
-     * @var int|null $sourceId Reference to the source/endpoint that was called
+     * @var integer|null $sourceId Reference to the source/endpoint that was called
      */
     protected ?int $sourceId = null;
 
     /**
-     * @var int|null $actionId Reference to the action that triggered this call
+     * @var integer|null $actionId Reference to the action that triggered this call
      */
     protected ?int $actionId = null;
 
     /**
-     * @var int|null $synchronizationId Reference to the synchronization process if this call is part of one
+     * @var integer|null $synchronizationId Reference to the synchronization process if this call is part of one
      */
     protected ?int $synchronizationId = null;
 
@@ -70,7 +70,7 @@ class CallLog extends Entity implements JsonSerializable
     protected ?DateTime $created = null;
 
     /**
-     * @var int $size Size of this log entry in bytes (calculated from serialized object)
+     * @var integer $size Size of this log entry in bytes (calculated from serialized object)
      */
     protected int $size = 4096;
 

--- a/lib/Db/Consumer.php
+++ b/lib/Db/Consumer.php
@@ -23,22 +23,30 @@ class Consumer extends Entity implements JsonSerializable
 
     protected ?string $uuid = null;
 
-    protected ?string $name = null; // The name of the consumer
+    protected ?string $name = null;
 
-    protected ?string $description = null; // The description of the consumer
+    // The name of the consumer
+    protected ?string $description = null;
 
-    protected ?array $domains = []; // The domains the consumer is allowed to run from
+    // The description of the consumer
+    protected ?array $domains = [];
 
-    protected ?array $ips = []; // The ips the consumer is allowed to run from
+    // The domains the consumer is allowed to run from
+    protected ?array $ips = [];
 
-    protected ?string $authorizationType = null; // The authorization type of the consumer, should be one of the following: 'none', 'basic', 'bearer', 'apiKey', 'oauth2', 'jwt'. Keep in mind that the consumer needs to be able to handle the authorization type.
+    // The ips the consumer is allowed to run from
+    protected ?string $authorizationType = null;
 
-    protected ?array $authorizationConfiguration = []; // The authorization configuration of the consumer
+    // The authorization type of the consumer, should be one of the following: 'none', 'basic', 'bearer', 'apiKey', 'oauth2', 'jwt'. Keep in mind that the consumer needs to be able to handle the authorization type.
+    protected ?array $authorizationConfiguration = [];
 
-    protected ?DateTime $created = null; // the date and time the consumer was created
+    // The authorization configuration of the consumer
+    protected ?DateTime $created = null;
 
-    protected ?DateTime $updated = null; // the date and time the consumer was updated
+    // the date and time the consumer was created
+    protected ?DateTime $updated = null;
 
+    // the date and time the consumer was updated
     protected ?string $userId = null;
 
     /**
@@ -126,7 +134,7 @@ class Consumer extends Entity implements JsonSerializable
             try {
                 $this->$method($value);
             } catch (\Exception $exception) {
-                //                ("Error writing $key");
+                // ("Error writing $key");
             }
         }
 

--- a/lib/Db/ConsumerMapper.php
+++ b/lib/Db/ConsumerMapper.php
@@ -126,12 +126,12 @@ class ConsumerMapper extends QBMapper
         $obj->hydrate($object);
 
         // @todo: does Consumer need a version? $version field does currently not exist.
-        //        if (isset($object['version']) === false) {
-        //            // Set or update the version
-        //            $version = explode('.', $obj->getVersion());
-        //            $version[2] = (int)$version[2] + 1;
-        //            $obj->setVersion(implode('.', $version));
-        //        }
+        // if (isset($object['version']) === false) {
+        // Set or update the version
+        // $version = explode('.', $obj->getVersion());
+        // $version[2] = (int)$version[2] + 1;
+        // $obj->setVersion(implode('.', $version));
+        // }
         return $this->update($obj);
     }//end updateFromArray()
 

--- a/lib/Db/Endpoint.php
+++ b/lib/Db/Endpoint.php
@@ -28,28 +28,39 @@ class Endpoint extends Entity implements JsonSerializable
 
     protected ?string $uuid = null;
 
-    protected ?string $name = null; // The name of the endpoint
+    protected ?string $name = null;
 
-    protected ?string $description = null; // The description of the endpoint
+    // The name of the endpoint
+    protected ?string $description = null;
 
-    protected ?string $reference = null; // The reference of the endpoint
+    // The description of the endpoint
+    protected ?string $reference = null;
 
-    protected ?string $version = '0.0.0'; // The version of the endpoint
+    // The reference of the endpoint
+    protected ?string $version = '0.0.0';
 
-    protected ?string $endpoint = null; // The actual endpoint e.g /api/buildings/{{id}}. An endpoint may contain parameters e.g {{id}}
+    // The version of the endpoint
+    protected ?string $endpoint = null;
 
-    protected ?array $endpointArray = []; // An array representation of the endpoint. Automatically generated
+    // The actual endpoint e.g /api/buildings/{{id}}. An endpoint may contain parameters e.g {{id}}
+    protected ?array $endpointArray = [];
 
-    protected ?string $endpointRegex = null; // A regex representation of the endpoint. Automatically generated
+    // An array representation of the endpoint. Automatically generated
+    protected ?string $endpointRegex = null;
 
-    protected ?string $method = null; // One of GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD. method and endpoint combination should be unique
+    // A regex representation of the endpoint. Automatically generated
+    protected ?string $method = null;
 
-    protected ?string $targetType = null; // The target to attach this endpoint to, should be one of source (to create a proxy endpoint) or register/schema (to create an object endpoint) or job (to fire an event) or synchronization (to create a synchronization endpoint)
+    // One of GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD. method and endpoint combination should be unique
+    protected ?string $targetType = null;
 
-    protected ?string $targetId = null; // The target id to attach this endpoint to
+    // The target to attach this endpoint to, should be one of source (to create a proxy endpoint) or register/schema (to create an object endpoint) or job (to fire an event) or synchronization (to create a synchronization endpoint)
+    protected ?string $targetId = null;
 
-    protected ?array $conditions = []; // Array of conditions to be applied
+    // The target id to attach this endpoint to
+    protected ?array $conditions = [];
 
+    // Array of conditions to be applied
     protected ?DateTime $created = null;
 
     protected ?DateTime $updated = null;
@@ -58,10 +69,12 @@ class Endpoint extends Entity implements JsonSerializable
 
     protected ?string $outputMapping = null;
 
-    protected ?array $rules = []; // Array of rules to be applied
+    protected ?array $rules = [];
 
-    protected ?array $configurations = []; // Array of configuration IDs that this endpoint belongs to
+    // Array of rules to be applied
+    protected ?array $configurations = [];
 
+    // Array of configuration IDs that this endpoint belongs to
     protected ?string $slug = null;
 
     /**

--- a/lib/Db/EndpointMapper.php
+++ b/lib/Db/EndpointMapper.php
@@ -170,7 +170,8 @@ class EndpointMapper extends QBMapper
                 return '(?:/([^/]+))?$#';
             },
             $regex,
-            1 // Limit to only one replacement
+            1
+        // Limit to only one replacement
         );
 
         if (str_ends_with($regex, '?#') === false && str_ends_with($regex, '$#') === false) {

--- a/lib/Db/Event.php
+++ b/lib/Db/Event.php
@@ -16,35 +16,49 @@ class Event extends Entity implements JsonSerializable
 {
 
     // Required CloudEvent attributes
-    protected ?string $uuid = null; // Unique UUID identifier for the event
+    protected ?string $uuid = null;
 
-    protected ?string $source = null; // URI identifying the context where event happened
+    // Unique UUID identifier for the event
+    protected ?string $source = null;
 
-    protected ?string $type = null; // Event type identifier
+    // URI identifying the context where event happened
+    protected ?string $type = null;
 
-    protected ?string $specversion = '1.0'; // CloudEvents specification version
+    // Event type identifier
+    protected ?string $specversion = '1.0';
 
-    protected ?DateTime $time = null; // Timestamp of when the event occurred
+    // CloudEvents specification version
+    protected ?DateTime $time = null;
 
+    // Timestamp of when the event occurred
     // Optional CloudEvent attributes
-    protected ?string $datacontenttype = 'application/json'; // Content type of data
+    protected ?string $datacontenttype = 'application/json';
 
-    protected ?string $dataschema = null; // URI to the schema that data adheres to
+    // Content type of data
+    protected ?string $dataschema = null;
 
-    protected ?string $subject = null; // Subject of the event
+    // URI to the schema that data adheres to
+    protected ?string $subject = null;
 
-    protected ?array $data = []; // Event payload
+    // Subject of the event
+    protected ?array $data = [];
 
+    // Event payload
     // Additional tracking fields
-    protected ?string $userId = null; // User who triggered the event
+    protected ?string $userId = null;
 
-    protected ?DateTime $created = null; // When the event was created in our system
+    // User who triggered the event
+    protected ?DateTime $created = null;
 
-    protected ?DateTime $updated = null; // When the event was last updated
+    // When the event was created in our system
+    protected ?DateTime $updated = null;
 
-    protected ?DateTime $processed = null; // When the event was processed
+    // When the event was last updated
+    protected ?DateTime $processed = null;
 
-    protected ?string $status = 'pending'; // Event processing status
+    // When the event was processed
+    protected ?string $status = 'pending';
+    // Event processing status
 
     /**
      * Get the event data payload

--- a/lib/Db/EventMessage.php
+++ b/lib/Db/EventMessage.php
@@ -17,29 +17,41 @@ use OCP\AppFramework\Db\Entity;
 class EventMessage extends Entity implements JsonSerializable
 {
 
-    protected ?string $uuid = null; // Unique identifier for the message
+    protected ?string $uuid = null;
 
-    protected ?int $eventId = null; // Reference to the original event
+    // Unique identifier for the message
+    protected ?int $eventId = null;
 
-    protected ?int $consumerId = null; // Reference to the consumer
+    // Reference to the original event
+    protected ?int $consumerId = null;
 
-    protected ?int $subscriptionId = null; // Reference to the subscription
+    // Reference to the consumer
+    protected ?int $subscriptionId = null;
 
-    protected ?string $status = 'pending'; // Current status of the message (pending, delivered, failed)
+    // Reference to the subscription
+    protected ?string $status = 'pending';
 
-    protected ?array $payload = null; // The actual message payload to be delivered
+    // Current status of the message (pending, delivered, failed)
+    protected ?array $payload = null;
 
-    protected ?array $lastResponse = null; // The last response received from the consumer
+    // The actual message payload to be delivered
+    protected ?array $lastResponse = null;
 
-    protected int $retryCount = 0; // Number of delivery attempts
+    // The last response received from the consumer
+    protected int $retryCount = 0;
 
-    protected ?DateTime $lastAttempt = null; // Timestamp of the last delivery attempt
+    // Number of delivery attempts
+    protected ?DateTime $lastAttempt = null;
 
-    protected ?DateTime $nextAttempt = null; // Scheduled time for next attempt
+    // Timestamp of the last delivery attempt
+    protected ?DateTime $nextAttempt = null;
 
-    protected ?DateTime $created = null; // Creation timestamp
+    // Scheduled time for next attempt
+    protected ?DateTime $created = null;
 
-    protected ?DateTime $updated = null; // Last update timestamp
+    // Creation timestamp
+    protected ?DateTime $updated = null;
+    // Last update timestamp
 
     /**
      * Get the message payload

--- a/lib/Db/Job.php
+++ b/lib/Db/Job.php
@@ -24,46 +24,64 @@ class Job extends Entity implements JsonSerializable
 
     protected ?string $description = null;
 
-    protected ?string $reference = null; // The reference of the Job
+    protected ?string $reference = null;
 
-    protected ?string $version = '0.0.0'; // The version of the Job
+    // The reference of the Job
+    protected ?string $version = '0.0.0';
 
+    // The version of the Job
     protected ?string $jobClass = 'OCA\OpenConnector\Action\PingAction';
 
     protected ?array $arguments = null;
 
-    protected ?int $interval = 3600; // seconds in an hour
+    protected ?int $interval = 3600;
 
-    protected ?int $executionTime = 3600; // maximum execution time in seconds
+    // seconds in an hour
+    protected ?int $executionTime = 3600;
 
-    protected ?bool $timeSensitive = true; // if the job is time sensitive and should be executed even if the server is under heavy load
+    // maximum execution time in seconds
+    protected ?bool $timeSensitive = true;
 
-    protected ?bool $allowParallelRuns = false; // if the job can be executed in parallel
+    // if the job is time sensitive and should be executed even if the server is under heavy load
+    protected ?bool $allowParallelRuns = false;
 
-    protected ?bool $isEnabled = true; // if the job is enabled
+    // if the job can be executed in parallel
+    protected ?bool $isEnabled = true;
 
-    protected ?bool $singleRun = false; // if set, the job will only run once and then disable itself
+    // if the job is enabled
+    protected ?bool $singleRun = false;
 
-    protected ?DateTime $scheduleAfter = null; // if the job should be executed after a certain date and time
+    // if set, the job will only run once and then disable itself
+    protected ?DateTime $scheduleAfter = null;
 
-    protected ?string $userId = null; // the user which the job is running for security reasons
+    // if the job should be executed after a certain date and time
+    protected ?string $userId = null;
 
-    protected ?string $jobListId = null; // the id of the job in the job list
+    // the user which the job is running for security reasons
+    protected ?string $jobListId = null;
 
-    protected ?int $logRetention = 3600; // seconds to save all logs
+    // the id of the job in the job list
+    protected ?int $logRetention = 3600;
 
-    protected ?int $errorRetention = 86400; // seconds to save error logs
+    // seconds to save all logs
+    protected ?int $errorRetention = 86400;
 
-    protected ?DateTime $lastRun = null; // the last time the job was run
+    // seconds to save error logs
+    protected ?DateTime $lastRun = null;
 
-    protected ?DateTime $nextRun = null; // the next time the job will be run
+    // the last time the job was run
+    protected ?DateTime $nextRun = null;
 
-    protected ?DateTime $created = null; // the date and time the job was created
+    // the next time the job will be run
+    protected ?DateTime $created = null;
 
-    protected ?DateTime $updated = null; // the date and time the job was updated
+    // the date and time the job was created
+    protected ?DateTime $updated = null;
 
-    protected ?array $configurations = []; // Array of configuration IDs that this job belongs to
+    // the date and time the job was updated
+    protected ?array $configurations = [];
 
+    // Array of configuration IDs that this job belongs to
     protected ?string $status = null;
 
     protected ?string $slug = null;
@@ -160,7 +178,7 @@ class Job extends Entity implements JsonSerializable
             try {
                 $this->$method($value);
             } catch (\Exception $exception) {
-                //                ("Error writing $key");
+                // ("Error writing $key");
             }
         }
 

--- a/lib/Db/JobLog.php
+++ b/lib/Db/JobLog.php
@@ -43,7 +43,7 @@ class JobLog extends Entity implements JsonSerializable
     protected ?DateTime $created = null;
 
     /**
-     * @var int $size Size of this log entry in bytes (calculated from serialized object)
+     * @var integer $size Size of this log entry in bytes (calculated from serialized object)
      */
     protected int $size = 4096;
 

--- a/lib/Db/Mapping.php
+++ b/lib/Db/Mapping.php
@@ -44,8 +44,9 @@ class Mapping extends Entity implements JsonSerializable
 
     protected ?DateTime $dateModified = null;
 
-    protected ?array $configurations = []; // Array of configuration IDs that this mapping belongs to
+    protected ?array $configurations = [];
 
+    // Array of configuration IDs that this mapping belongs to
     protected ?string $slug = null;
 
     /**
@@ -189,7 +190,7 @@ class Mapping extends Entity implements JsonSerializable
             try {
                 $this->$method($value);
             } catch (\Exception $exception) {
-                //                ("Error writing $key");
+                // ("Error writing $key");
             }
         }
 

--- a/lib/Db/Rule.php
+++ b/lib/Db/Rule.php
@@ -27,20 +27,27 @@ class Rule extends Entity implements JsonSerializable
 
     protected ?string $version = '0.0.0';
 
-    protected ?string $action = null; // create, read, update, delete
+    protected ?string $action = null;
 
-    protected ?string $timing = 'before'; // before or after
+    // create, read, update, delete
+    protected ?string $timing = 'before';
 
-    protected ?array $conditions = []; // JSON Logic format conditions
+    // before or after
+    protected ?array $conditions = [];
 
-    protected ?string $type = null; // mapping, error, script, synchronization
+    // JSON Logic format conditions
+    protected ?string $type = null;
 
-    protected ?array $configuration = []; // Type-specific configuration
+    // mapping, error, script, synchronization
+    protected ?array $configuration = [];
 
-    protected int $order = 0; // Order in which the rule should be applied
+    // Type-specific configuration
+    protected int $order = 0;
 
-    protected ?array $configurations = []; // Array of configuration IDs that this rule belongs to
+    // Order in which the rule should be applied
+    protected ?array $configurations = [];
 
+    // Array of configuration IDs that this rule belongs to
     // Additional tracking fields
     protected ?DateTime $created = null;
 

--- a/lib/Db/Source.php
+++ b/lib/Db/Source.php
@@ -77,22 +77,28 @@ class Source extends Entity implements JsonSerializable
 
     protected ?string $status = null;
 
-    protected ?int $logRetention = 3600; // seconds to save all logs
+    protected ?int $logRetention = 3600;
 
-    protected ?int $errorRetention = 86400; // seconds to save error logs
+    // seconds to save all logs
+    protected ?int $errorRetention = 86400;
 
+    // seconds to save error logs
     protected ?int $objectCount = null;
 
     protected ?bool $test = null;
 
-    protected ?int $rateLimitLimit = null; // Indicates the total number of allowed requests within a specific time period.
+    protected ?int $rateLimitLimit = null;
 
-    protected ?int $rateLimitRemaining = null; // Specifies how many requests are still allowed within the current limit.
+    // Indicates the total number of allowed requests within a specific time period.
+    protected ?int $rateLimitRemaining = null;
 
-    protected ?int $rateLimitReset = null; // A Unix Time Stamp that indicates when the rate limit will be reset.
+    // Specifies how many requests are still allowed within the current limit.
+    protected ?int $rateLimitReset = null;
 
-    protected ?int $rateLimitWindow = null; // Indicates how many seconds the client must wait before making new requests.
+    // A Unix Time Stamp that indicates when the rate limit will be reset.
+    protected ?int $rateLimitWindow = null;
 
+    // Indicates how many seconds the client must wait before making new requests.
     protected ?DateTime $lastCall = null;
 
     protected ?DateTime $lastSync = null;
@@ -101,9 +107,11 @@ class Source extends Entity implements JsonSerializable
 
     protected ?DateTime $dateModified = null;
 
-    protected ?array $configurations = []; // Array of configuration IDs that this source belongs to
+    protected ?array $configurations = [];
 
-    protected ?string $slug = null; // URL-friendly identifier for the source
+    // Array of configuration IDs that this source belongs to
+    protected ?string $slug = null;
+    // URL-friendly identifier for the source
 
     /**
      * Get the authentication configuration

--- a/lib/Db/Synchronization.php
+++ b/lib/Db/Synchronization.php
@@ -20,61 +20,89 @@ class Synchronization extends Entity implements JsonSerializable
 
     protected ?string $uuid = null;
 
-    protected ?string $name = null;    // The name of the synchronization
+    protected ?string $name = null;
 
-    protected ?string $description = null;    // The description of the synchronization
+    // The name of the synchronization
+    protected ?string $description = null;
 
-    protected ?string $reference = null; // The reference of the endpoint
+    // The description of the synchronization
+    protected ?string $reference = null;
 
-    protected ?string $version = '0.0.0';    // The version of the synchronization
+    // The reference of the endpoint
+    protected ?string $version = '0.0.0';
+
+    // The version of the synchronization
     // Source
-    protected ?string $sourceId = null;    // The id of the source object
+    protected ?string $sourceId = null;
 
-    protected ?string $sourceType = null;    // The type of the source object (e.g. api, database, register/schema.)
+    // The id of the source object
+    protected ?string $sourceType = null;
 
-    protected ?string $sourceHash = null;    // The hash of the source object when it was last synced.
+    // The type of the source object (e.g. api, database, register/schema.)
+    protected ?string $sourceHash = null;
 
-    protected ?string $sourceHashMapping = null;    // The mapping id of the mapping that we map the object to for hashing.
+    // The hash of the source object when it was last synced.
+    protected ?string $sourceHashMapping = null;
 
-    protected ?string $sourceTargetMapping = null;    // The mapping of the source object to the target object
+    // The mapping id of the mapping that we map the object to for hashing.
+    protected ?string $sourceTargetMapping = null;
 
-    protected ?array $sourceConfig = []; // The configuration of the object in the source
+    // The mapping of the source object to the target object
+    protected ?array $sourceConfig = [];
 
-    protected ?DateTime $sourceLastChanged = null;    // The last changed date of the source object
+    // The configuration of the object in the source
+    protected ?DateTime $sourceLastChanged = null;
 
-    protected ?DateTime $sourceLastChecked = null;    // The last checked date of the source object
+    // The last changed date of the source object
+    protected ?DateTime $sourceLastChecked = null;
 
-    protected ?DateTime $sourceLastSynced = null;    // The last synced date of the source object
+    // The last checked date of the source object
+    protected ?DateTime $sourceLastSynced = null;
 
-    protected ?int $currentPage = 1; // The last page synced. Used for keeping track where to continue syncing after Rate Limit has been exceeded on source with pagination.
+    // The last synced date of the source object
+    protected ?int $currentPage = 1;
+
+    // The last page synced. Used for keeping track where to continue syncing after Rate Limit has been exceeded on source with pagination.
     // Target
-    protected ?string $targetId = null;    // The id of the target object
+    protected ?string $targetId = null;
 
-    protected ?string $targetType = null;    // The type of the target object (e.g. api, database, register/schema.)
+    // The id of the target object
+    protected ?string $targetType = null;
 
-    protected ?string $targetHash = null;    // The hash of the target object
+    // The type of the target object (e.g. api, database, register/schema.)
+    protected ?string $targetHash = null;
 
-    protected ?string $targetSourceMapping = null;    // The mapping of the target object to the source object
+    // The hash of the target object
+    protected ?string $targetSourceMapping = null;
 
-    protected ?array $targetConfig = []; // The configuration of the object in the target
+    // The mapping of the target object to the source object
+    protected ?array $targetConfig = [];
 
-    protected ?DateTime $targetLastChanged = null;    // The last changed date of the target object
+    // The configuration of the object in the target
+    protected ?DateTime $targetLastChanged = null;
 
-    protected ?DateTime $targetLastChecked = null;    // The last checked date of the target object
+    // The last changed date of the target object
+    protected ?DateTime $targetLastChecked = null;
 
-    protected ?DateTime $targetLastSynced = null;    // The last synced date of the target object
+    // The last checked date of the target object
+    protected ?DateTime $targetLastSynced = null;
+
+    // The last synced date of the target object
     // General
-    protected ?DateTime $created = null;    // The date and time the synchronization was created
+    protected ?DateTime $created = null;
 
-    protected ?DateTime $updated = null;    // The date and time the synchronization was updated
+    // The date and time the synchronization was created
+    protected ?DateTime $updated = null;
 
+    // The date and time the synchronization was updated
     protected array $conditions = [];
 
     protected array $followUps = [];
 
     protected array $actions = [];
 
-    protected ?array $configurations = []; // Array of configuration IDs that this synchronization belongs to
+    protected ?array $configurations = [];
+    // Array of configuration IDs that this synchronization belongs to
 
     /**
      * @var string|null The status of the synchronization

--- a/lib/Db/SynchronizationContract.php
+++ b/lib/Db/SynchronizationContract.php
@@ -18,43 +18,60 @@ class SynchronizationContract extends Entity implements JsonSerializable
 {
 
     // @todo can be removed when migrations are merged
-    protected ?string $sourceId = null; // OLD The id of the object in the source
+    protected ?string $sourceId = null;
 
-    protected ?string $sourceHash = null; // OLD The hash of the object in the source
+    // OLD The id of the object in the source
+    protected ?string $sourceHash = null;
 
+    // OLD The hash of the object in the source
     protected ?string $uuid = null;
 
     protected ?string $version = null;
 
-    protected ?string $synchronizationId = null; // The synchronization that this contract belongs to
+    protected ?string $synchronizationId = null;
+
+    // The synchronization that this contract belongs to
     // Source
-    protected ?string $originId = null; // The id of the object in the source
+    protected ?string $originId = null;
 
-    protected ?string $originHash = null; // The hash of the object in the source
+    // The id of the object in the source
+    protected ?string $originHash = null;
 
-    protected ?DateTime $sourceLastChanged = null; // The last changed date of the object in the source
+    // The hash of the object in the source
+    protected ?DateTime $sourceLastChanged = null;
 
-    protected ?DateTime $sourceLastChecked = null; // The last checked date of the object in the source
+    // The last changed date of the object in the source
+    protected ?DateTime $sourceLastChecked = null;
 
-    protected ?DateTime $sourceLastSynced = null; // The last synced date of the object in the source
+    // The last checked date of the object in the source
+    protected ?DateTime $sourceLastSynced = null;
+
+    // The last synced date of the object in the source
     // Target
-    protected ?string $targetId = null; // The id of the object in the target
+    protected ?string $targetId = null;
 
-    protected ?string $targetHash = null; // The hash of the object in the target
+    // The id of the object in the target
+    protected ?string $targetHash = null;
 
-    protected ?DateTime $targetLastChanged = null; // The last changed date of the object in the target
+    // The hash of the object in the target
+    protected ?DateTime $targetLastChanged = null;
 
-    protected ?DateTime $targetLastChecked = null; // The last checked date of the object in the target
+    // The last changed date of the object in the target
+    protected ?DateTime $targetLastChecked = null;
 
-    protected ?DateTime $targetLastSynced = null; // The last synced date of the object in the target
+    // The last checked date of the object in the target
+    protected ?DateTime $targetLastSynced = null;
 
-    protected ?string $targetLastAction = null; // The last CRUD action performed on the target (create, read, update, delete)
+    // The last synced date of the object in the target
+    protected ?string $targetLastAction = null;
+
+    // The last CRUD action performed on the target (create, read, update, delete)
     // General
-    protected ?DateTime $created = null; // the date and time the synchronization was created
+    protected ?DateTime $created = null;
 
-    protected ?DateTime $updated = null; // the date and time the synchronization was updated
-
-
+    // the date and time the synchronization was created
+    protected ?DateTime $updated = null;
+    // the date and time the synchronization was updated
     public function __construct()
     {
         $this->addType('uuid', 'string');

--- a/lib/Db/SynchronizationContractLog.php
+++ b/lib/Db/SynchronizationContractLog.php
@@ -31,8 +31,9 @@ class SynchronizationContractLog extends Entity implements JsonSerializable
 
     protected ?array $target = [];
 
-    protected ?string $targetResult = null; // CRUD action taken on target (create/read/update/delete)
+    protected ?string $targetResult = null;
 
+    // CRUD action taken on target (create/read/update/delete)
     protected ?string $userId = null;
 
     protected ?string $sessionId = null;
@@ -46,7 +47,7 @@ class SynchronizationContractLog extends Entity implements JsonSerializable
     protected ?DateTime $created = null;
 
     /**
-     * @var int $size Size of this log entry in bytes (calculated from serialized object)
+     * @var integer $size Size of this log entry in bytes (calculated from serialized object)
      */
     protected int $size = 4096;
 

--- a/lib/Db/SynchronizationContractMapper.php
+++ b/lib/Db/SynchronizationContractMapper.php
@@ -125,8 +125,8 @@ class SynchronizationContractMapper extends QBMapper
             ->where(
                 $qb->expr()->eq('origin_id', $qb->createNamedParameter($originId))
             )
-            ->setMaxResults(1); // Just in case
-
+            ->setMaxResults(1);
+        // Just in case
         try {
             $stmt   = $qb->executeQuery();
             $result = $stmt->fetchOne();
@@ -348,12 +348,14 @@ class SynchronizationContractMapper extends QBMapper
             ->where(
                 $qb->expr()->eq('origin_id', $qb->createNamedParameter($originId))
             )
-            ->setMaxResults(1); // Ensure only one result is returned
-
+            ->setMaxResults(1);
+        // Ensure only one result is returned
         try {
-            return $this->findEntity($qb); // Use findEntity to return a single result
+            return $this->findEntity($qb);
+            // Use findEntity to return a single result
         } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-            return null; // Return null if no match is found
+            return null;
+            // Return null if no match is found
         }
     }//end findByOriginId()
 
@@ -374,12 +376,14 @@ class SynchronizationContractMapper extends QBMapper
             ->from('openconnector_synchronization_contracts')
             ->where(
                 $qb->expr()->eq('target_id', $qb->createNamedParameter($targetId))
-            ); // Ensure only one result is returned
-
+            );
+        // Ensure only one result is returned
         try {
-            return $this->findEntities($qb); // Use findEntity to return a single result
+            return $this->findEntities($qb);
+            // Use findEntity to return a single result
         } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-            return []; // Return null if no match is found
+            return [];
+            // Return null if no match is found
         }
     }//end findByTargetId()
 

--- a/lib/Db/SynchronizationLog.php
+++ b/lib/Db/SynchronizationLog.php
@@ -35,7 +35,7 @@ class SynchronizationLog extends Entity implements JsonSerializable
     protected ?DateTime $expires = null;
 
     /**
-     * @var int $size Size of this log entry in bytes (calculated from serialized object)
+     * @var integer $size Size of this log entry in bytes (calculated from serialized object)
      */
     protected int $size = 4096;
 

--- a/lib/Migration/Version0Date20240826193657.php
+++ b/lib/Migration/Version0Date20240826193657.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -43,7 +43,7 @@ class Version0Date20240826193657 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();
@@ -227,19 +227,29 @@ class Version0Date20240826193657 extends SimpleMigrationStep
 
         if (!$schema->hasTable('openconnector_consumers')) {
             $table = $schema->createTable('openconnector_consumers');
-            $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]); // The id of the consumer
-            $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]); // The uuid of the consumer
-            $table->addColumn('name', Types::STRING, ['notnull' => true, 'length' => 255]); // The name of the consumer
-            $table->addColumn('description', Types::TEXT, ['notnull' => false]); // The description of the consumer
-            $table->addColumn('domains', Types::JSON, ['notnull' => false]); // The domains the consumer is allowed to run from
-            $table->addColumn('ips', Types::JSON, ['notnull' => false]); // The ips the consumer is allowed to run from
-            $table->addColumn('authorization_type', Types::STRING, ['notnull' => false, 'length' => 255]); // The authorization type of the consumer, should be one of the following: 'none', 'basic', 'bearer', 'apiKey', 'oauth2', 'jwt'. Keep in mind that the consumer needs to be able to handle the authorization type.
-            $table->addColumn('authorization_configuration', Types::TEXT, ['notnull' => false]); // The authorization configuration of the consumer
-            $table->addColumn('created', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']); // the date and time the consumer was created
-            $table->addColumn('updated', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']); // the date and time the consumer was updated
+            $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
+            // The id of the consumer
+            $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+            // The uuid of the consumer
+            $table->addColumn('name', Types::STRING, ['notnull' => true, 'length' => 255]);
+            // The name of the consumer
+            $table->addColumn('description', Types::TEXT, ['notnull' => false]);
+            // The description of the consumer
+            $table->addColumn('domains', Types::JSON, ['notnull' => false]);
+            // The domains the consumer is allowed to run from
+            $table->addColumn('ips', Types::JSON, ['notnull' => false]);
+            // The ips the consumer is allowed to run from
+            $table->addColumn('authorization_type', Types::STRING, ['notnull' => false, 'length' => 255]);
+            // The authorization type of the consumer, should be one of the following: 'none', 'basic', 'bearer', 'apiKey', 'oauth2', 'jwt'. Keep in mind that the consumer needs to be able to handle the authorization type.
+            $table->addColumn('authorization_configuration', Types::TEXT, ['notnull' => false]);
+            // The authorization configuration of the consumer
+            $table->addColumn('created', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);
+            // the date and time the consumer was created
+            $table->addColumn('updated', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);
+            // the date and time the consumer was updated
             $table->setPrimaryKey(['id']);
             $table->addIndex(['uuid'], 'openconnector_consumers_uuid_index');
-        }
+        }//end if
 
         if (!$schema->hasTable('openconnector_call_logs')) {
             $table = $schema->createTable('openconnector_call_logs');

--- a/lib/Migration/Version1Date20241111144800.php
+++ b/lib/Migration/Version1Date20241111144800.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -52,7 +52,7 @@ class Version1Date20241111144800 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();
@@ -108,7 +108,7 @@ class Version1Date20241111144800 extends SimpleMigrationStep
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20241121160300.php
+++ b/lib/Migration/Version1Date20241121160300.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -41,7 +41,7 @@ class Version1Date20241121160300 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20241126074122.php
+++ b/lib/Migration/Version1Date20241126074122.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -42,7 +42,7 @@ class Version1Date20241126074122 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20241206095007.php
+++ b/lib/Migration/Version1Date20241206095007.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -39,7 +39,7 @@ class Version1Date20241206095007 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20241210100000.php
+++ b/lib/Migration/Version1Date20241210100000.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -39,7 +39,7 @@ class Version1Date20241210100000 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20241210120155.php
+++ b/lib/Migration/Version1Date20241210120155.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -41,7 +41,7 @@ class Version1Date20241210120155 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20241218122708.php
+++ b/lib/Migration/Version1Date20241218122708.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -38,7 +38,7 @@ class Version1Date20241218122708 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20241218122932.php
+++ b/lib/Migration/Version1Date20241218122932.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -39,7 +39,7 @@ class Version1Date20241218122932 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20241230141628.php
+++ b/lib/Migration/Version1Date20241230141628.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -39,7 +39,7 @@ class Version1Date20241230141628 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20250107163601.php
+++ b/lib/Migration/Version1Date20250107163601.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -42,7 +42,7 @@ class Version1Date20250107163601 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20250109093325.php
+++ b/lib/Migration/Version1Date20250109093325.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -38,9 +38,9 @@ class Version1Date20250109093325 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
- * @var ISchemaWrapper $schema
-*/
+        /*
+         * @var ISchemaWrapper $schema
+         */
         $schema = $schemaClosure();
 
         if (!$schema->hasTable('openconnector_events')) {
@@ -124,10 +124,13 @@ class Version1Date20250109093325 extends SimpleMigrationStep
             $table->addColumn('description', Types::TEXT, ['notnull' => false]);
             $table->addColumn('reference', Types::STRING, ['notnull' => false, 'length' => 255]);
             $table->addColumn('version', Types::STRING, ['notnull' => true, 'length' => 255, 'default' => '0.0.1']);
-            $table->addColumn('action', Types::STRING, ['notnull' => true, 'length' => 20]); // create, read, update, delete
-            $table->addColumn('timing', Types::STRING, ['notnull' => true, 'length' => 10, 'default' => 'before']); // before or after
+            $table->addColumn('action', Types::STRING, ['notnull' => true, 'length' => 20]);
+            // create, read, update, delete
+            $table->addColumn('timing', Types::STRING, ['notnull' => true, 'length' => 10, 'default' => 'before']);
+            // before or after
             $table->addColumn('conditions', Types::JSON, ['notnull' => false]);
-            $table->addColumn('type', Types::STRING, ['notnull' => true, 'length' => 50]); // mapping, error, script, synchronization
+            $table->addColumn('type', Types::STRING, ['notnull' => true, 'length' => 50]);
+            // mapping, error, script, synchronization
             $table->addColumn('configuration', Types::JSON, ['notnull' => false]);
             $table->addColumn('order', Types::INTEGER, ['notnull' => true, 'default' => 0]);
             $table->addColumn('created', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);

--- a/lib/Migration/Version1Date20250109121103.php
+++ b/lib/Migration/Version1Date20250109121103.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -39,7 +39,7 @@ class Version1Date20250109121103 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20250118124025.php
+++ b/lib/Migration/Version1Date20250118124025.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -39,7 +39,7 @@ class Version1Date20250118124025 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();
@@ -68,13 +68,16 @@ class Version1Date20250118124025 extends SimpleMigrationStep
 
         if ($schema->hasTable(tableName: 'openconnector_synchronization_contracts') === true) {
             $table = $schema->getTable(tableName: 'openconnector_synchronization_contracts');
-            $table->addColumn('target_last_action', Types::STRING, ['notnull' => false, 'length' => 6]); // 6 chars is enough for 'create', 'update', 'delete'
+            $table->addColumn('target_last_action', Types::STRING, ['notnull' => false, 'length' => 6]);
+            // 6 chars is enough for 'create', 'update', 'delete'
         }
 
         if ($schema->hasTable(tableName: 'openconnector_synchronization_contract_logs') === true) {
             $table = $schema->getTable(tableName: 'openconnector_synchronization_contract_logs');
-            $table->addColumn('synchronization_log_id', Types::STRING, ['notnull' => false, 'length' => 36]); // synchronization_log_id
-            $table->addColumn('target_result', Types::STRING, ['notnull' => false, 'length' => 6]); // target_result
+            $table->addColumn('synchronization_log_id', Types::STRING, ['notnull' => false, 'length' => 36]);
+            // synchronization_log_id
+            $table->addColumn('target_result', Types::STRING, ['notnull' => false, 'length' => 6]);
+            // target_result
             $table->addColumn('test', Types::BOOLEAN, ['notnull' => true, 'default' => false]);
             $table->addColumn('force', Types::BOOLEAN, ['notnull' => true, 'default' => false]);
 

--- a/lib/Migration/Version1Date20250123100521.php
+++ b/lib/Migration/Version1Date20250123100521.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -39,7 +39,7 @@ class Version1Date20250123100521 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20250515232835.php
+++ b/lib/Migration/Version1Date20250515232835.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -47,7 +47,7 @@ class Version1Date20250515232835 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20250826103500.php
+++ b/lib/Migration/Version1Date20250826103500.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * JobLogMessageColumnMigration
  *
  * Migration step to increase the message column size in the openconnector_job_logs table
@@ -89,7 +89,7 @@ class Version1Date20250826103500 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Migration/Version1Date20250826120000.php
+++ b/lib/Migration/Version1Date20250826120000.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * LogSizeColumnsMigration
  *
  * Migration step to add size columns to all log tables for tracking log entry sizes.
@@ -92,7 +92,7 @@ class Version1Date20250826120000 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
+        /*
          * @var ISchemaWrapper $schema
          */
         $schema = $schemaClosure();

--- a/lib/Service/AuthorizationService.php
+++ b/lib/Service/AuthorizationService.php
@@ -249,17 +249,17 @@ class AuthorizationService
         }
 
         // @TODO: This code can be enabled once the frontend can properly set users and usergroups
-        //        $userInAllowedUsers = array_intersect($users, [$user->getUID(), $user->getEMailAddress()]) !== [];
+        // $userInAllowedUsers = array_intersect($users, [$user->getUID(), $user->getEMailAddress()]) !== [];
         //
-        //        $userGroups = array_map(function(IGroup $group) {
-        //            return $group->getGID();
-        //        }, $this->groupManager->getUserGroups($user));
+        // $userGroups = array_map(function(IGroup $group) {
+        // return $group->getGID();
+        // }, $this->groupManager->getUserGroups($user));
         //
-        //        $userInAllowedGroups = array_intersect($groups, $userGroups) !== [];
+        // $userInAllowedGroups = array_intersect($groups, $userGroups) !== [];
         //
-        //        if($userInAllowedUsers === false && $userInAllowedGroups === false) {
-        //            throw new AuthenticationException(message: 'Not authorized', details: ['reason' => 'The selected user is not allowed to login on this endpoint']);
-        //        }
+        // if($userInAllowedUsers === false && $userInAllowedGroups === false) {
+        // throw new AuthenticationException(message: 'Not authorized', details: ['reason' => 'The selected user is not allowed to login on this endpoint']);
+        // }
         $this->userSession->setUser($user);
     }//end authorizeBasic()
 
@@ -280,17 +280,17 @@ class AuthorizationService
         }
 
         // @TODO: This code can be enabled once the frontend can properly set users and usergroups
-        //        $userInAllowedUsers = array_intersect($users, [$user->getUID(), $user->getEMailAddress()]) !== [];
+        // $userInAllowedUsers = array_intersect($users, [$user->getUID(), $user->getEMailAddress()]) !== [];
         //
-        //        $userGroups = array_map(function(IGroup $group) {
-        //            return $group->getGID();
-        //        }, $this->groupManager->getUserGroups($user));
+        // $userGroups = array_map(function(IGroup $group) {
+        // return $group->getGID();
+        // }, $this->groupManager->getUserGroups($user));
         //
-        //        $userInAllowedGroups = array_intersect($groups, $userGroups) !== [];
+        // $userInAllowedGroups = array_intersect($groups, $userGroups) !== [];
         //
-        //        if($userInAllowedUsers === false && $userInAllowedGroups === false) {
-        //            throw new AuthenticationException(message: 'Not authorized', details: ['reason' => 'The selected user is not allowed to view endpoint']);
-        //        }
+        // if($userInAllowedUsers === false && $userInAllowedGroups === false) {
+        // throw new AuthenticationException(message: 'Not authorized', details: ['reason' => 'The selected user is not allowed to view endpoint']);
+        // }
     }//end authorizeOAuth()
 
     /**

--- a/lib/Service/ConfigurationService.php
+++ b/lib/Service/ConfigurationService.php
@@ -250,9 +250,9 @@ class ConfigurationService
 
         $id = (string) $id;
 
-        $this->mappings[$entityType]['idToSlug'][$id] = $slug;
+        $this->mappings[$entityType]['idToSlug'][$id]   = $slug;
         $this->mappings[$entityType]['slugToId'][$slug] = $id;
-    }
+    }//end registerImportedEntityMapping()
 
     /**
      * Ensure imported component payloads always carry their component-key slug.
@@ -273,7 +273,7 @@ class ConfigurationService
         }
 
         return $data;
-    }
+    }//end withComponentSlug()
 
     /**
      * Re-run import handlers for entity types whose dependencies are imported later
@@ -285,7 +285,7 @@ class ConfigurationService
      *
      * Each handler is idempotent (upsert by slug), so re-running it is safe.
      *
-     * @param array<string,mixed>               $components Original imported components
+     * @param array<string,mixed>                $components Original imported components
      * @param array<string,array<string,Entity>> $result     Imported entity result map
      *
      * @return void
@@ -305,7 +305,7 @@ class ConfigurationService
                 $result['endpoints'][$endpointSlug] = $this->handlers['endpoint']->import($endpointData, $this->mappings);
             }
         }
-    }
+    }//end reconcileImportedReferences()
 
     /**
      * Get all entities associated with a specific configuration ID, indexed by their slug.
@@ -874,7 +874,7 @@ class ConfigurationService
         if (isset($components['sources'])) {
             foreach ($components['sources'] as $sourceSlug => $sourceData) {
                 $sourceData = $this->withComponentSlug($sourceData, $sourceSlug);
-                $source = $this->handlers['source']->import($sourceData, $this->mappings);
+                $source     = $this->handlers['source']->import($sourceData, $this->mappings);
                 $result['sources'][$sourceSlug] = $source;
                 $this->registerImportedEntityMapping('source', $source);
             }
@@ -884,7 +884,7 @@ class ConfigurationService
         if (isset($components['mappings'])) {
             foreach ($components['mappings'] as $mappingSlug => $mappingData) {
                 $mappingData = $this->withComponentSlug($mappingData, $mappingSlug);
-                $mapping = $this->handlers['mapping']->import($mappingData, $this->mappings);
+                $mapping     = $this->handlers['mapping']->import($mappingData, $this->mappings);
                 $result['mappings'][$mappingSlug] = $mapping;
                 $this->registerImportedEntityMapping('mapping', $mapping);
             }
@@ -894,7 +894,7 @@ class ConfigurationService
         if (isset($components['rules'])) {
             foreach ($components['rules'] as $ruleSlug => $ruleData) {
                 $ruleData = $this->withComponentSlug($ruleData, $ruleSlug);
-                $rule = $this->handlers['rule']->import($ruleData, $this->mappings);
+                $rule     = $this->handlers['rule']->import($ruleData, $this->mappings);
                 $result['rules'][$ruleSlug] = $rule;
                 $this->registerImportedEntityMapping('rule', $rule);
             }
@@ -904,7 +904,7 @@ class ConfigurationService
         if (isset($components['endpoints'])) {
             foreach ($components['endpoints'] as $endpointSlug => $endpointData) {
                 $endpointData = $this->withComponentSlug($endpointData, $endpointSlug);
-                $endpoint = $this->handlers['endpoint']->import($endpointData, $this->mappings);
+                $endpoint     = $this->handlers['endpoint']->import($endpointData, $this->mappings);
                 $result['endpoints'][$endpointSlug] = $endpoint;
                 $this->registerImportedEntityMapping('endpoint', $endpoint);
             }
@@ -913,7 +913,7 @@ class ConfigurationService
         // 5. Import synchronizations (depends on sources, mappings, and endpoints).
         if (isset($components['synchronizations'])) {
             foreach ($components['synchronizations'] as $syncSlug => $syncData) {
-                $syncData = $this->withComponentSlug($syncData, $syncSlug);
+                $syncData        = $this->withComponentSlug($syncData, $syncSlug);
                 $synchronization = $this->handlers['synchronization']->import($syncData, $this->mappings);
                 $result['synchronizations'][$syncSlug] = $synchronization;
                 $this->registerImportedEntityMapping('synchronization', $synchronization);
@@ -924,7 +924,7 @@ class ConfigurationService
         if (isset($components['jobs'])) {
             foreach ($components['jobs'] as $jobSlug => $jobData) {
                 $jobData = $this->withComponentSlug($jobData, $jobSlug);
-                $job = $this->handlers['job']->import($jobData, $this->mappings);
+                $job     = $this->handlers['job']->import($jobData, $this->mappings);
                 $result['jobs'][$jobSlug] = $job;
                 $this->registerImportedEntityMapping('job', $job);
             }

--- a/lib/Service/EndpointCacheService.php
+++ b/lib/Service/EndpointCacheService.php
@@ -278,7 +278,8 @@ class EndpointCacheService
                 return '(?:/([^/]+))?$#';
             },
             $regex,
-            1 // Limit to only one replacement
+            1
+        // Limit to only one replacement
         );
 
         if (str_ends_with($regex, '?#') === false && str_ends_with($regex, '$#') === false) {

--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -195,29 +195,29 @@ class EndpointService
         try {
             $flowToken = new FlowToken(requestOriginal: $request, path: $path);
 
-            //            // Process initial data
-            //            $responseBody = $this->parseContent(
-            //                request: $request,
+            // Process initial data
+            // $responseBody = $this->parseContent(
+            // request: $request,
             //
-            //            );
+            // );
             //
-            //            if ($responseBody == '') {
-            //                $responseBody = [];
-            //            }
+            // if ($responseBody == '') {
+            // $responseBody = [];
+            // }
             //
             $currentDate = (new DateTime())->format('c');
             //
-            //            // This is double becuase mapping needs it in body but other rules seek directly in data.
+            // This is double becuase mapping needs it in body but other rules seek directly in data.
             //
-            //            $incomingMethod = $request->getMethod();
-            //            $incomingHeaders = $this->getHeaders($request->server, true);
-            //            $incomingParams = array_merge($request->getParams(), $responseBody);
+            // $incomingMethod = $request->getMethod();
+            // $incomingHeaders = $this->getHeaders($request->server, true);
+            // $incomingParams = array_merge($request->getParams(), $responseBody);
             //
-            //            $incomingData = [
-            //                'method' => $incomingMethod,
-            //                'headers' => $incomingHeaders,
-            //                'params' => $incomingParams
-            //            ];
+            // $incomingData = [
+            // 'method' => $incomingMethod,
+            // 'headers' => $incomingHeaders,
+            // 'params' => $incomingParams
+            // ];
             // @todo: This should eventually be merged into the flow tokens
             $data = [
                 'utility'    => [
@@ -406,9 +406,9 @@ class EndpointService
 
         $uses = (new Dot($object->jsonSerialize()))->flatten();
         //
-        //        if(isset($serializedObject) === true && !empty($serializedObject['@self']['relations'])) {
-        //            $uses = $serializedObject['@self']['relations'];
-        //        }
+        // if(isset($serializedObject) === true && !empty($serializedObject['@self']['relations'])) {
+        // $uses = $serializedObject['@self']['relations'];
+        // }
         $useUrls = [];
 
         $uuidToUrlMap = [];
@@ -463,7 +463,7 @@ class EndpointService
 
         // @TODO: correct rewriting self url. This has to be fixed with issue CONNECTOR-314
         // Add self object URI mapping
-        //        $uuidToUrlMap[$object->getUuid()] = $this->generateEndpointUrl(id: $object->getUuid(), schemaMapper: $schemaMapper);
+        // $uuidToUrlMap[$object->getUuid()] = $this->generateEndpointUrl(id: $object->getUuid(), schemaMapper: $schemaMapper);
         $uuidToUrlMap[$object->getUri()] = $this->generateEndpointUrl(id: $object->getUuid(), schemaMapper: $schemaMapper);
 
         // @TODO: temporary fix for download endpoints. This has to be fixed with issue CONNECTOR-314
@@ -511,7 +511,8 @@ class EndpointService
 
         $dot = new Dot([], parse: true);
         foreach ($reducedKeys as $path) {
-            $dot->set($path, true); // true is a safe placeholder for Dot to serialize
+            $dot->set($path, true);
+            // true is a safe placeholder for Dot to serialize
         }
 
         return $dot->jsonSerialize();
@@ -1124,10 +1125,10 @@ class EndpointService
 
             // Process each rule in order
             foreach ($ruleEntities as $rule) {
-                //                // Skip if rule action doesn't match request method
-                //                if (strtolower($rule->getAction()) !== strtolower($request->getMethod())) {
-                //                    continue;
-                //                }
+                // Skip if rule action doesn't match request method
+                // if (strtolower($rule->getAction()) !== strtolower($request->getMethod())) {
+                // continue;
+                // }
                 $logicResult = null;
 
                 $data['flowToken'] = $flowToken->__serialize();
@@ -1583,7 +1584,7 @@ class EndpointService
 
                     $tags = array_merge($config['tags'] ?? [], ["object:$objectId"]);
                     if ($file instanceof \OCP\Files\File === true) {
-                        //                        $this->attachTagsToFile(fileId: $file->getId(), tags: $tags);
+                        // $this->attachTagsToFile(fileId: $file->getId(), tags: $tags);
                     }
 
                     $result[$key] = $file->getPath();
@@ -1605,7 +1606,7 @@ class EndpointService
 
                 $tags = array_merge($config['tags'] ?? [], ["object:$objectId"]);
                 if ($file instanceof File === true) {
-                    //                    $this->attachTagsToFile(fileId: $file->getId(), tags: $tags);
+                    // $this->attachTagsToFile(fileId: $file->getId(), tags: $tags);
                 }
 
                 $dataDot[$config['filePath']] = $file->getPath();
@@ -1790,7 +1791,7 @@ class EndpointService
         $openRegister->setSchema($superSchemaId);
 
         $object = $openRegister->find(id: $objectId);
-        //        $location = $object->getFolder();
+        // $location = $object->getFolder();
         $fileService = $this->containerInterface->get('OCA\OpenRegister\Service\FileService');
         $location    = $fileService->getObjectFolder($object)->getPath();
 
@@ -1937,7 +1938,7 @@ class EndpointService
     {
         $config = $rule->getConfiguration();
 
-        /**
+        /*
          * @var ObjectEntity $object
          */
         $object = $this->objectService->getOpenRegisters()->getMapper('objectEntity')->find(identifier: $objectId);
@@ -1969,20 +1970,20 @@ class EndpointService
         }
 
         if (isset($data['parameters']['version']) === true) {
-            /**
- * @var File $file
-*/
+            /*
+             * @var File $file
+             */
              $file = $fileService->getFile(object: $object, file: $filename, version: $data['parameters']['version']);
         } else if (isset($data['parameters']['versie']) === true) {
             // @TODO: This can be nicer by mapping, but let's first get something sure
-            /**
- * @var File $file
-*/
+            /*
+             * @var File $file
+             */
              $file = $fileService->getFile(object: $object, file: $filename, version: $data['parameters']['versie']);
         } else {
-            /**
- * @var File $file
-*/
+            /*
+             * @var File $file
+             */
             $file = $fileService->getFile(object: $object, file: $filename);
         }
 
@@ -2033,7 +2034,8 @@ class EndpointService
 
         $flowToken->setRequestAmended($requestAmended);
 
-        return $flowToken; // Return the overridden request
+        return $flowToken;
+        // Return the overridden request
     }//end updateRequestWithRuleData()
 
     /**

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -94,6 +94,12 @@ class ExportService
         $dataString = $this->encode(objectArray: $objectArray, type: $accept);
 
         $this->download(dataString: $dataString, filename: $filename, type: $type);
+
+        // $this->download() is annotated #[NoReturn] and exits via the streamed
+        // file response; this return is unreachable but required by PHPStan
+        // since the JetBrains attribute is not natively understood.
+        // @phpstan-ignore-next-line
+        return new JSONResponse();
     }//end export()
 
     /**
@@ -211,6 +217,7 @@ class ExportService
 
         // Clean up: delete the temporary file
         unlink(filename: $filePath);
-        exit; // Ensure no further script execution
+        exit;
+        // Ensure no further script execution
     }//end download()
 }//end class

--- a/lib/Service/IBabsConnectorService.php
+++ b/lib/Service/IBabsConnectorService.php
@@ -121,8 +121,8 @@ class IBabsConnectorService
             $config = json_decode($config, true);
         }
 
-        $organisatieId = $config['organisatieId'] ?? null;
-
+        // NOTE: $config['organisatieId'] will be used by the real CallService
+        // upload once implemented; placeholder body below does not consume it.
         $metadata = [
             'onderwerp'          => $voorstel['onderwerp'] ?? '',
             'portefeuillehouder' => $voorstel['portefeuillehouder'] ?? '',

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -114,7 +114,7 @@ class ObjectService
 
         // @todo Fix mongodb sort
         // if (empty($sort) === false) {
-        //     $object['filter'][] = ['$sort' => $sort];
+        // $object['filter'][] = ['$sort' => $sort];
         // }
         $returnData = $client->post(
             uri: 'action/find',

--- a/lib/Service/OrganisationBridgeService.php
+++ b/lib/Service/OrganisationBridgeService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * OrganisationBridgeService
  *
  * This service acts as a bridge to access the OrganisationService from the OpenRegister app.

--- a/lib/Service/RuleService.php
+++ b/lib/Service/RuleService.php
@@ -302,34 +302,34 @@ class RuleService
 
         // // Add organisaties (leveranciers) to response data
         // foreach ($organisaties as $organisatie) {
-        //     $organisatie = $organisatie->jsonSerialize();
-        //     $newUuid = Uuid::v4();
-        //     $elementId = "id-{$newUuid}";
-        //     $data['body']['elements'][] = [
-        //         'identifier' => $elementId,
-        //         'name' => $organisatie['naam'],
-        //         'name-lang' => 'nl',
-        //         'documentation' => $organisatie['beschrijving'],
-        //         'documentation-lang' => 'nl',
-        //         'type' => 'BusinessActor',
-        //         'properties' => [
-        //             0 => [
-        //                 'propertyDefinitionRef' => 'id-c3355444b6cb8fb34b62e241dd073043', // SWC type
-        //                 'value' => 'Leverancier',
-        //             ],
-        //             1 => [
-        //                 'propertyDefinitionRef' => 'propid-2', // Object ID
-        //                 'value' => $newUuid,
-        //             ],
-        //             2 => [
-        //                 'propertyDefinitionRef' => 'propid-39', // URL
-        //                 'value' => '',
-        //             ],
-        //         ],
-        //     ];
+        // $organisatie = $organisatie->jsonSerialize();
+        // $newUuid = Uuid::v4();
+        // $elementId = "id-{$newUuid}";
+        // $data['body']['elements'][] = [
+        // 'identifier' => $elementId,
+        // 'name' => $organisatie['naam'],
+        // 'name-lang' => 'nl',
+        // 'documentation' => $organisatie['beschrijving'],
+        // 'documentation-lang' => 'nl',
+        // 'type' => 'BusinessActor',
+        // 'properties' => [
+        // 0 => [
+        // 'propertyDefinitionRef' => 'id-c3355444b6cb8fb34b62e241dd073043', // SWC type
+        // 'value' => 'Leverancier',
+        // ],
+        // 1 => [
+        // 'propertyDefinitionRef' => 'propid-2', // Object ID
+        // 'value' => $newUuid,
+        // ],
+        // 2 => [
+        // 'propertyDefinitionRef' => 'propid-39', // URL
+        // 'value' => '',
+        // ],
+        // ],
+        // ];
         // }
         // foreach ($voorzieningAanbod as $voorzieningAanbod) {
-        //     $voorzieningAanbod = $voorzieningAanbod->jsonSerialize();
+        // $voorzieningAanbod = $voorzieningAanbod->jsonSerialize();
         // }
         return $data;
     }//end processSoftwareCatalogusRule()
@@ -402,7 +402,8 @@ class RuleService
         // Add datum export
         $datumExport = new DateTime();
         $data['body']['properties'][] = [
-            'propertyDefinitionRef' => self::PROP_DATUM_EXPORT, // Datum export
+            'propertyDefinitionRef' => self::PROP_DATUM_EXPORT,
+        // Datum export
             'value'                 => $datumExport->format('Y-m-d H:i:s'),
             'value-lang'            => 'nl',
         ];
@@ -459,7 +460,8 @@ class RuleService
         }
 
         // Add the Applicaties / Pakketten (Softwarecatalogus) folder
-        $applicationFolderCount = count($data['body']['organizations'][$applicationFolderKey]['item']); // Index for adding to this organization/folder later on.
+        $applicationFolderCount = count($data['body']['organizations'][$applicationFolderKey]['item']);
+        // Index for adding to this organization/folder later on.
         $data['body']['organizations'][$applicationFolderKey]['item'][] = [
             'identifier' => "id-29ec7061-0aba-c9eb-25fd-7c9232e4f0",
             'label'      => "Applicaties (Softwarecatalogus)",
@@ -467,7 +469,8 @@ class RuleService
         ];
 
         // Add the Relaties (Softwarecatalogus) folder
-        $relationsFolderCount = count($data['body']['organizations'][$relationsFolderKey]['item']); // Index for adding to this organization/folder later on.
+        $relationsFolderCount = count($data['body']['organizations'][$relationsFolderKey]['item']);
+        // Index for adding to this organization/folder later on.
         $data['body']['organizations'][$relationsFolderKey]['item'][] = [
             'identifier' => "id-8e7d5c3b-6a2f-9d4e-1b3c-7a9e2d5f8c0b",
             'label'      => "Relaties (Softwarecatalogus)",
@@ -541,27 +544,33 @@ class RuleService
                 'type'               => 'ApplicationComponent',
                 'properties'         => [
                     [
-                        'propertyDefinitionRef' => self::PROP_SWC_TYPE, // SWC type
+                        'propertyDefinitionRef' => self::PROP_SWC_TYPE,
+            // SWC type
                         'value'                 => 'Pakket',
                     ],
                     [
-                        'propertyDefinitionRef' => self::PROP_OBJECT_ID, // Object ID
+                        'propertyDefinitionRef' => self::PROP_OBJECT_ID,
+                    // Object ID
                         'value'                 => $voorziening['id'],
                     ],
                     [
-                        'propertyDefinitionRef' => 'propid-39', // URL
+                        'propertyDefinitionRef' => 'propid-39',
+                    // URL
                         'value'                 => '',
                     ],
                     [
-                        'propertyDefinitionRef' => self::PROP_EXTERN_PAKKET, // Extern Pakket
+                        'propertyDefinitionRef' => self::PROP_EXTERN_PAKKET,
+                    // Extern Pakket
                         'value'                 => 'n',
                     ],
                     [
-                        'propertyDefinitionRef' => self::PROP_OMSCHRIJVING, // Omschrijving gebruik
+                        'propertyDefinitionRef' => self::PROP_OMSCHRIJVING,
+                    // Omschrijving gebruik
                         'value'                 => '',
                     ],
                     [
-                        'propertyDefinitionRef' => self::BRON, // Omschrijving gebruik
+                        'propertyDefinitionRef' => self::BRON,
+                    // Omschrijving gebruik
                         'value'                 => 'Softwarecatalogus',
                     ],
                 ],
@@ -685,7 +694,8 @@ class RuleService
                 // Available width = (parent width - left/right padding - spacing between children) / number of children
                 $childWidth = min(
                     ($parentWidth - ($childSpacing * ($totalChildren - 1))) / $totalChildren,
-                    120 // Maximum width of 120px
+                    120
+                // Maximum width of 120px
                 );
 
                 // Child height at least 30px and no more than 100px
@@ -800,7 +810,8 @@ class RuleService
             'type'       => $relationType,
             'properties' => [
                 [
-                    'propertyDefinitionRef' => self::PROP_OBJECT_ID, // Object ID
+                    'propertyDefinitionRef' => self::PROP_OBJECT_ID,
+        // Object ID
                     'value'                 => $relationUuid,
                 ],
                 [

--- a/lib/Service/SOAPService.php
+++ b/lib/Service/SOAPService.php
@@ -147,10 +147,10 @@ class SOAPService
                     )
                 ),
                 $this->transport = Psr18Transport::createForClient($this->client),
-            //                $transport = new TraceableTransport(
-            //                    $client,
-            //                    new ExtSoapClientTransport($client)
-            //                )
+            // $transport = new TraceableTransport(
+            // $client,
+            // new ExtSoapClientTransport($client)
+            // )
             );
         } catch (\SoapFault $fault) {
             throw $fault;
@@ -228,7 +228,7 @@ class SOAPService
                     return $system;
                 }
                 );
-        /**
+        /*
          * @var $engine Engine
          */
         $engine = $this->setupEngine(source: $source, passedConfig: $config);

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -101,7 +101,7 @@ class SearchService
 
         $directory = $this->directoryService->listDirectory(limit: 1000);
 
-        //        $directory = $this->objectService->findObjects(filters: ['_schema' => 'directory'], config: $dbConfig);
+        // $directory = $this->objectService->findObjects(filters: ['_schema' => 'directory'], config: $dbConfig);
         if (count($directory) === 0) {
             $pages = (int) ceil($totalResults / $limit);
             return [

--- a/lib/Service/SecurityService.php
+++ b/lib/Service/SecurityService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SecurityService
  *
  * Service for handling security measures including rate limiting and XSS protection
@@ -59,11 +59,16 @@ class SecurityService
     /**
      * Rate limiting configuration constants
      */
-    private const RATE_LIMIT_ATTEMPTS    = 5; // Max attempts per time window
-    private const RATE_LIMIT_WINDOW      = 900; // 15 minutes in seconds
-    private const LOCKOUT_DURATION       = 3600; // 1 hour in seconds
-    private const PROGRESSIVE_DELAY_BASE = 2; // Base delay in seconds
-    private const MAX_PROGRESSIVE_DELAY  = 60; // Maximum delay in seconds
+    private const RATE_LIMIT_ATTEMPTS = 5;
+    // Max attempts per time window
+    private const RATE_LIMIT_WINDOW = 900;
+    // 15 minutes in seconds
+    private const LOCKOUT_DURATION = 3600;
+    // 1 hour in seconds
+    private const PROGRESSIVE_DELAY_BASE = 2;
+    // Base delay in seconds
+    private const MAX_PROGRESSIVE_DELAY = 60;
+    // Maximum delay in seconds
 
     /**
      * Cache key prefixes for different security features
@@ -342,13 +347,20 @@ class SecurityService
 
         // Remove potentially dangerous patterns
         $dangerousPatterns = [
-            '/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/mi', // Script tags
-            '/javascript:/i', // JavaScript protocol
-            '/vbscript:/i', // VBScript protocol
-            '/onload\s*=/i', // onload events
-            '/onerror\s*=/i', // onerror events
-            '/onclick\s*=/i', // onclick events
-            '/onmouseover\s*=/i', // onmouseover events
+            '/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/mi',
+        // Script tags
+            '/javascript:/i',
+        // JavaScript protocol
+            '/vbscript:/i',
+        // VBScript protocol
+            '/onload\s*=/i',
+        // onload events
+            '/onerror\s*=/i',
+        // onerror events
+            '/onclick\s*=/i',
+        // onclick events
+            '/onmouseover\s*=/i',
+        // onmouseover events
         ];
 
         foreach ($dangerousPatterns as $pattern) {
@@ -378,8 +390,8 @@ class SecurityService
         }
 
         // Sanitize username (but preserve original for authentication)
-        $sanitizedUsername = $this->sanitizeInput($credentials['username'], 320); // Max email length
-
+        $sanitizedUsername = $this->sanitizeInput($credentials['username'], 320);
+        // Max email length
         // Validate username format (basic checks)
         if (strlen($sanitizedUsername) < 2) {
             return [
@@ -398,7 +410,8 @@ class SecurityService
 
         // Password validation
         $password = $credentials['password'];
-        if (strlen($password) > 1000) { // Prevent extremely long passwords
+        if (strlen($password) > 1000) {
+            // Prevent extremely long passwords
             return [
                 'valid' => false,
                 'error' => 'Password is too long',
@@ -409,7 +422,8 @@ class SecurityService
             'valid'       => true,
             'credentials' => [
                 'username' => $sanitizedUsername,
-                'password' => $password,// Don't sanitize password as it might change the actual value
+                'password' => $password,
+        // Don't sanitize password as it might change the actual value
             ],
         ];
     }//end validateLoginCredentials()
@@ -464,12 +478,18 @@ class SecurityService
 
         // Check for forwarded IP headers (in order of preference)
         $forwardedHeaders = [
-            'HTTP_CF_CONNECTING_IP', // Cloudflare
-            'HTTP_X_FORWARDED_FOR', // Standard proxy header
-            'HTTP_X_REAL_IP', // Nginx
-            'HTTP_X_FORWARDED', // Alternative
-            'HTTP_FORWARDED_FOR', // Alternative
-            'HTTP_FORWARDED', // RFC 7239
+            'HTTP_CF_CONNECTING_IP',
+        // Cloudflare
+            'HTTP_X_FORWARDED_FOR',
+        // Standard proxy header
+            'HTTP_X_REAL_IP',
+        // Nginx
+            'HTTP_X_FORWARDED',
+        // Alternative
+            'HTTP_FORWARDED_FOR',
+        // Alternative
+            'HTTP_FORWARDED',
+        // RFC 7239
         ];
 
         foreach ($forwardedHeaders as $header) {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -195,12 +195,18 @@ class SettingsService
             // Retention Settings with defaults
             // Retention Settings with defaults
             $data['retention'] = [
-                'successLogRetention'      => 3600000,     // 1 Hour default
-                'callLogRetention'         => 2592000000,  // 1 month default
-                'eventMessageRetention'    => 604800000,   // 1 week default
-                'jobLogRetention'          => 2592000000,  // 1 month default
-                'syncContractLogRetention' => 7776000000,  // 3 months default
-                'syncLogRetention'         => 2592000000,  // 1 month default
+                'successLogRetention'      => 3600000,
+            // 1 Hour default
+                'callLogRetention'         => 2592000000,
+            // 1 month default
+                'eventMessageRetention'    => 604800000,
+            // 1 week default
+                'jobLogRetention'          => 2592000000,
+            // 1 month default
+                'syncContractLogRetention' => 7776000000,
+            // 3 months default
+                'syncLogRetention'         => 2592000000,
+            // 1 month default
             ];
 
             $retentionConfig = $this->config->getValueString($this->appName, 'retention', '');
@@ -304,7 +310,8 @@ class SettingsService
                         WHERE expires IS NULL OR expires = ''
                     ";
                     $stmt        = $this->db->prepare($expiryQuery);
-                    $stmt->execute([$retentionMs * 1000]); // Convert ms to microseconds
+                    $stmt->execute([$retentionMs * 1000]);
+                    // Convert ms to microseconds
                     $results['retentionResults']['callLogsUpdated'] = $stmt->rowCount();
                 } catch (\Exception $e) {
                     $error = 'Failed to set call logs expiry dates: '.$e->getMessage();
@@ -323,7 +330,8 @@ class SettingsService
                         WHERE expires IS NULL OR expires = ''
                     ";
                     $stmt        = $this->db->prepare($expiryQuery);
-                    $stmt->execute([$retentionMs * 1000]); // Convert ms to microseconds
+                    $stmt->execute([$retentionMs * 1000]);
+                    // Convert ms to microseconds
                     $results['retentionResults']['callLogsUpdated'] = $stmt->rowCount();
                 } catch (\Exception $e) {
                     $error = 'Failed to set call logs expiry dates: '.$e->getMessage();

--- a/lib/Service/StorageService.php
+++ b/lib/Service/StorageService.php
@@ -77,7 +77,7 @@ class StorageService
     public function createUpload(string $path, string $fileName, int $size, ?string $objectId=null): array
     {
         $user = $this->userManager->get(self::APP_USER);
-        //        $userFolder = $this->rootFolder->getUserFolder(userId: $user ? $user->getUID() : 'Guest');
+        // $userFolder = $this->rootFolder->getUserFolder(userId: $user ? $user->getUID() : 'Guest');
         $uploadFolder = $this->rootFolder->get($path);
 
         $partSize = $this->config->getValueInt('openconnector', 'part-size', 1000000);
@@ -87,7 +87,7 @@ class StorageService
         $remainingSize = $size;
         $parts         = [];
 
-        /**
+        /*
          * @var File $target
          */
         $target = $uploadFolder->newFile($fileName);
@@ -141,9 +141,9 @@ class StorageService
         $uploadFolder = $userFolder->get($path);
 
         try {
-            /**
- * @var File $target
-*/
+            /*
+             * @var File $target
+             */
             $target = $uploadFolder->get($fileName);
             $target->putContent($content);
         } catch (NotFoundException $e) {

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -80,9 +80,8 @@ class SynchronizationService
     const EXTEND_BEFORE_CONDITIONS_FETCH_OBJECT = 'extendInputFetchObjectBeforeConditions';
     const FILE_TAG_TYPE        = 'files';
     const VALID_MUTATION_TYPES = ['create', 'update', 'delete'];
-    const DEFAULT_MAX_PAGES    = 50; // Safety limit to prevent infinite page requesting loop
-
-
+    const DEFAULT_MAX_PAGES    = 50;
+    // Safety limit to prevent infinite page requesting loop
     private const DEFAULT_SUCCESS_LOG_RETENTION = 3600000;
     private const DEFAULT_ERROR_LOG_RETENTION   = 259200000;
 
@@ -593,7 +592,8 @@ class SynchronizationService
                 $objectList = $this->getAllObjectsFromSource($synchronization, $isTest, $data);
             } catch (TooManyRequestsHttpException $e) {
                 $rateLimitException = $e;
-                $objectList         = []; // Ensure it's defined
+                $objectList         = [];
+                // Ensure it's defined
             }
 
             $fetchDuration = round((microtime(true) - $stageStartTime) * 1000, 2);
@@ -1384,7 +1384,8 @@ class SynchronizationService
         return [
             'log'          => $contractLog ? $contractLog->jsonSerialize() : [],
             'contract'     => $synchronizationContract->jsonSerialize(),
-            'resultAction' => 'update',// /create
+            'resultAction' => 'update',
+        // /create
         ];
     }//end synchronizeContract()
 
@@ -1437,17 +1438,17 @@ class SynchronizationService
                 $synchronizationContract->setTargetId($target->getUuid());
 
                 // @TODO: Orphan cleanup is done also in the fetch file rule, this can be removed after a succesful test.
-                //                // Clean up orphaned files based on the attachments array
-                //                if (isset($targetObject['attachments']) && is_array($targetObject['attachments'])) {
-                //                    try {
-                //                        $deletedCount = $this->cleanupFilesFromAttachments($target->getUuid(), $targetObject['attachments']);
-                //                        if ($deletedCount > 0) {
-                //                            error_log("Cleaned up {$deletedCount} orphaned files for object {$target->getUuid()}");
-                //                        }
-                //                    } catch (Exception $e) {
-                //                        error_log("Failed to cleanup orphaned files for object {$target->getUuid()}: " . $e->getMessage());
-                //                    }
-                //                }
+                // Clean up orphaned files based on the attachments array
+                // if (isset($targetObject['attachments']) && is_array($targetObject['attachments'])) {
+                // try {
+                // $deletedCount = $this->cleanupFilesFromAttachments($target->getUuid(), $targetObject['attachments']);
+                // if ($deletedCount > 0) {
+                // error_log("Cleaned up {$deletedCount} orphaned files for object {$target->getUuid()}");
+                // }
+                // } catch (Exception $e) {
+                // error_log("Failed to cleanup orphaned files for object {$target->getUuid()}: " . $e->getMessage());
+                // }
+                // }
                 // Handle sub-objects synchronization if sourceConfig is defined
                 if (isset($sourceConfig['subObjects']) === true) {
                     $targetObject = $objectService->renderEntity($target, ['all']);
@@ -1846,7 +1847,8 @@ class SynchronizationService
         $this->checkRateLimit($source);
 
         // Extract source configuration
-        $sourceConfig   = $this->callService->applyConfigDot($synchronization->getSourceConfig()); // TODO; This is the second time this function is called in the synchonysation flow, needs further refactoring investigation
+        $sourceConfig = $this->callService->applyConfigDot($synchronization->getSourceConfig());
+        // TODO; This is the second time this function is called in the synchonysation flow, needs further refactoring investigation
         $endpoint       = $sourceConfig['endpoint'] ?? '';
         $headers        = $sourceConfig['headers'] ?? [];
         $query          = $sourceConfig['query'] ?? [];
@@ -2065,7 +2067,8 @@ class SynchronizationService
             // Use next endpoint URL pagination
             $nextEndpoint = $this->getNextEndpoint(body: $result, url: $source->getLocation(), currentEndpoint: $currentEndpoint);
             if ($nextEndpoint === null || $nextEndpoint === $currentEndpoint) {
-                return null; // No more pages
+                return null;
+                // No more pages
             }
 
             return [
@@ -2080,7 +2083,8 @@ class SynchronizationService
             $nextConfig = $this->getNextPage(config: $config, sourceConfig: $synchronization->getSourceConfig(), currentPage: $nextPage);
 
             return [
-                'endpoint'         => $currentEndpoint, // Base endpoint stays the same
+                'endpoint'         => $currentEndpoint,
+            // Base endpoint stays the same
                 'config'           => $nextConfig,
                 'page'             => $nextPage,
                 'usesNextEndpoint' => false,
@@ -2185,8 +2189,8 @@ class SynchronizationService
     {
         $allObjects      = [];
         $currentEndpoint = $endpoint;
-        $maxPages        = 50; // Safety limit
-
+        $maxPages        = 50;
+        // Safety limit
         for ($i = 0; $i < $maxPages; $i++) {
             $pageData    = $this->fetchSinglePageData($source, $currentEndpoint, $config, $synchronization);
             $pageObjects = $pageData['objects'];
@@ -2802,7 +2806,7 @@ class SynchronizationService
         try {
             return $this->ruleMapper->find((int) $id);
         } catch (Exception $e) {
-            //            $this->logger->error('Error fetching rule: ' . $e->getMessage());
+            // $this->logger->error('Error fetching rule: ' . $e->getMessage());
             return null;
         }
     }//end getRuleById()
@@ -3222,45 +3226,45 @@ class SynchronizationService
         // $tags = [];
         // $published = null;
         // $registerId = null;
-        //        switch ($this->getArrayType($endpoint)) {
-        //            // Single file endpoint
-        //            case 'Not array':
-        //                $this->fetchFile(source: $source, endpoint: $endpoint, config: $config, objectId: $objectId, tags: $tags, published: $published);
-        //                break;
-        //            // Array of object that has file(s)
-        //            case 'Associative array':
-        //                $actualEndpoint = $this->getFileContext(config: $config, endpoint: $endpoint, filename: $filename, tags: $tags, objectId: $objectId, published: $published, registerId: $registerId);
+        // switch ($this->getArrayType($endpoint)) {
+        // Single file endpoint
+        // case 'Not array':
+        // $this->fetchFile(source: $source, endpoint: $endpoint, config: $config, objectId: $objectId, tags: $tags, published: $published);
+        // break;
+        // Array of object that has file(s)
+        // case 'Associative array':
+        // $actualEndpoint = $this->getFileContext(config: $config, endpoint: $endpoint, filename: $filename, tags: $tags, objectId: $objectId, published: $published, registerId: $registerId);
         //
-        //                if ($actualEndpoint === null) {
-        //                    return $dataDot->jsonSerialize();
-        //                }
-        //                $this->fetchFile(source: $source, endpoint: $actualEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, filename: $filename, published: $published);
-        //                break;
-        //            // Array of object(s) that has file(s)
-        //            case "Multidimensional array":
-        //                foreach ($endpoint as $object) {
-        //                    $filename = null;
-        //                    $tags = [];
-        //                    $published = null;
-        //                    $registerId = null;
-        //                    $actualEndpoint = $this->getFileContext(config: $config, endpoint: $object, filename: $filename, tags: $tags, objectId: $objectId, published: $published, registerId: $registerId);
-        //                    if ($actualEndpoint === null) {
-        //                        continue;
-        //                    }
-        //                    $this->fetchFile(source: $source, endpoint: $actualEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, filename: $filename, published: $published);
-        //                }
-        //                break;
-        //            // Array of just endpoints
-        //            case "Indexed array":
-        //                foreach ($endpoint as $key => $childEndpoint) {
-        //                    $filename = null;
-        //                    $tags = [];
-        //                    $published = null;
-        //                    $registerId = null;
-        //                    $this->fetchFile(source: $source, endpoint: $childEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, published: $published);
-        //                }
-        //                break;
-        //        }
+        // if ($actualEndpoint === null) {
+        // return $dataDot->jsonSerialize();
+        // }
+        // $this->fetchFile(source: $source, endpoint: $actualEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, filename: $filename, published: $published);
+        // break;
+        // Array of object(s) that has file(s)
+        // case "Multidimensional array":
+        // foreach ($endpoint as $object) {
+        // $filename = null;
+        // $tags = [];
+        // $published = null;
+        // $registerId = null;
+        // $actualEndpoint = $this->getFileContext(config: $config, endpoint: $object, filename: $filename, tags: $tags, objectId: $objectId, published: $published, registerId: $registerId);
+        // if ($actualEndpoint === null) {
+        // continue;
+        // }
+        // $this->fetchFile(source: $source, endpoint: $actualEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, filename: $filename, published: $published);
+        // }
+        // break;
+        // Array of just endpoints
+        // case "Indexed array":
+        // foreach ($endpoint as $key => $childEndpoint) {
+        // $filename = null;
+        // $tags = [];
+        // $published = null;
+        // $registerId = null;
+        // $this->fetchFile(source: $source, endpoint: $childEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, published: $published);
+        // }
+        // break;
+        // }
         // Start fire-and-forget file fetching based on endpoint type
         $this->startAsyncFileFetching(source: $source, config: $config, endpoint: $endpoint, ruleId: $rule->getId(), objectId: $objectId);
 
@@ -3328,8 +3332,9 @@ class SynchronizationService
 
                 // Array of object that has file(s)
                 case 'Associative array':
-                    $contextObjectId = null; // Separate variable to avoid overwriting the original
-                    $actualEndpoint  = $this->getFileContext(config: $config, endpoint: $endpoint, filename: $filename, tags: $tags, objectId: $contextObjectId, published: $published, registerId: $registerId);
+                    $contextObjectId = null;
+                    // Separate variable to avoid overwriting the original
+                    $actualEndpoint = $this->getFileContext(config: $config, endpoint: $endpoint, filename: $filename, tags: $tags, objectId: $contextObjectId, published: $published, registerId: $registerId);
                     // Use context object ID if specified, otherwise fall back to the original object ID
                     $targetObjectId = $contextObjectId ?? $objectId;
                     if ($actualEndpoint !== null) {
@@ -3858,9 +3863,9 @@ class SynchronizationService
             return $this->synchronizationMapper->find($id);
         }
 
-        /**
- * @var Synchronization[] $synchronizations
-*/
+        /*
+         * @var Synchronization[] $synchronizations
+         */
         $synchronizations = $this->synchronizationMapper->findAll(filters: $filters);
 
         if (count($synchronizations) === 0) {
@@ -4223,7 +4228,7 @@ class SynchronizationService
         return false;
     }//end shouldPublishFile()
 
-    /**
+    /*
      * Fetches a file from a given endpoint and saves it to the OpenRegister system.
      *
      * This method downloads a file from a remote source and stores it in the OpenRegister

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * UserService
  *
  * This service handles all user-related business logic including user data retrieval,
@@ -131,7 +131,8 @@ class UserService
             'avatarScope'         => method_exists($user, 'getAvatarScope') ? $user->getAvatarScope() : 'contacts',
             'lastLogin'           => method_exists($user, 'getLastLogin') ? $user->getLastLogin() : 0,
             'backend'             => method_exists($user, 'getBackendClassName') ? $user->getBackendClassName() : 'unknown',
-            'subadmin'            => [], // Subadmin info would require additional service
+            'subadmin'            => [],
+        // Subadmin info would require additional service
             'groups'              => $groupNames,
             'language'            => $language,
             'locale'              => $locale,
@@ -361,7 +362,8 @@ class UserService
             $currentMemoryUsage  = memory_get_usage(true);
 
             // If we're already using too much memory, return 0 to prevent OOM
-            if ($currentMemoryUsage > 128 * 1024 * 1024) { // 128MB threshold
+            if ($currentMemoryUsage > 128 * 1024 * 1024) {
+                // 128MB threshold
                 $this->logger->warning(
                         'Memory usage too high for quota calculation',
                         [

--- a/lib/Settings/OpenConnectorAdmin.php
+++ b/lib/Settings/OpenConnectorAdmin.php
@@ -36,7 +36,8 @@ class OpenConnectorAdmin implements ISettings
 
     public function getSection()
     {
-        return 'openconnector'; // Name of the previously created section.
+        return 'openconnector';
+        // Name of the previously created section.
     }//end getSection()
 
     /**

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * Warn when a PHP class or public method lacks an @spec PHPDoc tag.
+ *
+ * ConductionNL ADR-003 (Backend rules) mandates that every class and public
+ * method MUST have one or more @spec PHPDoc tags linking back to the OpenSpec
+ * change that caused the code to exist:
+ *
+ *     @spec openspec/changes/{change-name}/tasks.md#task-N
+ *
+ * This sniff emits warnings (not errors) so that CI surfaces the gap without
+ * blocking merges while teams backfill coverage. Tests files and magic
+ * methods are skipped, as are private/protected methods — the ADR only
+ * mandates @spec for classes and public methods.
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * SpecTagSniff — warns when @spec PHPDoc tag is missing on classes / public methods.
+ */
+class SpecTagSniff implements Sniff
+{
+
+
+    /**
+     * PHP magic methods that are exempt from the @spec requirement.
+     *
+     * @var array<string>
+     */
+    private const MAGIC_METHODS = [
+        '__construct',
+        '__destruct',
+        '__get',
+        '__set',
+        '__call',
+        '__callstatic',
+        '__isset',
+        '__unset',
+        '__tostring',
+        '__invoke',
+        '__clone',
+        '__sleep',
+        '__wakeup',
+        '__serialize',
+        '__unserialize',
+        '__set_state',
+        '__debuginfo',
+    ];
+
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_CLASS, T_FUNCTION];
+
+    }//end register()
+
+
+    /**
+     * Process a T_CLASS or T_FUNCTION token.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // Skip test files.
+        if ($this->isTestFile(phpcsFile: $phpcsFile) === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $code   = $tokens[$stackPtr]['code'];
+
+        if ($code === T_CLASS) {
+            $this->processClass(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+        if ($code === T_FUNCTION) {
+            $this->processFunction(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+    }//end process()
+
+
+    /**
+     * Check a class declaration for an @spec docblock tag.
+     *
+     * Skips anonymous classes (no name follows the T_CLASS keyword).
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_CLASS token.
+     *
+     * @return void
+     */
+    private function processClass(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Anonymous classes — $var = new class { ... } — have no name; skip.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1), null, false, null, true);
+        if ($namePtr === false) {
+            return;
+        }
+
+        // Sanity: name should be on the same line or within a short window.
+        $openBracePtr = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1));
+        if ($openBracePtr !== false && $namePtr > $openBracePtr) {
+            return;
+        }
+
+        $className = $tokens[$namePtr]['content'];
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Class %s is missing @spec PHPDoc tag — link back to openspec/changes/{name}/tasks.md#task-N';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingClassSpec', [$className]);
+
+    }//end processClass()
+
+
+    /**
+     * Check a function declaration for an @spec docblock tag.
+     *
+     * Only flags public methods declared inside a class. Global functions,
+     * private/protected methods, and magic methods are skipped.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return void
+     */
+    private function processFunction(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Must be inside a class scope.
+        $className = $this->getEnclosingClassName(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+        if ($className === null) {
+            return;
+        }
+
+        // Get method name.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1));
+        if ($namePtr === false) {
+            return;
+        }
+
+        $methodName = $tokens[$namePtr]['content'];
+
+        // Skip magic methods.
+        if (in_array(strtolower($methodName), self::MAGIC_METHODS, true) === true) {
+            return;
+        }
+
+        // Determine visibility: default is public when no modifier present.
+        if ($this->isPublicMethod(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === false) {
+            return;
+        }
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Public method %s::%s() is missing @spec PHPDoc tag';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingMethodSpec', [$className, $methodName]);
+
+    }//end processFunction()
+
+
+    /**
+     * Check whether the docblock directly preceding $stackPtr contains an @spec tag.
+     *
+     * Walks backwards from the token skipping whitespace, attribute tokens, and
+     * visibility/abstract/final/static modifiers. If the next non-skipped token
+     * is the close of a doc comment, scan the block for @spec.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the class/function token.
+     *
+     * @return bool True when an @spec tag is present.
+     */
+    private function hasSpecTag(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $skip = [
+            T_WHITESPACE,
+            T_ABSTRACT,
+            T_FINAL,
+            T_STATIC,
+            T_PUBLIC,
+            T_PROTECTED,
+            T_PRIVATE,
+            T_READONLY,
+            T_ATTRIBUTE,
+            T_ATTRIBUTE_END,
+        ];
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+
+            // Skip over attribute blocks (PHP 8 #[Attribute]) in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if (in_array($code, $skip, true) === true) {
+                $ptr--;
+                continue;
+            }
+
+            break;
+        }
+
+        if ($ptr < 0) {
+            return false;
+        }
+
+        if ($tokens[$ptr]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            return false;
+        }
+
+        if (isset($tokens[$ptr]['comment_opener']) === false) {
+            return false;
+        }
+
+        $opener = $tokens[$ptr]['comment_opener'];
+        for ($i = $opener; $i <= $ptr; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG
+                && strtolower($tokens[$i]['content']) === '@spec'
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end hasSpecTag()
+
+
+    /**
+     * Determine if the function at $stackPtr is a public method.
+     *
+     * Methods default to public when no visibility modifier is present.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return bool True when the method is public (explicit or default).
+     */
+    private function isPublicMethod(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+            if ($code === T_PUBLIC) {
+                return true;
+            }
+
+            if ($code === T_PROTECTED || $code === T_PRIVATE) {
+                return false;
+            }
+
+            if ($code === T_WHITESPACE
+                || $code === T_ABSTRACT
+                || $code === T_FINAL
+                || $code === T_STATIC
+                || $code === T_READONLY
+            ) {
+                $ptr--;
+                continue;
+            }
+
+            // Skip attributes in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if ($code === T_DOC_COMMENT_CLOSE_TAG
+                || $code === T_COMMENT
+                || $code === T_OPEN_CURLY_BRACKET
+                || $code === T_CLOSE_CURLY_BRACKET
+                || $code === T_SEMICOLON
+            ) {
+                // No visibility modifier found — default public.
+                return true;
+            }
+
+            $ptr--;
+        }
+
+        return true;
+
+    }//end isPublicMethod()
+
+
+    /**
+     * Return the name of the class/interface/trait/enum enclosing $stackPtr, or null.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token to inspect.
+     *
+     * @return string|null The enclosing class name, or null when at file scope.
+     */
+    private function getEnclosingClassName(File $phpcsFile, int $stackPtr): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['conditions']) === false) {
+            return null;
+        }
+
+        // Walk the conditions chain looking for the innermost class-like scope.
+        $classLike = [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM, T_ANON_CLASS];
+
+        foreach (array_reverse($tokens[$stackPtr]['conditions'], true) as $scopePtr => $scopeCode) {
+            if (in_array($scopeCode, $classLike, true) === true) {
+                $namePtr = $phpcsFile->findNext(T_STRING, ($scopePtr + 1));
+                if ($namePtr === false) {
+                    return '{anonymous}';
+                }
+
+                // Sanity: ensure the name is before the opening brace for that class.
+                if (isset($tokens[$scopePtr]['scope_opener']) === true
+                    && $namePtr > $tokens[$scopePtr]['scope_opener']
+                ) {
+                    return '{anonymous}';
+                }
+
+                return $tokens[$namePtr]['content'];
+            }
+        }
+
+        return null;
+
+    }//end getEnclosingClassName()
+
+
+    /**
+     * Check whether the currently-scanned file is a test file.
+     *
+     * @param File $phpcsFile The file being scanned.
+     *
+     * @return bool True for files under /tests/ or /Tests/.
+     */
+    private function isTestFile(File $phpcsFile): bool
+    {
+        $path = str_replace('\\', '/', $phpcsFile->getFilename());
+        return (stripos($path, '/tests/') !== false);
+
+    }//end isTestFile()
+
+
+}//end class

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
-    <description>The coding standard for PHP_CodeSniffer itself, for more config -> for https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options.</description>
+    <description>Coding standard for OpenConnector, based on the Conduction/OpenRegister standard.</description>
 
     <file>lib</file>
 
     <!-- Exclude external and vendor files -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/vendor-bin/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>composer-setup.php</exclude-pattern>
+    <!-- Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt)
+         keep it out of lint scope; no-op for apps without the directory. -->
+    <exclude-pattern>lib/Resources/template/*</exclude-pattern>
+
+    <!-- Surface phpcs warnings (e.g. SpecTagSniff) in CI logs without failing the build. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>
-    <arg name="parallel" value="1"/>
+    <arg name="parallel" value="75"/>
     <arg name="extensions" value="php"/>
     <arg value="p"/>
 
@@ -46,22 +53,22 @@
     <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
     <rule ref="Squiz.Commenting.PostStatementComment"/>
     <rule ref="Squiz.Commenting.VariableComment"/>
-    <!-- Removed the OperatorBracket rule to allow operations without brackets -->
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
-    <!-- Removed DisallowInlineIf to allow ternary operators for ElseExpression elimination -->
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Scope.MethodScope"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
-    <!-- Disabled: Conflicts with Squiz.WhiteSpace.FunctionSpacing -->
-    <!-- <rule ref="Squiz.WhiteSpace.FunctionClosingBraceSpace"/> -->
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>
             <property name="spacing" value="1"/>
             <property name="spacingAfterLast" value="0"/>
             <property name="spacingBeforeFirst" value="0"/>
         </properties>
-        <exclude-pattern>lib/Db/AuditTrailMapper\.php</exclude-pattern>
     </rule>
     <rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
     <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
@@ -76,14 +83,18 @@
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Files.LineLength">
         <properties>
-            <property name="lineLimit" value="125"/>
+            <property name="lineLimit" value="150"/>
             <property name="absoluteLineLimit" value="150"/>
         </properties>
     </rule>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.LowerCaseKeyword"/>
-    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <rule ref="PSR2.Classes.PropertyDeclaration"/>
     <rule ref="PSR2.Methods.MethodDeclaration"/>
@@ -154,8 +165,6 @@
                 <element value="T_OPEN_SHORT_ARRAY"/>
             </property>
         </properties>
-        <exclude-pattern>lib/Service/Settings/ConfigurationSettingsHandler\.php</exclude-pattern>
-        <exclude-pattern>lib/Db/AuditTrailMapper\.php</exclude-pattern>
     </rule>
 
     <!-- Have 12 chars padding maximum and always show as errors -->
@@ -192,16 +201,6 @@
         <type>error</type>
     </rule>
 
-    <!-- The testing bootstrap file uses string concats to stop IDEs seeing the class aliases -->
-    <rule ref="Generic.Strings.UnnecessaryStringConcat">
-        <exclude-pattern>tests/bootstrap\.php</exclude-pattern>
-    </rule>
-
-    <!-- This test file specifically *needs* Windows line endings for testing purposes. -->
-    <rule ref="Generic.Files.LineEndings.InvalidEOLChar">
-        <exclude-pattern>tests/Core/Tokenizer/StableCommentWhitespaceWinTest\.php</exclude-pattern>
-    </rule>
-
     <!-- Explicitly exclude other rules that might conflict -->
     <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction">
         <severity>0</severity>
@@ -216,137 +215,20 @@
         <severity>0</severity>
     </rule>
 
-    <!--
-        Custom rule to enforce named parameters.
-        Temporarily registered at severity 0 during the initial phpcs re-enable
-        (656 pre-existing positional calls cannot be wrapped in a single PR).
-        Tracked for incremental cleanup in follow-up issue #807; once that work
-        lands, drop the severity-0 override below to restore enforcement.
-    -->
+    <!-- Custom rule to enforce named parameters -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php">
         <type>error</type>
-        <severity>0</severity>
     </rule>
 
-    <!-- Custom rule to forbid legacy \OC::$server->getX() accessors removed in Nextcloud 34 -->
+    <!-- Block calls to \OC::$server->getX() / \OC::$server->query() removed in Nextcloud 34. -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
         <type>error</type>
     </rule>
 
-    <!--
-        Doc-quality rules are temporarily relaxed while bringing openconnector to a
-        clean phpcs baseline. The 2026-05 cleanup PR (#808) re-enabled the phpcs
-        gate after auto-fixing 28,865 mechanical violations; the remaining
-        ~3,500 doc-comment + line-length issues are tracked for incremental
-        cleanup in follow-up issue #807. Once that work lands, remove these
-        severity-0 overrides to restore full doc-quality enforcement.
-    -->
-    <rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Commenting.InlineComment.NotCapital">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Commenting.InlineComment.SpacingBefore">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Commenting.InlineComment.WrongStyle">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Commenting.InlineComment.DocBlock">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Commenting.BlockComment">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Commenting.VariableComment">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Commenting.EmptyCatchComment">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Commenting.PostStatementComment">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Generic.Commenting.DocComment.MissingShort">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Generic.Commenting.DocComment.NonParamGroup">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Generic.Commenting.DocComment.ParamNotFirst">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Generic.Commenting.DocComment.Empty">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Generic.Commenting.DocComment.LongNotCapital">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.Missing">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.MissingParamComment">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.MissingParamTag">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.MissingReturn">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.ExtraParamComment">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.ParamNameNoMatch">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.WrongStyle">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.Missing">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.WrongStyle">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.IncompleteLicense">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.InvalidAuthors">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.InvalidVersion">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.VersionTagOrder">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Generic.Files.LineLength">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.MissingAuthorTag">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.MissingLicenseTag">
-        <severity>0</severity>
-    </rule>
-    <!--
-        phpcbf occasionally over-strips blank lines before member-var
-        declarations and reports a nonsensical "-1 found" delta that it cannot
-        fix on a subsequent pass. The cosmetic noise outweighs the value;
-        re-enable once the broader doc-quality follow-up lands.
-    -->
-    <rule ref="Squiz.WhiteSpace.MemberVarSpacing.Incorrect">
-        <severity>0</severity>
-    </rule>
-    <!--
-        ComparisonOperatorUsage flags idiomatic truthy/falsy PHP (`if ($x)`,
-        `if (!$x)`) and demands explicit `=== true`/`!== null`. 597 such
-        occurrences exist; tightening will happen in follow-up incrementally.
-    -->
-    <rule ref="Squiz.Operators.ComparisonOperatorUsage">
-        <severity>0</severity>
+    <!-- Warn when a class or public method is missing the @spec PHPDoc tag (hydra ADR-003).
+         Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php">
+        <type>warning</type>
     </rule>
 
 </ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<ruleset name="OpenCatalogi Nextcloud Rules"
+<ruleset name="OpenConnector Nextcloud Rules"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
                         http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
 
     <description>
-        This is a custom ruleset for Open Connector Nextcloud.
+        This is a custom ruleset for OpenConnector Nextcloud.
     </description>
 
     <!-- Clean Code Rules -->
@@ -36,8 +36,10 @@
     <rule ref="rulesets/controversial.xml/CamelCaseClassName"/>
     <rule ref="rulesets/controversial.xml/CamelCasePropertyName"/>
     <rule ref="rulesets/controversial.xml/CamelCaseMethodName"/>
-    <rule ref="rulesets/controversial.xml/CamelCaseParameterName"/>
-    <rule ref="rulesets/controversial.xml/CamelCaseVariableName"/>
+    <!-- CamelCaseParameterName removed - we allow leading underscores on parameters (convention for unused/config params) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseParameterName"/> -->
+    <!-- CamelCaseVariableName removed - we allow leading underscores on variables (convention for unused loop vars) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseVariableName"/> -->
 
     <!-- Design Rules -->
     <rule ref="rulesets/design.xml/ExitExpression"/>
@@ -53,7 +55,13 @@
     <!-- Naming Rules -->
     <rule ref="rulesets/naming.xml/LongClassName"/>
     <rule ref="rulesets/naming.xml/ShortClassName"/>
-    <rule ref="rulesets/naming.xml/ShortVariable"/>
+    <!-- ShortVariable configured with allowlist of idiomatic short names -->
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <property name="minimum" value="3" />
+            <property name="exceptions" value="id,db,qb,op,ui,io,gc,tz,pk,fk,to,ch,a,b,l,v,c,t,r,f,n,k,e" />
+        </properties>
+    </rule>
     <rule ref="rulesets/naming.xml/LongVariable"/>
     <rule ref="rulesets/naming.xml/ShortMethodName"/>
     <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
@@ -64,5 +72,7 @@
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
     <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter">
+        <exclude-pattern>*Migration*</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,2730 @@
+# PHPStan baseline — tracked lint debt for openconnector
+#
+# This baseline was generated during the Phase 2 canonical-root-config sync
+# (PR follow-up to shillinq#300 / decidesk#243). PHPStan had never run on
+# this repo before; everything below is pre-existing static-analysis debt
+# absorbed as tracked items, NOT new debt introduced by the sync.
+#
+# Burndown tracked at: https://github.com/ConductionNL/openconnector/issues/848
+# Remove entries here as the underlying code is fixed.
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Action\\\\EventAction\\:\\:\\$callService is never read, only written\\.$#"
+			count: 1
+			path: lib/Action/EventAction.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Action/PingAction.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Action\\\\SynchronizationAction\\:\\:\\$contractMapper is never read, only written\\.$#"
+			count: 1
+			path: lib/Action/SynchronizationAction.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between OCA\\\\OpenConnector\\\\Db\\\\Synchronization and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Action/SynchronizationAction.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$id with type string is incompatible with native type int\\.$#"
+			count: 2
+			path: lib/Controller/ConsumersController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\ConsumersController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/ConsumersController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\DashboardController\\:\\:\\$consumerMapper is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/DashboardController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\DashboardController\\:\\:\\$l is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/DashboardController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getConfigurations\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/EndpointsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getEndpoint\\(\\)\\.$#"
+			count: 4
+			path: lib/Controller/EndpointsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getInputMapping\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/EndpointsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getOutputMapping\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/EndpointsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getTargetId\\(\\)\\.$#"
+			count: 2
+			path: lib/Controller/EndpointsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getTargetType\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/EndpointsController.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Controller\\\\EndpointsController\\:\\:handlePath\\(\\) should return OCA\\\\OpenConnector\\\\Http\\\\XMLResponse\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse but returns OCP\\\\AppFramework\\\\Http\\\\Response\\.$#"
+			count: 1
+			path: lib/Controller/EndpointsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\EndpointsController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/EndpointsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventSubscription\\:\\:getStyle\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/EventsController.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$id with type string is incompatible with native type int\\.$#"
+			count: 2
+			path: lib/Controller/EventsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\EventsController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/EventsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\ExportController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/ExportController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\ImportController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/ImportController.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$id with type string is incompatible with native type int\\.$#"
+			count: 2
+			path: lib/Controller/JobsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\JobsController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/JobsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\JobsController\\:\\:\\$jobList is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/JobsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\JobsController\\:\\:\\$synchronizationMapper is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/JobsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\JobsController\\:\\:\\$synchronizationService is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/JobsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\LogsController\\:\\:\\$objectService is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/LogsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\MappingsController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/MappingsController.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$id with type string is incompatible with native type int\\.$#"
+			count: 2
+			path: lib/Controller/RulesController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\RulesController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/RulesController.php
+
+		-
+			message: "#^Caught class OCA\\\\OpenConnector\\\\Controller\\\\DoesNotExistException not found\\.$#"
+			count: 2
+			path: lib/Controller/SourcesController.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$id with type string is incompatible with native type int\\.$#"
+			count: 2
+			path: lib/Controller/SourcesController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\SourcesController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/SourcesController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getCreated\\(\\)\\.$#"
+			count: 2
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getOriginHash\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getOriginId\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getSourceLastSynced\\(\\)\\.$#"
+			count: 2
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getSynchronizationId\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getTargetHash\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getTargetId\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getTargetLastSynced\\(\\)\\.$#"
+			count: 2
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getUpdated\\(\\)\\.$#"
+			count: 2
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\SynchronizationContractsController\\:\\:\\$objectService is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationContractsController.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationsController.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$id with type string is incompatible with native type int\\.$#"
+			count: 2
+			path: lib/Controller/SynchronizationsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\SynchronizationsController\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/SynchronizationsController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\UserController\\:\\:\\$authorizationService is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/UserController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\UserController\\:\\:\\$organisationBridgeService is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/UserController.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Dashboard\\\\JobQueueWidget\\:\\:\\$url is never read, only written\\.$#"
+			count: 1
+			path: lib/Dashboard/JobQueueWidget.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Dashboard\\\\RecentCallsWidget\\:\\:\\$url is never read, only written\\.$#"
+			count: 1
+			path: lib/Dashboard/RecentCallsWidget.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Dashboard\\\\SourceSyncWidget\\:\\:\\$url is never read, only written\\.$#"
+			count: 1
+			path: lib/Dashboard/SourceSyncWidget.php
+
+		-
+			message: "#^Unknown PHPDoc tag\\: @phpstan\\-api$#"
+			count: 1
+			path: lib/Db/CallLog.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:getUuid\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/CallLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:setUuid\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/CallLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\CallLogMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\CallLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/CallLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\CallLogMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\CallLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/CallLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\CallLogMapper\\:\\:getLastCallLog\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\CallLog\\|null but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/CallLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\CallLogMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\CallLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/CallLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Consumer\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/ConsumerMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Consumer\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/ConsumerMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\ConsumerMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Consumer but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/ConsumerMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\ConsumerMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Consumer but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/ConsumerMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\ConsumerMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Consumer but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/ConsumerMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getEndpoint\\(\\)\\.$#"
+			count: 5
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getEndpointRegex\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getMethod\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getVersion\\(\\)\\.$#"
+			count: 3
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:setEndpointArray\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:setEndpointRegex\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:setVersion\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EndpointMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Endpoint but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EndpointMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Endpoint but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 2
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EndpointMapper\\:\\:findAll\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EndpointMapper\\:\\:findByConfiguration\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EndpointMapper\\:\\:getByTarget\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 3
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EndpointMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Endpoint but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$query of method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) expects OCP\\\\DB\\\\QueryBuilder\\\\IQueryBuilder, string given\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Variable \\$updateRegex might not be defined\\.$#"
+			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Event\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Event\\:\\:getVersion\\(\\)\\.$#"
+			count: 3
+			path: lib/Db/EventMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Event\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Event\\:\\:setVersion\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Event but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EventMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Event but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EventMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Event but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EventMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:getRetryCount\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessage.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:setLastAttempt\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessage.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:setNextAttempt\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessage.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:setRetryCount\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessage.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:getLastAttempt\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:getNextAttempt\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:getRetryCount\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:setCreated\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:setUpdated\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventMessageMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\EventMessage but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventMessageMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\EventMessage but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventMessageMapper\\:\\:findAll\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventMessageMapper\\:\\:findPendingRetries\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventMessageMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\EventMessage but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EventMessageMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventSubscription\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventSubscriptionMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventSubscription\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/EventSubscriptionMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventSubscriptionMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\EventSubscription but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EventSubscriptionMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventSubscriptionMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\EventSubscription but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EventSubscriptionMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventSubscriptionMapper\\:\\:findAll\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\EventSubscription\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/EventSubscriptionMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\EventSubscriptionMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\EventSubscription but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/EventSubscriptionMapper.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$id$#"
+			count: 1
+			path: lib/Db/EventSubscriptionMapper.php
+
+		-
+			message: "#^PHPDoc tag @return with type OCA\\\\OpenConnector\\\\Db\\\\EventSubscription is incompatible with native type array\\.$#"
+			count: 1
+			path: lib/Db/EventSubscriptionMapper.php
+
+		-
+			message: "#^Unknown PHPDoc tag\\: @phpstan\\-api$#"
+			count: 1
+			path: lib/Db/JobLog.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getJobClass\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getJobListId\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getLastRun\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getNextRun\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\JobLog\\:\\:getUuid\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\JobLog\\:\\:setUuid\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobLogMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\JobLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobLogMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\JobLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobLogMapper\\:\\:getLastCallLog\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\JobLog\\|null but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobLogMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\JobLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^PHPDoc tag @return with type OCA\\\\OpenConnector\\\\Db\\\\CallLog\\|null is not subtype of native type OCA\\\\OpenConnector\\\\Db\\\\JobLog\\|null\\.$#"
+			count: 1
+			path: lib/Db/JobLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getVersion\\(\\)\\.$#"
+			count: 3
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:setVersion\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Job but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Job but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 2
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobMapper\\:\\:findAll\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Job\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobMapper\\:\\:findByConfiguration\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Job\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobMapper\\:\\:findRunnable\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Job\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\JobMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Job but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$query of method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) expects OCP\\\\DB\\\\QueryBuilder\\\\IQueryBuilder, string given\\.$#"
+			count: 1
+			path: lib/Db/JobMapper.php
+
+		-
+			message: "#^Property OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:\\$id \\(int\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: lib/Db/Mapping.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 1
+			path: lib/Db/Mapping.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between lowercase\\-string&non\\-falsy\\-string and '' will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Db/Mapping.php
+
+		-
+			message: "#^Variable \\$generatedSlug on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Db/Mapping.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Mapping\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Mapping\\:\\:getVersion\\(\\)\\.$#"
+			count: 3
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Mapping\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Mapping\\:\\:setVersion\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\MappingMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Mapping but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\MappingMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Mapping but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 2
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\MappingMapper\\:\\:findAll\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Mapping\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\MappingMapper\\:\\:findByConfiguration\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Mapping\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\MappingMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Mapping but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$query of method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) expects OCP\\\\DB\\\\QueryBuilder\\\\IQueryBuilder, string given\\.$#"
+			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getOrder\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getVersion\\(\\)\\.$#"
+			count: 3
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:setOrder\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:setVersion\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\RuleMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Rule but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\RuleMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Rule but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 2
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\RuleMapper\\:\\:findAll\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Rule\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\RuleMapper\\:\\:findByConfiguration\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Rule\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\RuleMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Rule but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$id$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^PHPDoc tag @return with type OCA\\\\OpenConnector\\\\Db\\\\Rule is incompatible with native type array\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$query of method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) expects OCP\\\\DB\\\\QueryBuilder\\\\IQueryBuilder, string given\\.$#"
+			count: 1
+			path: lib/Db/RuleMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getVersion\\(\\)\\.$#"
+			count: 3
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:setVersion\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SourceMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Source but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SourceMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Source but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 2
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SourceMapper\\:\\:findAll\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Source\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SourceMapper\\:\\:findByConfiguration\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Source\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SourceMapper\\:\\:findOrCreateByLocation\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Source but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SourceMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Source but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$query of method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) expects OCP\\\\DB\\\\QueryBuilder\\\\IQueryBuilder, string given\\.$#"
+			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Unknown PHPDoc tag\\: @phpstan\\-api$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLog.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:getSessionId\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:getSynchronizationLogId\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:getUserId\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:setExpires\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:setSessionId\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:setSynchronizationLogId\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:setUserId\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLogMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLogMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLogMapper\\:\\:findOnSynchronizationId\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\|null but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLogMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getVersion\\(\\)\\.$#"
+			count: 3
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setVersion\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOriginId\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getTargetId\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOriginHash\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOriginId\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setTargetHash\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setTargetId\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Dead catch \\- OCP\\\\AppFramework\\\\Db\\\\DoesNotExistException is never thrown in the try block\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findAll\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findByOriginAndTarget\\(\\) should return bool\\|OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\|null but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findByOriginId\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\|null but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findByTargetId\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findByTypeAndId\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findOnTarget\\(\\) should return bool\\|OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\|null but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findSyncContractByOriginId\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\|null but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$synchronization$#"
+			count: 1
+			path: lib/Db/SynchronizationContractMapper.php
+
+		-
+			message: "#^Unknown PHPDoc tag\\: @phpstan\\-api$#"
+			count: 1
+			path: lib/Db/SynchronizationLog.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLog\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLog\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLogMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLogMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationLogMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLogMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLog but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationLogMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getVersion\\(\\)\\.$#"
+			count: 3
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:setVersion\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationMapper\\:\\:createFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Synchronization but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationMapper\\:\\:find\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Synchronization but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 2
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationMapper\\:\\:findAll\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationMapper\\:\\:findByConfiguration\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationMapper\\:\\:findByUuid\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Synchronization but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationMapper\\:\\:getByTarget\\(\\) should return array\\<OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\> but returns array\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationMapper\\:\\:updateFromArray\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Synchronization but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$query of method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCP\\\\AppFramework\\\\Db\\\\Entity\\>\\:\\:findEntities\\(\\) expects OCP\\\\DB\\\\QueryBuilder\\\\IQueryBuilder, string given\\.$#"
+			count: 1
+			path: lib/Db/SynchronizationMapper.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\EventListener\\\\ViewDeletedEventListener\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/EventListener/ViewDeletedEventListener.php
+
+		-
+			message: "#^Call to method getNewObject\\(\\) on an unknown class OCA\\\\OpenConnector\\\\EventListener\\\\ObjectCreatedEvent\\.$#"
+			count: 1
+			path: lib/EventListener/ViewUpdatedOrCreatedEventListener.php
+
+		-
+			message: "#^Class OCA\\\\OpenConnector\\\\EventListener\\\\ObjectCreatedEvent not found\\.$#"
+			count: 1
+			path: lib/EventListener/ViewUpdatedOrCreatedEventListener.php
+
+		-
+			message: "#^Constant OCA\\\\OpenConnector\\\\EventListener\\\\ViewUpdatedOrCreatedEventListener\\:\\:SOFTWARE_CATALOG_REGISTER_ID is unused\\.$#"
+			count: 1
+			path: lib/EventListener/ViewUpdatedOrCreatedEventListener.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\EventListener\\\\ViewUpdatedOrCreatedEventListener\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/EventListener/ViewUpdatedOrCreatedEventListener.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\EventListener\\\\ViewUpdatedOrCreatedEventListener\\:\\:\\$synchronizationService is never read, only written\\.$#"
+			count: 1
+			path: lib/EventListener/ViewUpdatedOrCreatedEventListener.php
+
+		-
+			message: "#^Parameter \\#1 \\$status of method OCP\\\\AppFramework\\\\Http\\\\Response\\<int,array\\<string, mixed\\>\\>\\:\\:__construct\\(\\) expects 100\\|101\\|102\\|200\\|201\\|202\\|203\\|204\\|205\\|206\\|207\\|208\\|226\\|300\\|301\\|302\\|303\\|304\\|305\\|306\\|307\\|400\\|401\\|402\\|403\\|404\\|405\\|406\\|407\\|408\\|409\\|410\\|411\\|412\\|413\\|414\\|415\\|416\\|417\\|418\\|422\\|423\\|424\\|426\\|428\\|429\\|431\\|500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|509\\|510\\|511, int given\\.$#"
+			count: 1
+			path: lib/Http/XMLResponse.php
+
+		-
+			message: "#^Access to an undefined property OCA\\\\OpenConnector\\\\Service\\\\AuthenticationService\\:\\:\\$twig\\.$#"
+			count: 2
+			path: lib/Service/AuthenticationService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\AuthenticationService\\:\\:getHSJWK\\(\\) never returns null so it can be removed from the return type\\.$#"
+			count: 1
+			path: lib/Service/AuthenticationService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\AuthenticationService\\:\\:getRSJWK\\(\\) never returns null so it can be removed from the return type\\.$#"
+			count: 1
+			path: lib/Service/AuthenticationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Consumer\\:\\:getUserId\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/AuthorizationService.php
+
+		-
+			message: "#^Instantiated class OC\\\\AppFramework\\\\Middleware\\\\Security\\\\Exceptions\\\\SecurityException not found\\.$#"
+			count: 1
+			path: lib/Service/AuthorizationService.php
+
+		-
+			message: "#^PHPDoc tag @throws with type OC\\\\AppFramework\\\\Middleware\\\\Security\\\\Exceptions\\\\SecurityException is not subtype of Throwable$#"
+			count: 1
+			path: lib/Service/AuthorizationService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\AuthorizationService\\:\\:\\$groupManager is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/AuthorizationService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\AuthorizationService\\:\\:\\$tokenProvider is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/AuthorizationService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between OCP\\\\IUser\\|null and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/AuthorizationService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between non\\-empty\\-string and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/AuthorizationService.php
+
+		-
+			message: "#^Access to an undefined property OCA\\\\OpenConnector\\\\Service\\\\CallService\\:\\:\\$source\\.$#"
+			count: 3
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'now \\+' and array\\<int\\> results in an error\\.$#"
+			count: 1
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:getStatusCode\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:setCreated\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:setExpires\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:setRequest\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:setResponse\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:setSourceId\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:setStatusCode\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:setStatusMessage\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:setUuid\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getErrorRetention\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getIsEnabled\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getLocation\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getLogRetention\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getRateLimitLimit\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getRateLimitRemaining\\(\\)\\.$#"
+			count: 5
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getRateLimitReset\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getRateLimitWindow\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getType\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:setRateLimitLimit\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:setRateLimitRemaining\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:setRateLimitReset\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Call to function in_array\\(\\) with arguments 0, array\\<int\\|string, array\\<int\\>\\> and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\CallService\\:\\:call\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\CallLog but returns GuzzleHttp\\\\Promise\\\\PromiseInterface\\.$#"
+			count: 1
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Variable \\$response might not be defined\\.$#"
+			count: 7
+			path: lib/Service/CallService.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method OCA\\\\OpenConnector\\\\Db\\\\EndpointMapper\\:\\:updateFromArray\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationHandlers/EndpointHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method OCA\\\\OpenConnector\\\\Db\\\\JobMapper\\:\\:updateFromArray\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationHandlers/JobHandler.php
+
+		-
+			message: "#^Variable \\$arguments might not be defined\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationHandlers/JobHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method OCA\\\\OpenConnector\\\\Db\\\\MappingMapper\\:\\:updateFromArray\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationHandlers/MappingHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method OCA\\\\OpenConnector\\\\Db\\\\RuleMapper\\:\\:updateFromArray\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationHandlers/RuleHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method OCA\\\\OpenConnector\\\\Db\\\\SourceMapper\\:\\:updateFromArray\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationHandlers/SourceHandler.php
+
+		-
+			message: "#^Offset int on array\\<string, string\\> in isset\\(\\) does not exist\\.$#"
+			count: 2
+			path: lib/Service/ConfigurationHandlers/SynchronizationHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationMapper\\:\\:updateFromArray\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationHandlers/SynchronizationHandler.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 3
+			path: lib/Service/ConfigurationHandlers/SynchronizationHandler.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'actions'\\|'followUps' and 'conditions' will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationHandlers/SynchronizationHandler.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getInputMapping\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getOutputMapping\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getTargetId\\(\\)\\.$#"
+			count: 5
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getTargetType\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getType\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getType\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getSourceId\\(\\)\\.$#"
+			count: 5
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getSourceTargetMapping\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getSourceType\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getTargetId\\(\\)\\.$#"
+			count: 5
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getTargetSourceMapping\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getTargetType\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to method export\\(\\) on an unknown class OCA\\\\OpenConnector\\\\Service\\\\ConfigurationHandlerInterface\\.$#"
+			count: 6
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Call to method import\\(\\) on an unknown class OCA\\\\OpenConnector\\\\Service\\\\ConfigurationHandlerInterface\\.$#"
+			count: 8
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\ConfigurationService\\:\\:exportRule\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Parameter \\$ids of method OCA\\\\OpenConnector\\\\Db\\\\MappingMapper\\:\\:findAll\\(\\) expects array\\<string, array\\<string\\>\\>\\|null, array\\<string, array\\<int\\>\\> given\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\ConfigurationService\\:\\:\\$handlers has unknown class OCA\\\\OpenConnector\\\\Service\\\\ConfigurationHandlerInterface as its type\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between int and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ConfigurationService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/DSOParserService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\EndpointCacheService\\:\\:reconstructEndpointObjects\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/EndpointCacheService.php
+
+		-
+			message: "#^Access to an undefined property OCP\\\\IRequest\\:\\:\\$server\\.$#"
+			count: 2
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:getStatusCode\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getConfigurations\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getInputMapping\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getName\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getPath\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getSource\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getTargetId\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Endpoint\\:\\:getTargetType\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getAction\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getName\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getOrder\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getTiming\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getType\\(\\)\\.$#"
+			count: 6
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Http\\\\Response\\:\\:getData\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Class OC\\\\Files\\\\Node\\\\File not found\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Function request_parse_body not found\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:getObjects\\(\\) never returns OCP\\\\AppFramework\\\\Db\\\\Entity so it can be removed from the return type\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:handleRequest\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse but returns OCP\\\\AppFramework\\\\Http\\\\Response\\.$#"
+			count: 3
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:parseContent\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Offset 'page' does not exist on array\\{results\\: array\\}\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Offset 'pages' does not exist on array\\{results\\: array\\}\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Offset 'total' does not exist on array\\{results\\: array\\}\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$schemaMapper with type OCA\\\\OpenConnector\\\\Service\\\\OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper is not subtype of native type OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$content$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$contentType$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$incomingData$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$registerId$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$request$#"
+			count: 2
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$schemaId$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @return with type OCP\\\\IRequest is not subtype of native type OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @return with type array\\|null is not subtype of native type array\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^PHPDoc tag @throws with type GuzzleHttp\\\\Exception\\\\GuzzleException\\|OCA\\\\OpenRegister\\\\Exception\\\\ValidationException\\|OCP\\\\AppFramework\\\\Db\\\\DoesNotExistException\\|OCP\\\\AppFramework\\\\Db\\\\MultipleObjectsReturnedException\\|OCP\\\\Files\\\\InvalidPathException\\|OCP\\\\Files\\\\NotFoundException\\|Psr\\\\Container\\\\ContainerExceptionInterface\\|Twig\\\\Error\\\\LoaderError\\|Twig\\\\Error\\\\SyntaxError is not subtype of Throwable$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Parameter \\#2 \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:transformError\\(\\) expects OC\\\\AppFramework\\\\Http\\\\Request, OCP\\\\IRequest given\\.$#"
+			count: 3
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:parseContent\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processFilePartUploadRule\\(\\) expects OC\\\\AppFramework\\\\Http\\\\Request, OCP\\\\IRequest given\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processFilePartUploadRule\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:transformError\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
+			count: 2
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Parameter \\$requestOriginal of class OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken constructor expects array\\|OC\\\\AppFramework\\\\Http\\\\Request, OCP\\\\IRequest given\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Parameter \\$schemaMapper of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:generateEndpointUrl\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:\\$appConfig is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Result of \\|\\| is always false\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between array and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Variable \\$file might not be defined\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Variable \\$fileName might not be defined\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Variable \\$ids in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Variable \\$object might not be defined\\.$#"
+			count: 1
+			path: lib/Service/EndpointService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Event\\:\\:getSource\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Event\\:\\:getType\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventMessage\\:\\:getSubscriptionId\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventSubscription\\:\\:getConsumerId\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventSubscription\\:\\:getSink\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventSubscription\\:\\:getSource\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\EventSubscription\\:\\:getStyle\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Call to method evaluate\\(\\) on an unknown class Symfony\\\\Component\\\\ExpressionLanguage\\\\ExpressionLanguage\\.$#"
+			count: 1
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Expression in empty\\(\\) is always falsy\\.$#"
+			count: 1
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Instantiated class Symfony\\\\Component\\\\ExpressionLanguage\\\\ExpressionLanguage not found\\.$#"
+			count: 1
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/EventService.php
+
+		-
+			message: "#^Attribute class JetBrains\\\\PhpStorm\\\\NoReturn does not exist\\.$#"
+			count: 1
+			path: lib/Service/ExportService.php
+
+		-
+			message: "#^Cannot unset offset 'created' on array\\{reference\\: string\\}\\.$#"
+			count: 1
+			path: lib/Service/ExportService.php
+
+		-
+			message: "#^Cannot unset offset 'dateCreated' on array\\{reference\\: string\\}\\.$#"
+			count: 1
+			path: lib/Service/ExportService.php
+
+		-
+			message: "#^Cannot unset offset 'dateModified' on array\\{reference\\: string\\}\\.$#"
+			count: 1
+			path: lib/Service/ExportService.php
+
+		-
+			message: "#^Cannot unset offset 'id' on array\\{reference\\: string\\}\\.$#"
+			count: 1
+			path: lib/Service/ExportService.php
+
+		-
+			message: "#^Cannot unset offset 'updated' on array\\{reference\\: string\\}\\.$#"
+			count: 1
+			path: lib/Service/ExportService.php
+
+		-
+			message: "#^Cannot unset offset 'uuid' on array\\{reference\\: string\\}\\.$#"
+			count: 1
+			path: lib/Service/ExportService.php
+
+		-
+			message: "#^Class OC\\\\AppFramework\\\\Http\\\\Request not found\\.$#"
+			count: 1
+			path: lib/Service/Helper/FlowToken.php
+
+		-
+			message: "#^Function request_parse_body not found\\.$#"
+			count: 1
+			path: lib/Service/Helper/FlowToken.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$content$#"
+			count: 1
+			path: lib/Service/Helper/FlowToken.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$contentType$#"
+			count: 1
+			path: lib/Service/Helper/FlowToken.php
+
+		-
+			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken\\:\\:parseContent\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
+			count: 1
+			path: lib/Service/Helper/FlowToken.php
+
+		-
+			message: "#^Parameter \\$requestOriginal of method OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken\\:\\:__construct\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
+			count: 1
+			path: lib/Service/Helper/FlowToken.php
+
+		-
+			message: "#^Parameter \\$requestOriginal of method OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken\\:\\:setRequestOriginal\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
+			count: 1
+			path: lib/Service/Helper/FlowToken.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:getStatusCode\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/IBabsConnectorService.php
+
+		-
+			message: "#^Call to function is_string\\(\\) with array will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Service/IBabsConnectorService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\IBabsConnectorService\\:\\:\\$sourceMapper is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/IBabsConnectorService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Service/IBabsConnectorService.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getVersion\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/ImportService.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'now \\+' and array\\<int\\> results in an error\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getErrorRetention\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getInterval\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getIsEnabled\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getJobClass\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getJobListId\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getLogRetention\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getNextRun\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getScheduleAfter\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:getUserId\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:isSingleRun\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:setIsEnabled\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:setJobListId\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:setLastRun\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Job\\:\\:setNextRun\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\JobLog\\:\\:setExpires\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\JobLog\\:\\:setLevel\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\JobLog\\:\\:setMessage\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\JobLog\\:\\:setStackTrace\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to function in_array\\(\\) with arguments 0, array\\<int\\|string, array\\<int\\>\\> and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\JobService\\:\\:scheduleJob\\(\\) should return OCA\\\\OpenConnector\\\\Db\\\\Job but returns OCP\\\\AppFramework\\\\Db\\\\Entity\\.$#"
+			count: 2
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Parameter \\$hour of method DateTime\\:\\:setTime\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Parameter \\$minute of method DateTime\\:\\:setTime\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/JobService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Mapping\\:\\:getName\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/MappingService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Mapping\\:\\:getPassThrough\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/MappingService.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 4
+			path: lib/Service/MappingService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between \\*NEVER\\* and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/MappingService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/MappingService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/MappingService.php
+
+		-
+			message: "#^Variable \\$setNullIfValue might not be defined\\.$#"
+			count: 3
+			path: lib/Service/MappingService.php
+
+		-
+			message: "#^Variable \\$unsetIfValue might not be defined\\.$#"
+			count: 3
+			path: lib/Service/MappingService.php
+
+		-
+			message: "#^Match arm comparison between string and 'eventSubscription' is always false\\.$#"
+			count: 1
+			path: lib/Service/ObjectService.php
+
+		-
+			message: "#^PHPDoc tag @return with type mixed is not subtype of native type OCA\\\\OpenRegister\\\\Service\\\\ObjectService\\|null\\.$#"
+			count: 1
+			path: lib/Service/ObjectService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:getStatusCode\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/RuleService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getType\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/RuleService.php
+
+		-
+			message: "#^Constant OCA\\\\OpenConnector\\\\Service\\\\RuleService\\:\\:PROP_TITEL_VIEW is unused\\.$#"
+			count: 1
+			path: lib/Service/RuleService.php
+
+		-
+			message: "#^Constant OCA\\\\OpenConnector\\\\Service\\\\RuleService\\:\\:PROP_VERBINDINGSROL is unused\\.$#"
+			count: 1
+			path: lib/Service/RuleService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\RuleService\\:\\:processCustomConnectionsRule\\(\\) never returns array so it can be removed from the return type\\.$#"
+			count: 1
+			path: lib/Service/RuleService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$relationsFolderCount$#"
+			count: 1
+			path: lib/Service/RuleService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$relationsFolderKey$#"
+			count: 1
+			path: lib/Service/RuleService.php
+
+		-
+			message: "#^PHPDoc tag @throws with type GuzzleHttp\\\\Exception\\\\GuzzleException\\|OCA\\\\OpenRegister\\\\Exception\\\\ValidationException\\|OCP\\\\AppFramework\\\\Db\\\\DoesNotExistException\\|OCP\\\\AppFramework\\\\Db\\\\MultipleObjectsReturnedException\\|OCP\\\\DB\\\\Exception\\|Psr\\\\Container\\\\ContainerExceptionInterface\\|Twig\\\\Error\\\\LoaderError\\|Twig\\\\Error\\\\SyntaxError is not subtype of Throwable$#"
+			count: 1
+			path: lib/Service/RuleService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\RuleService\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/RuleService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getLocation\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SOAPService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\SOAPService\\:\\:\\$transport is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/SOAPService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between SimpleXMLElement\\|false and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SOAPService.php
+
+		-
+			message: "#^Access to an undefined property OCA\\\\OpenConnector\\\\Service\\\\SearchService\\:\\:\\$directoryService\\.$#"
+			count: 1
+			path: lib/Service/SearchService.php
+
+		-
+			message: "#^Access to an undefined property OCA\\\\OpenConnector\\\\Service\\\\SearchService\\:\\:\\$elasticService\\.$#"
+			count: 1
+			path: lib/Service/SearchService.php
+
+		-
+			message: "#^Variable \\$vars might not be defined\\.$#"
+			count: 1
+			path: lib/Service/SearchService.php
+
+		-
+			message: "#^Anonymous function has an unused use \\$deferred\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^Anonymous function has an unused use \\$openRegister\\.$#"
+			count: 2
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$modelId$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$viewId$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\StUFFieldMapper\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/StUFFieldMapper.php
+
+		-
+			message: "#^Access to an undefined property OCA\\\\OpenConnector\\\\Service\\\\StorageService\\:\\:\\$userSession\\.$#"
+			count: 1
+			path: lib/Service/StorageService.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\Files\\\\Node\\:\\:get\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/StorageService.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\Files\\\\Node\\:\\:newFile\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/StorageService.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\Files\\\\Node\\:\\:newFolder\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/StorageService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$userSession$#"
+			count: 1
+			path: lib/Service/StorageService.php
+
+		-
+			message: "#^Parameter \\#1 \\$folderContents of method OCA\\\\OpenConnector\\\\Service\\\\StorageService\\:\\:attemptCloseUpload\\(\\) expects array\\<OC\\\\Files\\\\Node\\\\Node\\>, array\\<OCP\\\\Files\\\\Node\\> given\\.$#"
+			count: 1
+			path: lib/Service/StorageService.php
+
+		-
+			message: "#^Parameter \\$folderContents of method OCA\\\\OpenConnector\\\\Service\\\\StorageService\\:\\:attemptCloseUpload\\(\\) has invalid type OC\\\\Files\\\\Node\\\\Node\\.$#"
+			count: 1
+			path: lib/Service/StorageService.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'now \\+' and array\\<int\\> results in an error\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\CallLog\\:\\:getStatusCode\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getConfig\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getName\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getOrder\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getTiming\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Rule\\:\\:getType\\(\\)\\.$#"
+			count: 5
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getLocation\\(\\)\\.$#"
+			count: 8
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getRateLimitLimit\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getRateLimitRemaining\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getRateLimitReset\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getRateLimitWindow\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getCurrentPage\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getName\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getSourceHashMapping\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getSourceId\\(\\)\\.$#"
+			count: 6
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getSourceTargetMapping\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getSourceType\\(\\)\\.$#"
+			count: 5
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getTargetId\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getTargetType\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getUpdated\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:setCurrentPage\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:setSourceConfig\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:setSourceId\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Synchronization\\:\\:setTargetLastSynced\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getOriginHash\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getOriginId\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getSourceId\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getSourceLastChecked\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getSynchronizationId\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getTargetHash\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getTargetId\\(\\)\\.$#"
+			count: 11
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getTargetLastAction\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setOriginHash\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setOriginId\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setSourceLastChanged\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setSourceLastChecked\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setSourceLastSynced\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setSynchronizationId\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setTargetHash\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setTargetId\\(\\)\\.$#"
+			count: 6
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setTargetLastAction\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setTargetLastChanged\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setTargetLastSynced\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContract\\:\\:setUuid\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:setExpires\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:setSynchronizationLogId\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:setTarget\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractLog\\:\\:setTargetResult\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLog\\:\\:setExecutionTime\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLog\\:\\:setExpires\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLog\\:\\:setMessage\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationLog\\:\\:setResult\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getSynchronizationId\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Call to function in_array\\(\\) with arguments 0, array\\<int\\|string, array\\<int\\>\\> and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\SynchronizationService\\:\\:fetchAllPagesSequential\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\SynchronizationService\\:\\:getFileContext\\(\\) should return string but returns null\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\SynchronizationService\\:\\:getFilenameFromHeaders\\(\\) never returns null so it can be removed from the return type\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\SynchronizationService\\:\\:writeFile\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Missing parameter \\$flowToken \\(OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken\\) in call to method OCA\\\\OpenConnector\\\\Service\\\\SynchronizationService\\:\\:synchronizeContract\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(int\\|            \\$objectId   The id of the object the file belongs to\\.\\)\\: Unexpected token \"\\$objectId\", expected type at offset 381$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$parentIsNumericArray$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Parameter \\#2 \\$message of class Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\TooManyRequestsHttpException constructor expects string, int given\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Parameter \\#3 \\$previous of class Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\TooManyRequestsHttpException constructor expects Throwable\\|null, array given\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Parameter \\$registerId of method OCA\\\\OpenConnector\\\\Service\\\\SynchronizationService\\:\\:processRules\\(\\) expects int\\|null, string given\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Parameter \\$schemaId of method OCA\\\\OpenConnector\\\\Service\\\\SynchronizationService\\:\\:processRules\\(\\) expects int\\|null, string given\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Parameter \\$synchronization of method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findOnTarget\\(\\) expects string, int given\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Parameter \\$synchronizationId of method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findAllBySynchronizationAndSchema\\(\\) expects string, int given\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Parameter \\$synchronizationId of method OCA\\\\OpenConnector\\\\Db\\\\SynchronizationContractMapper\\:\\:findSyncContractByOriginId\\(\\) expects string, int given\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Parameter \\$synchronizationId of method OCA\\\\OpenConnector\\\\Service\\\\SynchronizationService\\:\\:updateContractsForSubObjects\\(\\) expects string, int given\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Parameter \\$synchronizationId of method OCA\\\\OpenConnector\\\\Service\\\\SynchronizationService\\:\\:updateIdsOnSubObjects\\(\\) expects string, int given\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Variable \\$contractLog in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 7
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Variable \\$endpoint might not be defined\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Variable \\$id might not be defined\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Variable \\$object might not be defined\\.$#"
+			count: 2
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Variable \\$synchronization in isset\\(\\) is never defined\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Variable \\$value in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: lib/Service/SynchronizationService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\UserService\\:\\:\\$userManager is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/UserService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between OCP\\\\Accounts\\\\IAccountProperty and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/UserService.php
+
+		-
+			message: "#^Property OCA\\\\OpenConnector\\\\Settings\\\\OpenConnectorAdmin\\:\\:\\$l is never read, only written\\.$#"
+			count: 1
+			path: lib/Settings/OpenConnectorAdmin.php
+
+		-
+			message: "#^Call to an undefined method OCA\\\\OpenConnector\\\\Db\\\\Source\\:\\:getLocation\\(\\)\\.$#"
+			count: 2
+			path: lib/Twig/MappingRuntime.php
+
+		-
+			message: "#^Class OC\\\\Files\\\\Node\\\\File not found\\.$#"
+			count: 1
+			path: lib/Twig/MappingRuntime.php
+
+		-
+			message: "#^PHPDoc tag @return with type array is incompatible with native type Symfony\\\\Component\\\\Uid\\\\UuidV4\\.$#"
+			count: 1
+			path: lib/Twig/MappingRuntime.php
+
+		-
+			message: "#^Undefined variable\\: \\$file$#"
+			count: 1
+			path: lib/Twig/MappingRuntime.php

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * PHPStan bootstrap file - registers OCP autoloader for static analysis.
+ */
+
+$autoloader = require __DIR__ . '/vendor/autoload.php';
+$autoloader->addPsr4('OCP\\', __DIR__ . '/vendor/nextcloud/ocp/OCP/');
+$autoloader->addPsr4('NCU\\', __DIR__ . '/vendor/nextcloud/ocp/NCU/');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,59 @@
+includes:
+    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
+    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
+    # across the fleet.
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - lib
+    bootstrapFiles:
+        - phpstan-bootstrap.php
+    excludePaths:
+        - vendor
+        - vendor-bin
+        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
+        - lib/Resources/template
+    scanDirectories:
+        - vendor/nextcloud/ocp
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
+        - '#Call to an undefined method OC::#'
+        - '#Class OC not found#'
+        - '#Access to static property \$server on an unknown class OC#'
+        - '#unknown class OC\\#'
+        - '#Caught class OC\\#'
+        - '#unknown class OC_App#'
+        - '#Class OC_App not found#'
+        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
+        - '#unknown class OCA\\DAV\\#'
+        - '#Class OCA\\DAV\\#'
+        # OCA classes from other apps (OpenRegister) not available during static analysis
+        - '#unknown class OCA\\OpenRegister\\#'
+        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\OpenRegister\\#'
+        - '#has invalid return type OCA\\OpenRegister\\#'
+        - '#has invalid type OCA\\OpenRegister\\#'
+        - '#implements unknown interface OCA\\OpenRegister\\#'
+        # GuzzleHttp is available at runtime via Nextcloud but not in composer require
+        - '#unknown class GuzzleHttp\\#'
+        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class GuzzleHttp\\#'
+        - '#invalid type GuzzleHttp\\#'
+        - '#Caught class GuzzleHttp\\#'
+        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
+        - '#unknown class Doctrine\\DBAL\\#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
+        # Dynamic HTTP status codes from business rule validation results
+        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
+        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
+        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
+        # OCP stub gaps for methods that exist at runtime
+        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
+        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
+        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
+        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="1"
+    errorLevel="4"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     findUnusedBaselineEntry="true"
     findUnusedCode="true"
+    findUnusedVariablesAndParams="true"
 >
     <projectFiles>
         <directory name="lib" />
@@ -14,7 +14,114 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
-	<extraFiles>
-		<directory name="vendor"/>
-	</extraFiles>
+    <stubs>
+        <file name="vendor/nextcloud/ocp/OCP/Capabilities/ICapability.php" preloadClasses="true" />
+    </stubs>
+    <issueHandlers>
+        <UndefinedDocblockClass errorLevel="suppress"/>
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <!-- Nextcloud OCP Classes -->
+                <referencedClass name="OCP\AppFramework\App"/>
+                <referencedClass name="OCP\AppFramework\Bootstrap\IBootstrap"/>
+                <referencedClass name="OCP\AppFramework\Controller"/>
+                <referencedClass name="OCP\AppFramework\IAppContainer"/>
+                <referencedClass name="OCP\App\IAppManager"/>
+                <referencedClass name="OCP\BackgroundJob\IJobList"/>
+                <referencedClass name="OCP\BackgroundJob\QueuedJob"/>
+                <referencedClass name="OCP\BackgroundJob\TimedJob"/>
+                <referencedClass name="OCP\EventDispatcher\Event"/>
+                <referencedClass name="OCP\EventDispatcher\IEventListener"/>
+                <referencedClass name="OCP\IAppConfig"/>
+                <referencedClass name="OCP\ICacheFactory"/>
+                <referencedClass name="OCP\IConfig"/>
+                <referencedClass name="OCP\IDBConnection"/>
+                <referencedClass name="OCP\IGroupManager"/>
+                <referencedClass name="OCP\IUserManager"/>
+                <referencedClass name="OCP\IUserSession"/>
+                <referencedClass name="OCP\IMemcache"/>
+                <referencedClass name="OCP\IRequest"/>
+                <referencedClass name="OCP\EventDispatcher\IEventDispatcher"/>
+                <referencedClass name="OCP\DB\QueryBuilder\IQueryBuilder"/>
+                <referencedClass name="OCP\AppFramework\Db\QBMapper"/>
+                <referencedClass name="OCP\AppFramework\Db\Entity"/>
+                <referencedClass name="OCP\Files\IRootFolder"/>
+                <referencedClass name="OCP\Files\Node"/>
+                <referencedClass name="OCP\Files\File"/>
+                <referencedClass name="OCP\Files\Folder"/>
+                <referencedClass name="OCP\Files\NotFoundException"/>
+                <referencedClass name="OCP\AppFramework\Http\JSONResponse"/>
+                <referencedClass name="OCP\AppFramework\Http\TemplateResponse"/>
+                <referencedClass name="OCP\AppFramework\Http\DataResponse"/>
+                <referencedClass name="OCP\IL10N"/>
+                <referencedClass name="OCP\IURLGenerator"/>
+                <referencedClass name="OCP\Http\Client\IClient"/>
+                <referencedClass name="OCP\Http\Client\IClientService"/>
+                <referencedClass name="OCP\Notification\IManager"/>
+                <referencedClass name="OCP\Share\IManager"/>
+                <!-- OpenRegister cross-app classes (loaded dynamically) -->
+                <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
+                <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
+                <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
+                <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
+                <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
+                <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
+                <referencedClass name="OCA\OpenRegister\Service\FileService"/>
+                <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
+                <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- Additional OCP infrastructure types used across the fleet -->
+                <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
+                <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>
+                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
+                <referencedClass name="OCP\DB\Exception"/>
+                <referencedClass name="OCP\IGroup"/>
+                <referencedClass name="OCP\IUser"/>
+                <referencedClass name="OCP\Migration\IRepairStep"/>
+                <!-- Nextcloud server internals -->
+                <referencedClass name="OC"/>
+                <!-- GuzzleHttp (loaded via composer at runtime) -->
+                <referencedClass name="GuzzleHttp\Client"/>
+                <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>
+            </errorLevel>
+        </UndefinedClass>
+        <UndefinedMagicMethod errorLevel="suppress"/>
+        <UnusedClass errorLevel="suppress"/>
+        <PossiblyUnusedMethod errorLevel="suppress"/>
+        <UnusedMethod errorLevel="suppress"/>
+        <UnusedProperty errorLevel="suppress"/>
+        <PossiblyUnusedParam errorLevel="suppress"/>
+        <UnusedDocblockParam errorLevel="suppress"/>
+        <UnusedVariable errorLevel="suppress"/>
+        <PossiblyUnusedReturnValue errorLevel="suppress"/>
+        <RedundantCondition errorLevel="suppress"/>
+        <RedundantFunctionCall errorLevel="suppress"/>
+        <RedundantCast errorLevel="suppress"/>
+        <InvalidDocblock errorLevel="suppress"/>
+        <MoreSpecificImplementedParamType errorLevel="suppress"/>
+        <MissingDependency errorLevel="suppress"/>
+        <UnevaluatedCode errorLevel="suppress"/>
+        <NoValue errorLevel="suppress"/>
+        <TypeDoesNotContainNull errorLevel="suppress"/>
+        <TypeDoesNotContainType errorLevel="suppress"/>
+        <InvalidArrayOffset errorLevel="suppress"/>
+        <InvalidCast errorLevel="suppress"/>
+        <InvalidArgument errorLevel="suppress"/>
+        <InvalidReturnType errorLevel="suppress"/>
+        <InvalidReturnStatement errorLevel="suppress"/>
+        <MismatchingDocblockReturnType errorLevel="suppress"/>
+        <EmptyArrayAccess errorLevel="suppress"/>
+        <ImplementedReturnTypeMismatch errorLevel="suppress"/>
+        <InvalidMethodCall errorLevel="suppress"/>
+        <UndefinedInterfaceMethod errorLevel="suppress"/>
+        <MissingTemplateParam errorLevel="suppress"/>
+    </issueHandlers>
+    <extraFiles>
+        <directory name="vendor/nextcloud/ocp" />
+    </extraFiles>
 </psalm>


### PR DESCRIPTION
## Summary

Phase 2 fleet root-config consolidation for openconnector. Pattern from shillinq#300 (merged) and decidesk#243 (merged). Canonical lives in `nextcloud-app-template`.

**openconnector is uniquely a "phpstan turned on for the first time" PR in this rollout** — see the large baseline below.

## Changes

### Canonical configs synced
- `phpcs.xml` (cosmetic name → OpenConnector; ~30 silent `<severity>0</severity>` PEAR overrides gone)
- `phpmd.xml` (cosmetic name → OpenConnector)
- `psalm.xml` (replaces a 20-line stub with the full 127-line canonical ruleset)
- `phpstan.neon`, `phpstan-bootstrap.php`, `phpstan-baseline.neon` (new — phpstan was previously not running here at all)
- `phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php` (new)

### Composer fleet-consistency fix
- `composer.json` `config.platform.php`: `"8.3"` → `"8.2"`. The rest of the fleet pins `8.1`, but openconnector requires `8.2+` via `php-soap/ext-soap-engine` — `8.2` is the lowest realistic floor that lets `composer install` work on the standard dev/CI hosts. `composer.lock` regenerated; side-effect rolls `azjezz/psl` off its `4.3.0` 8.3-only typed-class-constant syntax.

### Mechanical PHPMD cleanups
- `PdokConnector::suggest/free`: `$q` → `$query` (5 sites). Controller route bindings deliberately left as `$q` because Nextcloud binds query params by parameter name.
- `PdokConnector::orLookup/writeThrough`: `$or` → `$objectService`.
- `IBabsConnectorService::pushVoorstel`: removed `UnusedLocalVariable $organisatieId` from placeholder body.
- `ExportService::export`: added unreachable `return new JSONResponse()` after `#[NoReturn] $this->download()` (JetBrains attribute not natively understood by phpstan).

### Auto-fix
`phpcbf` fixed 575 violations across 64 files (brace placement, spacing, comment style — categories the removed PEAR overrides were masking).

## Gate counts

| Gate    | Before (initial)      | After                  | Notes |
|---------|-----------------------|------------------------|-------|
| PHPCS   | 5 406 err / 806 warn  | 4 756 err / 798 warn   | `ignore_warnings_on_exit=1` — warnings logged not failed |
| PHPMD   | 22 lines              | 17 lines               | 5 mechanical fixes; remainder is architectural |
| PSALM   | 520 issues            | 150 err + 520 other    | Canonical ruleset landed cold |
| PHPSTAN | 820 errors            | 0 (with 818 baseline)  | First time phpstan ran here |

## Tracking issue

Burndown of the absorbed lint debt: ConductionNL/openconnector#848

## Test plan

- [x] `./vendor/bin/phpcs --standard=phpcs.xml --report=summary` — runs, 4 756/798 logged
- [x] `./vendor/bin/phpstan analyse --memory-limit=2G --no-progress` — `[OK] No errors`
- [x] `./vendor/bin/psalm --threads=1 --no-cache --show-info=false --no-progress` — completes, count noted in tracking issue
- [x] `./vendor/bin/phpmd lib text phpmd.xml` — 17 lines, categories listed in tracking issue
- [x] CI gates (phpcs / phpstan / psalm / phpmd) will green or noisy-but-non-failing per ruleset config

🤖 Generated with [Claude Code](https://claude.com/claude-code)