### PR TITLE
feat(sync): port Twig endpoint templating + event-trigger guard from #745 (re-open)

### DIFF
--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -1135,8 +1135,11 @@ class EndpointService
 
                 $data['flowToken'] = $flowToken->__serialize();
 
+                $conditionsPassed = $this->checkRuleConditions(rule: $rule, data: $data, logicResult: $logicResult);
+                $timingMatches    = (($ruleData['timing'] ?? 'before') === $timing);
+
                 // Check rule conditions
-                if ($this->checkRuleConditions(rule: $rule, data: $data, logicResult:  $logicResult) === false || ($ruleData['timing'] ?? 'before') !== $timing) {
+                if ($conditionsPassed === false || $timingMatches === false) {
                     $this->logger->info('Rule condition check failed for endpoint '.($endpointData['name'] ?? '').' and rule '.($ruleData['name'] ?? '').' of type: '.($ruleData['type'] ?? ''));
 
                     continue;
@@ -1644,12 +1647,16 @@ class EndpointService
             $synchronizationId = $config['synchronization'];
         }
 
+        $this->logger->debug('[EndpointService] processSyncRule ruleId='.$rule->getUuid().' synchronizationId='.$synchronizationId);
+
         // Fetch the synchronization.
         if (is_numeric($synchronizationId) === true) {
             $synchronization = $this->synchronizationService->getSynchronization(id: (int) $synchronizationId);
         } else {
             $synchronization = $this->synchronizationService->getSynchronization(filters: ['reference' => $synchronizationId]);
         }
+
+        $this->logger->debug('[EndpointService] processSyncRule synchronization fetched id='.$synchronization->getUuid().' name='.$synchronization->getName());
 
         // Check if the synchronization should be in test mode.
         if (isset($data['body']['isTest']) === true) {
@@ -1708,7 +1715,9 @@ class EndpointService
             $mutationType = 'delete';
         }
 
+        $this->logger->debug('[EndpointService] processSyncRule calling synchronize syncId='.$synchronization->getUuid().' isTest='.var_export($test, true).' force='.var_export($force, true).' mutationType='.var_export($mutationType, true));
         $log = $this->synchronizationService->synchronize(synchronization: $synchronization, isTest: $test, force: $force, object: $fetchedObject, mutationType: $mutationType, data: $object, flowToken: $flowToken);
+        $this->logger->debug('[EndpointService] processSyncRule synchronize complete syncId='.$synchronization->getUuid());
 
         // $object got updated through reference.
         $returnedObject = $object;

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -118,6 +118,24 @@ class MappingService
     }//end encodeArrayKeys()
 
     /**
+     * Renders a Twig template string using the mapping Twig environment.
+     *
+     * @param string $template The Twig template to render.
+     * @param array  $context  The context available inside the template.
+     *
+     * @return string The rendered template result.
+     *
+     * @throws LoaderError|SyntaxError Twig exceptions.
+     *
+     * @psalm-param array<string, mixed> $context
+     */
+    public function renderTemplateString(string $template, array $context=[]): string
+    {
+        return html_entity_decode($this->twig->createTemplate($template)->render($context));
+
+    }//end renderTemplateString()
+
+    /**
      * Maps (transforms) an array (input) to a different array (output).
      *
      * Delegates to OpenRegister's MappingService when available, otherwise
@@ -219,7 +237,7 @@ class MappingService
             }
 
             try {
-                $dotArray->set($key, html_entity_decode($this->twig->createTemplate($value)->render($originalInput)));
+                $dotArray->set($key, $this->renderTemplateString($value, $originalInput));
             } catch (Throwable $e) {
                 throw new Exception("Error for mapping: {$mapping->getName()}, key: $key, value: $value and with message thrown: {$e->getMessage()}");
             }

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -62,6 +62,9 @@ class SynchronizationService
     const KEY_FOR_EXTRA_DATA_LOCATION          = 'keyToSetExtraData';
     const MERGE_EXTRA_DATA_OBJECT_LOCATION     = 'mergeExtraData';
     const UNSET_CONFIG_KEY_LOCATION            = 'unsetConfigKey';
+
+    const EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION = 'endpointTemplate';
+
     const EXTRA_DATA_BEFORE_CONDITIONS_LOCATION = 'fetchExtraDataBeforeConditions';
     const EXTEND_BEFORE_CONDITIONS_LOCATION     = 'extendInputBeforeConditions';
     const EXTEND_BEFORE_CONDITIONS_FETCH_OBJECT = 'extendInputFetchObjectBeforeConditions';
@@ -157,6 +160,10 @@ class SynchronizationService
 
         $directSynchronizations = $this->findAllBySourceId(register: $register, schema: $schema);
         foreach ($directSynchronizations as $synchronization) {
+            if ($this->shouldTriggerOnEvent(synchronization: $synchronization, eventMutationType: $eventMutationType) === false) {
+                continue;
+            }
+
             try {
                 if ($eventMutationType === 'delete') {
                     $this->synchronize(
@@ -195,6 +202,10 @@ class SynchronizationService
                 continue;
             }
 
+            if ($this->shouldTriggerOnEvent(synchronization: $synchronization, eventMutationType: $eventMutationType) === false) {
+                continue;
+            }
+
             try {
                 $parentObjectArray = $this->resolveParentObjectForRelatedObjectTrigger(
                  synchronization: $synchronization,
@@ -226,6 +237,32 @@ class SynchronizationService
             }//end try
         }//end foreach
     }//end handleObjectEventSynchronization()
+
+    /**
+     * Determines whether a synchronization should run for the given mutation type.
+     *
+     * Checks sourceConfig['triggerOnlyOnEvents'] (case-insensitive). When the key
+     * is absent or empty the synchronization always runs; when present it runs only
+     * if $eventMutationType is listed.
+     *
+     * @param ObjectEntity $synchronization   The synchronization to evaluate.
+     * @param string       $eventMutationType One of create|update|delete.
+     *
+     * @return bool True when the synchronization should run, false when it should be skipped.
+     */
+    private function shouldTriggerOnEvent(ObjectEntity $synchronization, string $eventMutationType): bool
+    {
+        $sourceConfig  = (array) ($synchronization->getSourceConfig() ?? []);
+        $allowedEvents = ($sourceConfig['triggerOnlyOnEvents'] ?? []);
+
+        if (empty($allowedEvents) === true) {
+            return true;
+        }
+
+        $normalised = array_map('strtolower', (array) $allowedEvents);
+        return in_array(strtolower($eventMutationType), $normalised, true);
+
+    }//end shouldTriggerOnEvent()
 
     /**
      * Resolve and fetch the parent object for a related-object trigger.
@@ -989,6 +1026,21 @@ class SynchronizationService
                 }
             }
         }//end if
+
+        if (isset($extraDataConfig[$this::EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION]) === true
+            && is_string($extraDataConfig[$this::EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION]) === true
+            && $extraDataConfig[$this::EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION] !== ''
+        ) {
+            $endpoint = $this->mappingService->renderTemplateString(
+                template: $extraDataConfig[$this::EXTRA_DATA_ENDPOINT_TEMPLATE_LOCATION],
+                context: [
+                    'endpoint'        => ($endpoint ?? null),
+                    'object'          => $object,
+                    'originId'        => $originId,
+                    'extraDataConfig' => $extraDataConfig,
+                ]
+            );
+        }
 
         if (!$endpoint) {
             throw new Exception(
@@ -1870,8 +1922,25 @@ class SynchronizationService
         $this->checkRateLimit($source);
 
         // Extract source configuration
-        $sourceConfig   = $this->callService->applyConfigDot($syncData['sourceConfig'] ?? []); // TODO; This is the second time this function is called in the synchonysation flow, needs further refactoring investigation
-        $endpoint       = $sourceConfig['endpoint'] ?? '';
+        $sourceConfig = $this->callService->applyConfigDot($syncData['sourceConfig'] ?? []); // TODO; This is the second time this function is called in the synchonysation flow, needs further refactoring investigation
+        $endpoint     = $sourceConfig['endpoint'] ?? '';
+        if (is_string($endpoint) === true
+            && str_contains($endpoint, '{{') === true
+            && str_contains($endpoint, '}}') === true
+        ) {
+            $contextData = ($data ?? []);
+            // After-rule responses pass the OR object (`{id, @self}`) here; lift @self.relations
+            // to the top level so simple `{{ data.zaaknummer }}` lookups still resolve.
+            if (isset($contextData['@self']['relations']) === true && is_array($contextData['@self']['relations']) === true) {
+                $contextData = array_merge($contextData['@self']['relations'], $contextData);
+            }
+
+            $endpoint = $this->mappingService->renderTemplateString(
+                template: $endpoint,
+                context: ['data' => $contextData]
+            );
+        }
+
         $headers        = $sourceConfig['headers'] ?? [];
         $query          = $sourceConfig['query'] ?? [];
         $usesPagination = true;


### PR DESCRIPTION
Re-opening — the original PR #845 was opened against `feature/i18n-complete-translations` (chain-E), which got squash-merged into development without including this branch's commits. The port is still needed — `MappingService::renderTemplateString` + the `shouldTriggerOnEvent` guard + `@self.relations` Twig context merge are NOT in development.

## Summary

4 backend strands cherry-picked from the original #745 (rjzondervan):
- `shouldTriggerOnEvent` guard on `SynchronizationService::handleObjectEventSynchronization`
- Twig templating in `MappingService::renderTemplateString` + `SynchronizationService::fetchObjectProperty / getAllObjectsFromApi`
- `@self.relations` merge into Twig context
- `EndpointService::processRules` debug logs + named-vars refactor

Skipped from the original PR:
- `src/modals/Synchronization/EditSynchronization.vue` hunk — file is eslint-ignored extraction reference post-chain-E
- `appinfo/routes.php` SPA catch-all regex — already fixed in development via the chain-E route-fix commit

Quality gates: PHPCS strict pass (verified during the original port).

Closes #745 (overtaken by chain-B/C cutover; carry-forward value ported here).