### PR TITLE
fix(tests): restore phpunit harness on chain-E (closes #844)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
 			"OCA\\OpenConnector\\": "lib/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"OCA\\OpenConnector\\Tests\\": "tests/"
+		}
+	},
 	"scripts": {
 		"post-install-cmd": [
 			"@composer bin all install --ansi"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,7 @@
          colors="true">
     <testsuites>
         <testsuite name="Unit Tests">
-            <directory>tests/unit</directory>
+            <directory>tests/Unit</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * PHPUnit bootstrap for OpenConnector unit tests.
+ *
+ * @category Test
+ * @package  OCA\OpenConnector\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://openconnector.app
+ */
+
+declare(strict_types=1);
+
+// Define that we're running PHPUnit.
+define('PHPUNIT_RUN', 1);
+
+// Include Composer's autoloader. Use `require` (not `require_once`) so the
+// ClassLoader instance is returned even when PHPUnit has already pulled it in.
+$autoloader = require __DIR__ . '/../vendor/autoload.php';
+
+// Register the OCP/NCU namespaces from the nextcloud/ocp dev dependency so that
+// unit tests can run in a bare environment (no installed Nextcloud server). When
+// NC is present its own autoloader provides these and these mappings are inert.
+if ($autoloader instanceof \Composer\Autoload\ClassLoader && is_dir(__DIR__ . '/../vendor/nextcloud/ocp/OCP') === true) {
+    $autoloader->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP/');
+    if (is_dir(__DIR__ . '/../vendor/nextcloud/ocp/NCU') === true) {
+        $autoloader->addPsr4('NCU\\', __DIR__ . '/../vendor/nextcloud/ocp/NCU/');
+    }
+}
+
+// Bootstrap Nextcloud only when the config file is readable (i.e., in a
+// properly provisioned dev/CI environment). Skip silently in standalone mode —
+// OCP stubs are sufficient for unit-only test suites.
+$ncBase   = __DIR__ . '/../../../lib/base.php';
+$ncConfig = __DIR__ . '/../../../config/config.php';
+if (defined('OC_CONSOLE') === false && is_readable($ncConfig) === true) {
+    if (file_exists($ncBase) === true) {
+        try {
+            require_once $ncBase;
+        } catch (\Throwable $e) {
+            // NC not fully installed — unit tests continue with vendor stubs only.
+        }
+    }
+
+    // Load Test\TestCase and other NC test classes (NC convention).
+    if (file_exists(__DIR__ . '/../../../tests/autoload.php') === true) {
+        require_once __DIR__ . '/../../../tests/autoload.php';
+    }
+
+    // Load all enabled apps if Nextcloud is available.
+    if (class_exists('OC_App')) {
+        \OC_App::loadApps();
+
+        // Load our specific app.
+        \OC_App::loadApp('openconnector');
+
+        // Clear hooks for testing.
+        OC_Hook::clear();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the three test-harness gaps tracked in #844 that were blocking every PHPUnit run on the chain-E branch (since merged to development):

1. **Added `tests/bootstrap.php`** — matches the fleet pattern (decidesk / pipelinq). Registers OCP/NCU PSR-4 from `vendor/nextcloud/ocp` for bare runs, then bootstraps Nextcloud + loads the `openconnector` app only when `config/config.php` is readable.
2. **Added `autoload-dev` PSR-4** in `composer.json`: `OCA\\OpenConnector\\Tests\\` → `tests/`, so fresh test classes (like the one introduced in #843) are discoverable.
3. **Fixed `phpunit.xml` testsuite path** — `tests/unit` → `tests/Unit` (case-sensitive on Linux CI).

> Note: original target `feature/i18n-complete-translations` has since been merged + deleted; retargeted to `development`.

## Verification

Ran `vendor/bin/phpunit -c phpunit.xml --testsuite="Unit Tests"` inside the dev container (PHP 8.3.30, PHPUnit 10.5.63):

- **Before**: PHP Fatal error — `Failed to open stream: tests/bootstrap.php`. Zero tests discovered.
- **After**: 123 tests discovered + executed in 0.367s. 64 errors + 15 failures all pre-existing chain-C debt (deleted `OCA\OpenConnector\Db\*` entity classes still referenced by `HealthControllerTest`, `RegisterDescriptorTest`, etc.) — **out of scope for this PR**.

The harness itself is now green: bootstrap loads, autoloader finds test classes, testsuite resolves. Test-content fixes belong to follow-up PRs (one per dead-entity reference cluster).

## Test plan

- [x] PHPUnit discovers tests (123 vs 0 before)
- [x] Bootstrap matches fleet (decidesk/pipelinq pattern)
- [x] `composer dump-autoload` succeeds with new mapping
- [ ] CI's central `code-quality.yml` PHPUnit step now runs the suite (will surface on this PR's checks)
- [ ] Follow-up issue(s) to fix the 64 pre-existing entity-class errors

## Follow-ups (not this PR)

- The 64 errors come from tests referencing chain-C deleted entities (`OCA\OpenConnector\Db\Source`, `Consumer`, `Endpoint`, `Event`, etc.). These tests must be either rewritten against `\OCA\OpenRegister\Service\ObjectService` (chain-C migration target) or deleted alongside the entities. Tracking left to a separate ticket.
- 15 failures from `RegisterDescriptorTest::testEveryProtectedEntityPropertyAppearsInSchema` are the same root cause (entity-class existence asserts).