### PR TITLE
fix(phpcs): auto-fix 91 sniff violations from Tier-4 cascade

### DIFF
--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -56,7 +56,7 @@ class EndpointsController extends Controller
     /**
      * CORS max age
      *
-     * @var int
+     * @var integer
      */
     private int $corsMaxAge;
 
@@ -325,8 +325,8 @@ class EndpointsController extends Controller
                     $returnArray            = $result;
                     $returnArray['count']   = $result['total'];
                     $returnArray['results'] = array_map(fn($obj) => $obj->jsonSerialize(), $result['results']);
-                    unset($returnArray['total']); // Remove 'total' since we renamed it to 'count'
-
+                    unset($returnArray['total']);
+                    // Remove 'total' since we renamed it to 'count'
                     // Add pagination links if needed
                     if ($result['page'] < $result['pages']) {
                         $parameters['page']  = $result['page'] + 1;

--- a/lib/Controller/SynchronizationsController.php
+++ b/lib/Controller/SynchronizationsController.php
@@ -141,7 +141,8 @@ class SynchronizationsController extends Controller
             }
 
             if (!empty($filters['slow_syncs'])) {
-                $specialFilters['slow_syncs'] = 5000; // 5 seconds in milliseconds
+                $specialFilters['slow_syncs'] = 5000;
+                // 5 seconds in milliseconds
             }
 
             // Build search conditions and parameters
@@ -495,7 +496,8 @@ class SynchronizationsController extends Controller
                     '%s,%s,"%s",%s,%s,%s,%s,%s,%s'."\n",
                     $log->getUuid() ?? '',
                     $data['status'] ?? '',
-                    str_replace('"', '""', $data['message'] ?? ''), // Escape quotes in message
+                    str_replace('"', '""', $data['message'] ?? ''),
+                // Escape quotes in message
                     $data['synchronizationId'] ?? '',
                     $data['sourceId'] ?? '',
                     $data['targetId'] ?? '',

--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -128,7 +128,7 @@ class UserController extends Controller
     /**
      * CORS max age
      *
-     * @var int
+     * @var integer
      */
     private int $corsMaxAge;
 

--- a/lib/Migration/Version2Date20260520000001.php
+++ b/lib/Migration/Version2Date20260520000001.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
  *

--- a/lib/Migration/Version2Date20260520000099.php
+++ b/lib/Migration/Version2Date20260520000099.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
  *
@@ -94,9 +94,9 @@ class Version2Date20260520000099 extends SimpleMigrationStep
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
-        /**
- * @var ISchemaWrapper $schema
-*/
+        /*
+         * @var ISchemaWrapper $schema
+         */
         $schema = $schemaClosure();
 
         $db     = \OC::$server->get(IDBConnection::class);

--- a/lib/Service/EndpointCacheService.php
+++ b/lib/Service/EndpointCacheService.php
@@ -49,7 +49,7 @@ class EndpointCacheService
     /**
      * Whether the in-memory cache is considered stale (set to true after a write).
      *
-     * @var bool
+     * @var boolean
      */
     private bool $cacheDirty = false;
 

--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -191,29 +191,29 @@ class EndpointService
         try {
             $flowToken = new FlowToken(requestOriginal: $request, path: $path);
 
-            //            // Process initial data
-            //            $responseBody = $this->parseContent(
-            //                request: $request,
+            // Process initial data
+            // $responseBody = $this->parseContent(
+            // request: $request,
             //
-            //            );
+            // );
             //
-            //            if ($responseBody == '') {
-            //                $responseBody = [];
-            //            }
+            // if ($responseBody == '') {
+            // $responseBody = [];
+            // }
             //
             $currentDate = (new DateTime())->format('c');
             //
-            //            // This is double becuase mapping needs it in body but other rules seek directly in data.
+            // This is double becuase mapping needs it in body but other rules seek directly in data.
             //
-            //            $incomingMethod = $request->getMethod();
-            //            $incomingHeaders = $this->getHeaders($request->server, true);
-            //            $incomingParams = array_merge($request->getParams(), $responseBody);
+            // $incomingMethod = $request->getMethod();
+            // $incomingHeaders = $this->getHeaders($request->server, true);
+            // $incomingParams = array_merge($request->getParams(), $responseBody);
             //
-            //            $incomingData = [
-            //                'method' => $incomingMethod,
-            //                'headers' => $incomingHeaders,
-            //                'params' => $incomingParams
-            //            ];
+            // $incomingData = [
+            // 'method' => $incomingMethod,
+            // 'headers' => $incomingHeaders,
+            // 'params' => $incomingParams
+            // ];
             // @todo: This should eventually be merged into the flow tokens
             $data = [
                 'utility'    => [
@@ -402,9 +402,9 @@ class EndpointService
 
         $uses = (new Dot($object->jsonSerialize()))->flatten();
         //
-        //        if(isset($serializedObject) === true && !empty($serializedObject['@self']['relations'])) {
-        //            $uses = $serializedObject['@self']['relations'];
-        //        }
+        // if(isset($serializedObject) === true && !empty($serializedObject['@self']['relations'])) {
+        // $uses = $serializedObject['@self']['relations'];
+        // }
         $useUrls = [];
 
         $uuidToUrlMap = [];
@@ -459,7 +459,7 @@ class EndpointService
 
         // @TODO: correct rewriting self url. This has to be fixed with issue CONNECTOR-314
         // Add self object URI mapping
-        //        $uuidToUrlMap[$object->getUuid()] = $this->generateEndpointUrl(id: $object->getUuid(), schemaMapper: $schemaMapper);
+        // $uuidToUrlMap[$object->getUuid()] = $this->generateEndpointUrl(id: $object->getUuid(), schemaMapper: $schemaMapper);
         $uuidToUrlMap[$object->getUri()] = $this->generateEndpointUrl(id: $object->getUuid(), schemaMapper: $schemaMapper);
 
         // @TODO: temporary fix for download endpoints. This has to be fixed with issue CONNECTOR-314
@@ -507,7 +507,8 @@ class EndpointService
 
         $dot = new Dot([], parse: true);
         foreach ($reducedKeys as $path) {
-            $dot->set($path, true); // true is a safe placeholder for Dot to serialize
+            $dot->set($path, true);
+            // true is a safe placeholder for Dot to serialize
         }
 
         return $dot->jsonSerialize();
@@ -1126,10 +1127,10 @@ class EndpointService
 
             // Process each rule in order
             foreach ($ruleEntities as $rule) {
-                //                // Skip if rule action doesn't match request method
-                //                if (strtolower($ruleData['action']) !== strtolower($request->getMethod())) {
-                //                    continue;
-                //                }
+                // Skip if rule action doesn't match request method
+                // if (strtolower($ruleData['action']) !== strtolower($request->getMethod())) {
+                // continue;
+                // }
                 $ruleData    = $rule->getObject();
                 $logicResult = null;
 
@@ -1591,7 +1592,7 @@ class EndpointService
 
                     $tags = array_merge($config['tags'] ?? [], ["object:$objectId"]);
                     if ($file instanceof \OCP\Files\File === true) {
-                        //                        $this->attachTagsToFile(fileId: $file->getId(), tags: $tags);
+                        // $this->attachTagsToFile(fileId: $file->getId(), tags: $tags);
                     }
 
                     $result[$key] = $file->getPath();
@@ -1613,7 +1614,7 @@ class EndpointService
 
                 $tags = array_merge($config['tags'] ?? [], ["object:$objectId"]);
                 if ($file instanceof File === true) {
-                    //                    $this->attachTagsToFile(fileId: $file->getId(), tags: $tags);
+                    // $this->attachTagsToFile(fileId: $file->getId(), tags: $tags);
                 }
 
                 $dataDot[$config['filePath']] = $file->getPath();
@@ -1805,7 +1806,7 @@ class EndpointService
         $openRegister->setSchema($superSchemaId);
 
         $object = $openRegister->find(id: $objectId);
-        //        $location = $object->getFolder();
+        // $location = $object->getFolder();
         $fileService = $this->containerInterface->get('OCA\OpenRegister\Service\FileService');
         $location    = $fileService->getObjectFolder($object)->getPath();
 
@@ -1953,7 +1954,7 @@ class EndpointService
     {
         $config = $rule->getObject()['configuration'] ?? [];
 
-        /**
+        /*
          * @var ObjectEntity $object
          */
         $object = $this->objectService->getOpenRegisters()->getMapper('objectEntity')->find(identifier: $objectId);
@@ -1985,20 +1986,20 @@ class EndpointService
         }
 
         if (isset($data['parameters']['version']) === true) {
-            /**
- * @var File $file
-*/
+            /*
+             * @var File $file
+             */
              $file = $fileService->getFile(object: $object, file: $filename, version: $data['parameters']['version']);
         } else if (isset($data['parameters']['versie']) === true) {
             // @TODO: This can be nicer by mapping, but let's first get something sure
-            /**
- * @var File $file
-*/
+            /*
+             * @var File $file
+             */
              $file = $fileService->getFile(object: $object, file: $filename, version: $data['parameters']['versie']);
         } else {
-            /**
- * @var File $file
-*/
+            /*
+             * @var File $file
+             */
             $file = $fileService->getFile(object: $object, file: $filename);
         }
 
@@ -2049,7 +2050,8 @@ class EndpointService
 
         $flowToken->setRequestAmended($requestAmended);
 
-        return $flowToken; // Return the overridden request
+        return $flowToken;
+        // Return the overridden request
     }//end updateRequestWithRuleData()
 
     /**

--- a/lib/Service/Migration/LegacyToRegisterMigrator.php
+++ b/lib/Service/Migration/LegacyToRegisterMigrator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
  *
@@ -379,7 +379,8 @@ class LegacyToRegisterMigrator
             'legacyCount'   => $count,
             'migratedCount' => $migrated,
             'skipped'       => $skipped,
-            'fkRewrites'    => 0, // populated by FK rewrite pass
+            'fkRewrites'    => 0,
+        // populated by FK rewrite pass
             'branching'     => $hasSyncBranching ? $syncBranchCounts : null,
         ];
     }//end migrateEntity()

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -71,9 +71,8 @@ class SynchronizationService
     const EXTEND_BEFORE_CONDITIONS_FETCH_OBJECT = 'extendInputFetchObjectBeforeConditions';
     const FILE_TAG_TYPE        = 'files';
     const VALID_MUTATION_TYPES = ['create', 'update', 'delete'];
-    const DEFAULT_MAX_PAGES    = 50; // Safety limit to prevent infinite page requesting loop
-
-
+    const DEFAULT_MAX_PAGES    = 50;
+    // Safety limit to prevent infinite page requesting loop
     private const DEFAULT_SUCCESS_LOG_RETENTION = 3600000;
     private const DEFAULT_ERROR_LOG_RETENTION   = 259200000;
 
@@ -627,7 +626,8 @@ class SynchronizationService
                 $objectList = $this->getAllObjectsFromSource($synchronization, $isTest, $data);
             } catch (TooManyRequestsHttpException $e) {
                 $rateLimitException = $e;
-                $objectList         = []; // Ensure it's defined
+                $objectList         = [];
+                // Ensure it's defined
             }
 
             $fetchDuration = round((microtime(true) - $stageStartTime) * 1000, 2);
@@ -1527,7 +1527,8 @@ class SynchronizationService
         return [
             'log'          => $contractLog !== null ? $contractLog->getObject() : [],
             'contract'     => $synchronizationContract->getObject(),
-            'resultAction' => 'update',// /create
+            'resultAction' => 'update',
+        // /create
         ];
     }//end synchronizeContract()
 
@@ -1993,8 +1994,9 @@ class SynchronizationService
         $this->checkRateLimit($source);
 
         // Extract source configuration
-        $sourceConfig = $this->callService->applyConfigDot($syncData['sourceConfig'] ?? []); // TODO; This is the second time this function is called in the synchonysation flow, needs further refactoring investigation
-        $endpoint     = $sourceConfig['endpoint'] ?? '';
+        $sourceConfig = $this->callService->applyConfigDot($syncData['sourceConfig'] ?? []);
+        // TODO; This is the second time this function is called in the synchonysation flow, needs further refactoring investigation
+        $endpoint = $sourceConfig['endpoint'] ?? '';
         if (is_string($endpoint) === true
             && str_contains($endpoint, '{{') === true
             && str_contains($endpoint, '}}') === true
@@ -2234,7 +2236,8 @@ class SynchronizationService
             // Use next endpoint URL pagination
             $nextEndpoint = $this->getNextEndpoint(body: $result, url: $sourceData['location'] ?? '', currentEndpoint: $currentEndpoint);
             if ($nextEndpoint === null || $nextEndpoint === $currentEndpoint) {
-                return null; // No more pages
+                return null;
+                // No more pages
             }
 
             return [
@@ -2250,7 +2253,8 @@ class SynchronizationService
             $nextConfig = $this->getNextPage(config: $config, sourceConfig: $syncData['sourceConfig'] ?? [], currentPage: $nextPage);
 
             return [
-                'endpoint'         => $currentEndpoint, // Base endpoint stays the same
+                'endpoint'         => $currentEndpoint,
+            // Base endpoint stays the same
                 'config'           => $nextConfig,
                 'page'             => $nextPage,
                 'usesNextEndpoint' => false,
@@ -2356,9 +2360,10 @@ class SynchronizationService
     {
         $allObjects      = [];
         $currentEndpoint = $endpoint;
-        $maxPages        = 50; // Safety limit
-        $sourceData      = $source !== null ? $source->getObject() : [];
-        $syncData        = $synchronization->getObject();
+        $maxPages        = 50;
+        // Safety limit
+        $sourceData = $source !== null ? $source->getObject() : [];
+        $syncData   = $synchronization->getObject();
 
         for ($i = 0; $i < $maxPages; $i++) {
             $pageData    = $this->fetchSinglePageData($source, $currentEndpoint, $config, $synchronization);
@@ -3431,45 +3436,45 @@ class SynchronizationService
         // $tags = [];
         // $published = null;
         // $registerId = null;
-        //        switch ($this->getArrayType($endpoint)) {
-        //            // Single file endpoint
-        //            case 'Not array':
-        //                $this->fetchFile(source: $source, endpoint: $endpoint, config: $config, objectId: $objectId, tags: $tags, published: $published);
-        //                break;
-        //            // Array of object that has file(s)
-        //            case 'Associative array':
-        //                $actualEndpoint = $this->getFileContext(config: $config, endpoint: $endpoint, filename: $filename, tags: $tags, objectId: $objectId, published: $published, registerId: $registerId);
+        // switch ($this->getArrayType($endpoint)) {
+        // Single file endpoint
+        // case 'Not array':
+        // $this->fetchFile(source: $source, endpoint: $endpoint, config: $config, objectId: $objectId, tags: $tags, published: $published);
+        // break;
+        // Array of object that has file(s)
+        // case 'Associative array':
+        // $actualEndpoint = $this->getFileContext(config: $config, endpoint: $endpoint, filename: $filename, tags: $tags, objectId: $objectId, published: $published, registerId: $registerId);
         //
-        //                if ($actualEndpoint === null) {
-        //                    return $dataDot->jsonSerialize();
-        //                }
-        //                $this->fetchFile(source: $source, endpoint: $actualEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, filename: $filename, published: $published);
-        //                break;
-        //            // Array of object(s) that has file(s)
-        //            case "Multidimensional array":
-        //                foreach ($endpoint as $object) {
-        //                    $filename = null;
-        //                    $tags = [];
-        //                    $published = null;
-        //                    $registerId = null;
-        //                    $actualEndpoint = $this->getFileContext(config: $config, endpoint: $object, filename: $filename, tags: $tags, objectId: $objectId, published: $published, registerId: $registerId);
-        //                    if ($actualEndpoint === null) {
-        //                        continue;
-        //                    }
-        //                    $this->fetchFile(source: $source, endpoint: $actualEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, filename: $filename, published: $published);
-        //                }
-        //                break;
-        //            // Array of just endpoints
-        //            case "Indexed array":
-        //                foreach ($endpoint as $key => $childEndpoint) {
-        //                    $filename = null;
-        //                    $tags = [];
-        //                    $published = null;
-        //                    $registerId = null;
-        //                    $this->fetchFile(source: $source, endpoint: $childEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, published: $published);
-        //                }
-        //                break;
-        //        }
+        // if ($actualEndpoint === null) {
+        // return $dataDot->jsonSerialize();
+        // }
+        // $this->fetchFile(source: $source, endpoint: $actualEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, filename: $filename, published: $published);
+        // break;
+        // Array of object(s) that has file(s)
+        // case "Multidimensional array":
+        // foreach ($endpoint as $object) {
+        // $filename = null;
+        // $tags = [];
+        // $published = null;
+        // $registerId = null;
+        // $actualEndpoint = $this->getFileContext(config: $config, endpoint: $object, filename: $filename, tags: $tags, objectId: $objectId, published: $published, registerId: $registerId);
+        // if ($actualEndpoint === null) {
+        // continue;
+        // }
+        // $this->fetchFile(source: $source, endpoint: $actualEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, filename: $filename, published: $published);
+        // }
+        // break;
+        // Array of just endpoints
+        // case "Indexed array":
+        // foreach ($endpoint as $key => $childEndpoint) {
+        // $filename = null;
+        // $tags = [];
+        // $published = null;
+        // $registerId = null;
+        // $this->fetchFile(source: $source, endpoint: $childEndpoint, config: $config, objectId: $objectId, registerId: $registerId, tags: $tags, published: $published);
+        // }
+        // break;
+        // }
         // Start fire-and-forget file fetching based on endpoint type
         $this->startAsyncFileFetching(source: $source, config: $config, endpoint: $endpoint, ruleId: $rule->getUuid(), objectId: $objectId);
 
@@ -3537,8 +3542,9 @@ class SynchronizationService
 
                 // Array of object that has file(s)
                 case 'Associative array':
-                    $contextObjectId = null; // Separate variable to avoid overwriting the original
-                    $actualEndpoint  = $this->getFileContext(config: $config, endpoint: $endpoint, filename: $filename, tags: $tags, objectId: $contextObjectId, published: $published, registerId: $registerId);
+                    $contextObjectId = null;
+                    // Separate variable to avoid overwriting the original
+                    $actualEndpoint = $this->getFileContext(config: $config, endpoint: $endpoint, filename: $filename, tags: $tags, objectId: $contextObjectId, published: $published, registerId: $registerId);
                     // Use context object ID if specified, otherwise fall back to the original object ID
                     $targetObjectId = $contextObjectId ?? $objectId;
                     if ($actualEndpoint !== null) {
@@ -4447,7 +4453,7 @@ class SynchronizationService
         return false;
     }//end shouldPublishFile()
 
-    /**
+    /*
      * Fetches a file from a given endpoint and saves it to the OpenRegister system.
      *
      * This method downloads a file from a remote source and stores it in the OpenRegister


### PR DESCRIPTION
PHPCBF ran via PHP 8.3 docker (`php:8.3-cli`) against the merged Tier-4 state on `development`. 91 auto-fixable errors fixed across 9 files in `lib/`. All categories were trivial style (block-comment formatting, doc-block format).

Files touched:
- `lib/Controller/{UserController,SynchronizationsController,EndpointsController}.php`
- `lib/Service/{EndpointService,SynchronizationService,EndpointCacheService}.php`
- `lib/Service/Migration/LegacyToRegisterMigrator.php`
- `lib/Migration/Version2Date20260520000{001,099}.php`

After this PR: `phpcs` still reports **3,194 errors + 465 warnings** across 96 files — those are pre-existing PHPDoc / @spec-tag debt (not auto-fixable), tracked under #848 (Lint debt cleanup Phase 2). Scope of this PR is the 91 auto-fix deltas only — it unsticks the merge-train phpcs gate from getting worse.

## Why phpcbf via docker

Host runs PHP 8.2.22; `vendor/azjezz/psl@4.3.0` uses PHP 8.3 typed class constants and can't be loaded under 8.2. Running phpcbf via `docker run --rm php:8.3-cli` bypasses the host PHP altogether. CI uses 8.3 so it would have run cleanly there too.