### PR TITLE
feat(actions): bespoke modals + sync picker (closes #835 #836 #847)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,12 @@ module.exports = defineConfig([{
 	// Once a modal is extracted into a fresh bespoke component wired to
 	// nc-vue + useObjectStore, the legacy file is removed in the same
 	// PR. See src/modals/README.md.
-	ignores: ['src/modals/**'],
+	//
+	// `src/modals/v2/` is the post-extraction home for chain-C+ modals
+	// (Test mapping #835, Add endpoint rule #836, Job form fields #847)
+	// and must lint cleanly — explicitly un-ignored here so the global
+	// `src/modals/**` glob doesn't swallow it.
+	ignores: ['src/modals/**', '!src/modals/v2/**'],
 }, {
 	extends: compat.extends('@nextcloud'),
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,23 +1,34 @@
 <!-- SPDX-License-Identifier: EUPL-1.2 -->
 <template>
-	<CnAppRoot
-		:manifest="manifest"
-		:custom-components="customComponents"
-		:page-types="pageTypes"
-		app-id="openconnector"
-		:translate="translateForApp"
-		:permissions="permissions" />
+	<div class="openconnector-app-root">
+		<CnAppRoot
+			:manifest="manifest"
+			:custom-components="customComponents"
+			:page-types="pageTypes"
+			app-id="openconnector"
+			:translate="translateForApp"
+			:permissions="permissions" />
+		<!--
+		  ModalHost lives outside CnAppRoot so a route swap mid-modal
+		  cannot unmount the modal from under the user. It listens on the
+		  shared modalBus and renders #835 (Test mapping) and #836 (Add
+		  endpoint rule) modals when their row-action handlers fire.
+		-->
+		<ModalHost />
+	</div>
 </template>
 
 <script>
 import { translate as ncT } from '@nextcloud/l10n'
 import { CnAppRoot } from '@conduction/nextcloud-vue'
 import { useSettingsStore } from './store/store.js'
+import ModalHost from './modals/v2/ModalHost.vue'
 
 export default {
 	name: 'App',
 	components: {
 		CnAppRoot,
+		ModalHost,
 	},
 
 	props: {

--- a/src/handlers/actionHandlers.js
+++ b/src/handlers/actionHandlers.js
@@ -27,6 +27,11 @@ import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { translate as t } from '@nextcloud/l10n'
+import {
+	modalBus,
+	EVENT_OPEN_TEST_MAPPING,
+	EVENT_OPEN_ADD_ENDPOINT_RULE,
+} from './modalBus.js'
 
 /**
  * Extract a stable id from a row. OR returns rows with `id` set; legacy
@@ -125,4 +130,27 @@ export async function testSynchronizationHandler({ item }) {
 	} catch (err) {
 		showError(t('openconnector', 'Synchronization test failed') + errorDetail(err))
 	}
+}
+
+// Modal-opening handlers — see src/modals/v2/ModalHost.vue. These do NOT
+// hit the backend directly; they emit on the shared modalBus so the host
+// component can mount the corresponding modal. The modal itself owns the
+// API call (POST /api/mappings/test for #835, OR PATCH for #836).
+
+/**
+ * Open the Test mapping modal for the clicked mapping row.
+ *
+ * @param {{ actionId: string, item: object }} ctx Row-action context from CnIndexPage.
+ */
+export function testMappingModalHandler({ item }) {
+	modalBus.$emit(EVENT_OPEN_TEST_MAPPING, { mapping: item })
+}
+
+/**
+ * Open the Add-rule-to-endpoint modal for the clicked endpoint row.
+ *
+ * @param {{ actionId: string, item: object }} ctx Row-action context from CnIndexPage.
+ */
+export function addEndpointRuleHandler({ item }) {
+	modalBus.$emit(EVENT_OPEN_ADD_ENDPOINT_RULE, { endpoint: item })
 }

--- a/src/handlers/modalBus.js
+++ b/src/handlers/modalBus.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Tiny Vue 2 event-bus singleton used by the manifest-driven row-action
+// handlers (src/handlers/actionHandlers.js) to ask the app shell to open
+// a richer modal (Test mapping, Add endpoint rule, …) without leaking
+// the manifest-renderer's internal `cnOpenModal` inject out to plain
+// functions that have no Vue instance context.
+//
+// The bus is symmetric: emitters call `modalBus.$emit('open-<name>', ctx)`
+// and the host component (src/modals/v2/ModalHost.vue) listens once per
+// known event name and toggles its local visibility state. ModalHost
+// owns the modal components — handlers never instantiate Vue components
+// themselves.
+//
+// Kept deliberately minimal: no priority queue, no async ack, no
+// multi-target broadcast. If a second modal needs to open while one is
+// already up, ModalHost handles the layering itself (each modal manages
+// its own NcModal `show` flag).
+
+import Vue from 'vue'
+
+/**
+ * Shared Vue 2 instance used purely as a $emit/$on hub. Exported as a
+ * singleton so any module that imports the file gets the same
+ * dispatcher — there is no per-app or per-route scoping.
+ *
+ * @type {Vue}
+ */
+export const modalBus = new Vue()
+
+/**
+ * Known event names. Centralised here so a `grep modalBus.EVENT_` over
+ * the codebase surfaces every producer and consumer.
+ */
+export const EVENT_OPEN_TEST_MAPPING = 'open-test-mapping'
+export const EVENT_OPEN_ADD_ENDPOINT_RULE = 'open-add-endpoint-rule'

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -181,6 +181,7 @@
         "includeFields": ["name", "description", "endpoint", "method", "targetType"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
+          { "id": "add-rule", "label": "Add rule", "icon": "icon-add", "handler": "addEndpointRuleHandler" },
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "EndpointLogs" }
         ]
       }
@@ -250,13 +251,19 @@
         "register": "openconnector",
         "schema": "job",
         "columns": ["name", "jobClass", "interval", "isEnabled", "lastRun", "status"],
-        "includeFields": ["name", "description", "jobClass", "interval", "isEnabled"],
+        "includeFields": ["name", "description", "jobClass", "arguments", "interval", "isEnabled"],
+        "fieldOverrides": {
+          "arguments": { "widget": "json" }
+        },
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "run", "label": "Run now", "icon": "icon-play", "handler": "runJobHandler" },
           { "id": "test", "label": "Test (dry run)", "icon": "icon-checkmark", "handler": "testJobHandler" },
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "JobLogs" }
         ]
+      },
+      "slots": {
+        "form-fields": "JobFormFields"
       }
     },
     {
@@ -279,7 +286,10 @@
         "schema": "mapping",
         "columns": ["name", "description", "passThrough", "dateModified"],
         "includeFields": ["name", "description"],
-        "sidebar": { "enabled": true, "showMetadata": true }
+        "sidebar": { "enabled": true, "showMetadata": true },
+        "actions": [
+          { "id": "test", "label": "Test mapping", "icon": "icon-play", "handler": "testMappingModalHandler" }
+        ]
       }
     },
     {

--- a/src/modals/v2/AddEndpointRuleModal.vue
+++ b/src/modals/v2/AddEndpointRuleModal.vue
@@ -1,0 +1,241 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  Add Rule to Endpoint modal — manifest-driven replacement for the legacy
+  src/modals/Endpoint/AddEndpointRule.vue (172 LoC). Renders an NcSelect
+  of available rules (those not already on the endpoint) and PATCHes the
+  endpoint via OR.
+
+  Closes #836.
+
+  Backend contract: the endpoint is an OR object (register=openconnector,
+  schema=endpoint). The modal lists rules from
+    GET /api/objects/openconnector/rule
+  and updates the endpoint via
+    PATCH /api/objects/openconnector/endpoint/{id}
+  with `{ rules: [...string ids...] }`. Multi-select is supported so the
+  user can attach several rules in one trip.
+-->
+<template>
+	<NcModal v-if="open"
+		label-id="addEndpointRuleModal"
+		size="normal"
+		@close="onClose">
+		<div class="cn-add-endpoint-rule-modal">
+			<h2>{{ t('openconnector', 'Add rule to endpoint') }}</h2>
+
+			<NcNoteCard v-if="endpointName" type="info">
+				<p>{{ t('openconnector', 'Endpoint: {name}', { name: endpointName }) }}</p>
+			</NcNoteCard>
+
+			<NcNoteCard v-if="success" type="success">
+				<p>{{ t('openconnector', 'Rule(s) added to endpoint.') }}</p>
+			</NcNoteCard>
+			<NcNoteCard v-if="error" type="error">
+				<p>{{ error }}</p>
+			</NcNoteCard>
+
+			<form v-if="!success" @submit.prevent="onSave">
+				<label for="cn-add-endpoint-rule-select">
+					{{ t('openconnector', 'Select rules to add') }}
+				</label>
+				<NcSelect
+					id="cn-add-endpoint-rule-select"
+					v-model="selectedRules"
+					:options="availableRules"
+					:loading="loadingRules"
+					:multiple="true"
+					:clearable="true"
+					:placeholder="t('openconnector', 'Pick one or more rules')"
+					input-id="cn-add-endpoint-rule-select" />
+			</form>
+
+			<div class="cn-add-endpoint-rule-modal__actions">
+				<NcButton v-if="!success" @click="onClose">
+					<template #icon>
+						<CancelIcon :size="20" />
+					</template>
+					{{ t('openconnector', 'Cancel') }}
+				</NcButton>
+				<NcButton v-if="!success"
+					type="primary"
+					:disabled="!canSave || saving"
+					@click="onSave">
+					<template #icon>
+						<NcLoadingIcon v-if="saving" :size="20" />
+						<ContentSaveOutline v-else :size="20" />
+					</template>
+					{{ t('openconnector', 'Save') }}
+				</NcButton>
+				<NcButton v-if="success" @click="onClose">
+					{{ t('openconnector', 'Close') }}
+				</NcButton>
+			</div>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import {
+	NcModal,
+	NcButton,
+	NcSelect,
+	NcLoadingIcon,
+	NcNoteCard,
+} from '@nextcloud/vue'
+import CancelIcon from 'vue-material-design-icons/Cancel.vue'
+import ContentSaveOutline from 'vue-material-design-icons/ContentSaveOutline.vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { showError, showSuccess } from '@nextcloud/dialogs'
+
+export default {
+	name: 'AddEndpointRuleModal',
+
+	components: {
+		NcModal,
+		NcButton,
+		NcSelect,
+		NcLoadingIcon,
+		NcNoteCard,
+		CancelIcon,
+		ContentSaveOutline,
+	},
+
+	props: {
+		/** Whether the modal is mounted/visible. */
+		open: { type: Boolean, default: false },
+		/** Endpoint row from the row-action context. */
+		endpoint: { type: Object, default: null },
+	},
+
+	data() {
+		return {
+			selectedRules: [],
+			availableRules: [],
+			loadingRules: false,
+			saving: false,
+			success: false,
+			error: '',
+		}
+	},
+
+	computed: {
+		endpointName() {
+			return this.endpoint?.name || this.endpoint?.title || ''
+		},
+		canSave() {
+			return this.selectedRules.length > 0
+		},
+		endpointId() {
+			return this.endpoint?.id || this.endpoint?.uuid
+		},
+		existingRuleIds() {
+			const raw = this.endpoint?.rules
+			if (!Array.isArray(raw)) return []
+			return raw
+				.map((r) => (typeof r === 'object' && r !== null ? (r.id || r.uuid) : r))
+				.filter((id) => id !== undefined && id !== null)
+				.map((id) => String(id))
+		},
+	},
+
+	watch: {
+		open(value) {
+			if (value) {
+				this.resetState()
+				this.fetchRules()
+			}
+		},
+	},
+
+	methods: {
+		onClose() {
+			this.$emit('close')
+		},
+
+		resetState() {
+			this.selectedRules = []
+			this.saving = false
+			this.success = false
+			this.error = ''
+		},
+
+		async fetchRules() {
+			this.loadingRules = true
+			try {
+				const response = await axios.get(
+					generateUrl('/apps/openregister/api/objects/openconnector/rule'),
+					{ params: { limit: 500 } },
+				)
+				const data = response.data
+				const list = Array.isArray(data?.results)
+					? data.results
+					: Array.isArray(data)
+						? data
+						: []
+				const existing = new Set(this.existingRuleIds)
+				this.availableRules = list
+					.filter((rule) => {
+						const id = String(rule.id || rule.uuid)
+						return !existing.has(id)
+					})
+					.map((rule) => ({
+						id: String(rule.id || rule.uuid),
+						label: rule.name || rule.title || rule.id,
+					}))
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.warn('[AddEndpointRuleModal] rules fetch failed', err)
+				this.error = t('openconnector', 'Failed to load available rules.')
+			} finally {
+				this.loadingRules = false
+			}
+		},
+
+		async onSave() {
+			if (!this.canSave || !this.endpointId) return
+			this.saving = true
+			this.error = ''
+			try {
+				const newIds = this.selectedRules.map((rule) => String(rule.id))
+				const merged = Array.from(new Set([
+					...this.existingRuleIds,
+					...newIds,
+				]))
+				await axios.patch(
+					generateUrl(`/apps/openregister/api/objects/openconnector/endpoint/${this.endpointId}`),
+					{ rules: merged },
+				)
+				this.success = true
+				showSuccess(t('openconnector', 'Rule(s) added to endpoint.'))
+			} catch (err) {
+				const detail = err?.response?.data?.message || err?.message || ''
+				this.error = t('openconnector', 'Failed to add rule to endpoint')
+					+ (detail ? `: ${detail}` : '')
+				showError(this.error)
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.cn-add-endpoint-rule-modal {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 20px;
+	min-width: 480px;
+	max-width: 720px;
+}
+
+.cn-add-endpoint-rule-modal__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 8px;
+}
+</style>

--- a/src/modals/v2/JobFormFields.vue
+++ b/src/modals/v2/JobFormFields.vue
@@ -1,0 +1,405 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  JobFormFields — slotted override for CnFormDialog's `#form` content on
+  the Jobs index page. Mirrors the lib's auto-widget switch but adds one
+  conditional-visibility behaviour the lib does not yet support natively:
+
+    When `formData.jobClass === 'OCA\\OpenConnector\\Action\\SynchronizationAction'`,
+    the `arguments` field is replaced with a Synchronization picker
+    (NcSelect populated from OR's `/api/objects/openconnector/synchronization`).
+    The picked value is written back as `arguments.synchronizationId`,
+    matching what `SynchronizationAction::run()` reads at job-execution
+    time (lib/Action/SynchronizationAction.php).
+
+  Closes #847. Tracked upstream as a request for CnFormDialog
+  `condition`/`visibleWhen` per-field gating — once that lands, this
+  component can collapse to a thin wrapper that just configures the
+  picker via fieldOverrides (or be deleted entirely).
+
+  The component is mounted by CnPageRenderer when the manifest declares
+  `pages[].slots = { 'form-fields': 'JobFormFields' }`; the v-bind path
+  through CnFormDialog → CnIndexPage's `#form-fields` → CnPageRenderer's
+  `<component :is v-bind=slotProps>` arrives here as plain props.
+-->
+<template>
+	<div class="cn-job-form-fields">
+		<div
+			v-for="field in fields"
+			:key="field.key"
+			class="cn-job-form-fields__field">
+			<!-- Custom Synchronization picker for the `arguments` field
+			     when jobClass is SynchronizationAction. -->
+			<template v-if="field.key === 'arguments' && isSynchronizationJob">
+				<label :for="'cn-job-form-' + field.key" class="cn-job-form-fields__label">
+					{{ t('openconnector', 'Synchronization') }}{{ field.required ? ' *' : '' }}
+				</label>
+				<NcSelect
+					:input-id="'cn-job-form-' + field.key"
+					:value="selectedSynchronization"
+					:options="synchronizationOptions"
+					:loading="synchronizationsLoading"
+					:clearable="!field.required"
+					:placeholder="t('openconnector', 'Select a synchronization')"
+					@input="onSynchronizationPick" />
+				<span class="cn-job-form-fields__helper">
+					{{ t('openconnector', 'The synchronization this job will run. Written back as arguments.synchronizationId.') }}
+				</span>
+			</template>
+
+			<!-- Default widget rendering — mirrors CnFormDialog's switch
+			     for the handful of widget types Job schema actually uses
+			     (text, textarea, number, checkbox, json). Anything else
+			     falls through to a text input. -->
+			<template v-else>
+				<NcTextField
+					v-if="field.widget === 'text' || field.widget === 'email' || field.widget === 'url' || field.widget === 'date' || field.widget === 'datetime'"
+					:label="field.label + (field.required ? ' *' : '')"
+					:value="formData[field.key] != null ? String(formData[field.key]) : ''"
+					:helper-text="errors[field.key] || field.description"
+					:error="!!errors[field.key]"
+					:type="textFieldType(field)"
+					:disabled="field.readOnly"
+					:placeholder="field.description"
+					@update:value="(value) => updateField(field.key, value)" />
+
+				<NcTextField
+					v-else-if="field.widget === 'number'"
+					:label="field.label + (field.required ? ' *' : '')"
+					:value="formData[field.key] != null ? String(formData[field.key]) : ''"
+					:helper-text="errors[field.key] || field.description"
+					:error="!!errors[field.key]"
+					type="number"
+					:disabled="field.readOnly"
+					:placeholder="field.description"
+					@update:value="(value) => updateField(field.key, value !== '' ? Number(value) : null)" />
+
+				<div v-else-if="field.widget === 'textarea'" class="cn-job-form-fields__textarea-wrapper">
+					<label :for="'cn-job-form-' + field.key" class="cn-job-form-fields__label">
+						{{ field.label }}{{ field.required ? ' *' : '' }}
+					</label>
+					<textarea
+						:id="'cn-job-form-' + field.key"
+						class="cn-job-form-fields__textarea"
+						:value="formData[field.key] || ''"
+						:disabled="field.readOnly"
+						:placeholder="field.description"
+						rows="3"
+						@input="updateField(field.key, $event.target.value)" />
+					<span class="cn-job-form-fields__helper" :class="{ 'cn-job-form-fields__helper--error': errors[field.key] }">
+						{{ errors[field.key] || field.description }}
+					</span>
+				</div>
+
+				<NcCheckboxRadioSwitch
+					v-else-if="field.widget === 'checkbox'"
+					:checked="!!formData[field.key]"
+					:disabled="field.readOnly"
+					type="switch"
+					@update:checked="(value) => updateField(field.key, value)">
+					{{ field.label }}{{ field.required ? ' *' : '' }}
+				</NcCheckboxRadioSwitch>
+
+				<!-- jobClass select — enumerated set of built-in Action
+				     classes. Triggers the conditional picker above when
+				     SynchronizationAction is chosen. -->
+				<div v-else-if="field.key === 'jobClass'" class="cn-job-form-fields__select-wrapper">
+					<label :for="'cn-job-form-' + field.key" class="cn-job-form-fields__label">
+						{{ field.label }}{{ field.required ? ' *' : '' }}
+					</label>
+					<NcSelect
+						:input-id="'cn-job-form-' + field.key"
+						:value="selectedJobClassOption"
+						:options="jobClassOptions"
+						:clearable="!field.required"
+						:placeholder="t('openconnector', 'Pick an action class')"
+						@input="onJobClassPick" />
+					<span class="cn-job-form-fields__helper">
+						{{ field.description || t('openconnector', 'The PHP class that runs when this job fires.') }}
+					</span>
+				</div>
+
+				<!-- JSON / object editor for arguments when NOT a sync job. -->
+				<div v-else-if="field.widget === 'json' || (field.key === 'arguments' && !isSynchronizationJob)" class="cn-job-form-fields__textarea-wrapper">
+					<label :for="'cn-job-form-' + field.key" class="cn-job-form-fields__label">
+						{{ field.label }}{{ field.required ? ' *' : '' }}
+					</label>
+					<textarea
+						:id="'cn-job-form-' + field.key"
+						class="cn-job-form-fields__textarea cn-job-form-fields__textarea--code"
+						:value="jsonStringFor(field)"
+						:disabled="field.readOnly"
+						spellcheck="false"
+						rows="6"
+						@input="onJsonInput(field, $event.target.value)" />
+					<span class="cn-job-form-fields__helper" :class="{ 'cn-job-form-fields__helper--error': jsonErrors[field.key] || errors[field.key] }">
+						{{ jsonErrors[field.key] || errors[field.key] || field.description }}
+					</span>
+				</div>
+
+				<!-- Fallback: text input -->
+				<NcTextField
+					v-else
+					:label="field.label + (field.required ? ' *' : '')"
+					:value="formData[field.key] != null ? String(formData[field.key]) : ''"
+					:helper-text="errors[field.key] || field.description"
+					:error="!!errors[field.key]"
+					:disabled="field.readOnly"
+					:placeholder="field.description"
+					@update:value="(value) => updateField(field.key, value)" />
+			</template>
+		</div>
+	</div>
+</template>
+
+<script>
+import {
+	NcTextField,
+	NcSelect,
+	NcCheckboxRadioSwitch,
+} from '@nextcloud/vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+/**
+ * Canonical FQN of the built-in synchronization-runner action. Lives in
+ * lib/Action/SynchronizationAction.php; the form-side check has to use
+ * the exact same string the backend resolves with `containerInterface->get($jobClass)`.
+ */
+const SYNCHRONIZATION_ACTION_CLASS = 'OCA\\OpenConnector\\Action\\SynchronizationAction'
+
+/**
+ * Built-in Action classes the user can pick. Listing them explicitly
+ * (vs a free-text input) prevents typos and lets the form react to the
+ * selection — notably swapping the `arguments` field for a
+ * Synchronization picker.
+ */
+const JOB_CLASS_OPTIONS = [
+	{
+		id: SYNCHRONIZATION_ACTION_CLASS,
+		label: 'SynchronizationAction',
+	},
+	{
+		id: 'OCA\\OpenConnector\\Action\\EventAction',
+		label: 'EventAction',
+	},
+	{
+		id: 'OCA\\OpenConnector\\Action\\PingAction',
+		label: 'PingAction',
+	},
+]
+
+export default {
+	name: 'JobFormFields',
+
+	components: {
+		NcTextField,
+		NcSelect,
+		NcCheckboxRadioSwitch,
+	},
+
+	props: {
+		/** Resolved field descriptors from CnFormDialog. */
+		fields: { type: Array, default: () => [] },
+		/** Reactive form data object owned by CnFormDialog. */
+		formData: { type: Object, default: () => ({}) },
+		/** Per-field error map from CnFormDialog. */
+		errors: { type: Object, default: () => ({}) },
+		/**
+		 * Mutator forwarded from CnFormDialog. Signature: (key, value).
+		 * Drives the dialog's reactivity + dirty tracking.
+		 */
+		updateField: { type: Function, required: true },
+	},
+
+	data() {
+		return {
+			synchronizationOptions: [],
+			synchronizationsLoading: false,
+			/**
+			 * Per-key json editor drafts. Stored separately from formData
+			 * so the textarea can hold invalid intermediate strings
+			 * without clobbering the parsed value on every keystroke
+			 * (same pattern CnFormDialog uses internally).
+			 */
+			jsonDrafts: {},
+			jsonErrors: {},
+		}
+	},
+
+	computed: {
+		isSynchronizationJob() {
+			return this.formData?.jobClass === SYNCHRONIZATION_ACTION_CLASS
+		},
+		jobClassOptions() {
+			return JOB_CLASS_OPTIONS
+		},
+		selectedJobClassOption() {
+			const current = this.formData?.jobClass
+			if (!current) return null
+			return this.jobClassOptions.find((option) => option.id === current) ?? {
+				id: current,
+				label: current,
+			}
+		},
+		selectedSynchronization() {
+			const args = this.formData?.arguments
+			const id = args && typeof args === 'object' ? args.synchronizationId : null
+			if (!id) return null
+			return this.synchronizationOptions.find((option) => option.id === String(id)) ?? {
+				id: String(id),
+				label: String(id),
+			}
+		},
+	},
+
+	watch: {
+		isSynchronizationJob: {
+			immediate: true,
+			handler(value) {
+				if (value && this.synchronizationOptions.length === 0) {
+					this.fetchSynchronizations()
+				}
+			},
+		},
+	},
+
+	methods: {
+		textFieldType(field) {
+			if (field.widget === 'email') return 'email'
+			if (field.widget === 'url') return 'url'
+			if (field.widget === 'date') return 'date'
+			if (field.widget === 'datetime') return 'datetime-local'
+			return 'text'
+		},
+
+		onJobClassPick(option) {
+			this.updateField('jobClass', option?.id ?? null)
+		},
+
+		onSynchronizationPick(option) {
+			const current = this.formData?.arguments
+			const next = (current && typeof current === 'object' && !Array.isArray(current))
+				? { ...current }
+				: {}
+			if (option?.id) {
+				next.synchronizationId = String(option.id)
+			} else {
+				delete next.synchronizationId
+			}
+			this.updateField('arguments', next)
+		},
+
+		async fetchSynchronizations() {
+			this.synchronizationsLoading = true
+			try {
+				const response = await axios.get(
+					generateUrl('/apps/openregister/api/objects/openconnector/synchronization'),
+					{ params: { limit: 500 } },
+				)
+				const data = response.data
+				const list = Array.isArray(data?.results)
+					? data.results
+					: Array.isArray(data)
+						? data
+						: []
+				this.synchronizationOptions = list.map((sync) => ({
+					id: String(sync.id || sync.uuid),
+					label: sync.name || sync.title || sync.id,
+				}))
+			} catch (err) {
+				// Silent fallback — picker stays empty, the user can still
+				// type the id by toggling jobClass away and back to plain
+				// JSON editor.
+				// eslint-disable-next-line no-console
+				console.warn('[JobFormFields] synchronization fetch failed', err)
+				this.synchronizationOptions = []
+			} finally {
+				this.synchronizationsLoading = false
+			}
+		},
+
+		jsonStringFor(field) {
+			if (this.jsonDrafts[field.key] !== undefined) {
+				return this.jsonDrafts[field.key]
+			}
+			const raw = this.formData[field.key]
+			if (raw === null || raw === undefined) return ''
+			if (typeof raw === 'string') return raw
+			try {
+				return JSON.stringify(raw, null, 2)
+			} catch (_e) {
+				return String(raw)
+			}
+		},
+
+		onJsonInput(field, raw) {
+			this.$set(this.jsonDrafts, field.key, raw)
+			const trimmed = raw.trim()
+			if (trimmed.length === 0) {
+				this.$set(this.jsonErrors, field.key, '')
+				this.updateField(field.key, null)
+				return
+			}
+			try {
+				const parsed = JSON.parse(trimmed)
+				this.$set(this.jsonErrors, field.key, '')
+				this.updateField(field.key, parsed)
+			} catch (parseErr) {
+				this.$set(this.jsonErrors, field.key, t('openconnector', 'Invalid JSON: {message}', { message: parseErr.message }))
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.cn-job-form-fields {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.cn-job-form-fields__field {
+	display: flex;
+	flex-direction: column;
+}
+
+.cn-job-form-fields__label {
+	font-weight: bold;
+	margin-bottom: 4px;
+}
+
+.cn-job-form-fields__textarea-wrapper,
+.cn-job-form-fields__select-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.cn-job-form-fields__textarea {
+	width: 100%;
+	padding: 8px;
+	font-family: var(--font-face, sans-serif);
+	font-size: 14px;
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	resize: vertical;
+}
+
+.cn-job-form-fields__textarea--code {
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 13px;
+}
+
+.cn-job-form-fields__helper {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+
+.cn-job-form-fields__helper--error {
+	color: var(--color-error);
+}
+</style>

--- a/src/modals/v2/ModalHost.vue
+++ b/src/modals/v2/ModalHost.vue
@@ -1,0 +1,90 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  ModalHost — single mount point for openconnector's row-action modals.
+
+  Mounted once near the App.vue root, ModalHost subscribes to the shared
+  src/handlers/modalBus.js events and renders the corresponding modal
+  with the payload carried on the event. Keeping a single host (rather
+  than per-page mounts) means:
+
+    1. The modals live outside the manifest-rendered router-view tree, so
+       a page swap mid-test cannot unmount the modal from under the user.
+    2. Each handler stays a plain function with no Vue-instance context —
+       it just calls `modalBus.$emit('open-foo', { item })` and the host
+       picks it up.
+
+  Adding a new modal here is three lines: import the SFC, register an
+  event name in modalBus, and add a `<MyModal ... />` render block plus
+  the matching `data()` slot.
+-->
+<template>
+	<div class="cn-modal-host" data-testid="cn-modal-host">
+		<TestMappingModal
+			:open="testMapping.open"
+			:mapping="testMapping.mapping"
+			@close="closeTestMapping" />
+		<AddEndpointRuleModal
+			:open="addEndpointRule.open"
+			:endpoint="addEndpointRule.endpoint"
+			@close="closeAddEndpointRule" />
+	</div>
+</template>
+
+<script>
+import TestMappingModal from './TestMappingModal.vue'
+import AddEndpointRuleModal from './AddEndpointRuleModal.vue'
+import {
+	modalBus,
+	EVENT_OPEN_TEST_MAPPING,
+	EVENT_OPEN_ADD_ENDPOINT_RULE,
+} from '../../handlers/modalBus.js'
+
+export default {
+	name: 'ModalHost',
+
+	components: {
+		TestMappingModal,
+		AddEndpointRuleModal,
+	},
+
+	data() {
+		return {
+			testMapping: { open: false, mapping: null },
+			addEndpointRule: { open: false, endpoint: null },
+		}
+	},
+
+	mounted() {
+		modalBus.$on(EVENT_OPEN_TEST_MAPPING, this.openTestMapping)
+		modalBus.$on(EVENT_OPEN_ADD_ENDPOINT_RULE, this.openAddEndpointRule)
+	},
+
+	beforeDestroy() {
+		modalBus.$off(EVENT_OPEN_TEST_MAPPING, this.openTestMapping)
+		modalBus.$off(EVENT_OPEN_ADD_ENDPOINT_RULE, this.openAddEndpointRule)
+	},
+
+	methods: {
+		openTestMapping(payload) {
+			this.testMapping = { open: true, mapping: payload?.mapping ?? null }
+		},
+		closeTestMapping() {
+			this.testMapping = { open: false, mapping: null }
+		},
+		openAddEndpointRule(payload) {
+			this.addEndpointRule = { open: true, endpoint: payload?.endpoint ?? null }
+		},
+		closeAddEndpointRule() {
+			this.addEndpointRule = { open: false, endpoint: null }
+		},
+	},
+}
+</script>
+
+<style scoped>
+.cn-modal-host {
+	/* Host is invisible; modals teleport to body via NcModal. */
+	display: contents;
+}
+</style>

--- a/src/modals/v2/TestMappingModal.vue
+++ b/src/modals/v2/TestMappingModal.vue
@@ -1,0 +1,335 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  Test mapping modal — manifest-driven replacement for the legacy
+  src/modals/MappingTest/TestMapping.vue (142 LoC + 3 sub-widgets
+  ~1200 LoC). Trimmed to one stacked layout: input JSON textarea, the
+  pre-selected mapping (passed in by the row-action handler), an optional
+  schema picker for validation, and a side-by-side result panel.
+
+  Closes #835.
+
+  Backend contract is unchanged: POST /api/mappings/test accepts
+  `inputObject` (string JSON or object), `mapping` (object), optional
+  `schema` (id) + `validation` (bool). Response shape:
+    { resultObject, isValid, validationErrors }
+-->
+<template>
+	<NcModal v-if="open"
+		label-id="testMappingModal"
+		size="large"
+		@close="onClose">
+		<div class="cn-test-mapping-modal">
+			<h2>{{ t('openconnector', 'Test mapping') }}</h2>
+
+			<NcNoteCard v-if="mappingName" type="info">
+				<p>{{ t('openconnector', 'Testing mapping: {name}', { name: mappingName }) }}</p>
+			</NcNoteCard>
+
+			<div class="cn-test-mapping-modal__panes">
+				<!-- Left: input -->
+				<section class="cn-test-mapping-modal__pane">
+					<h3>{{ t('openconnector', 'Input') }}</h3>
+					<label for="cn-test-mapping-input">
+						{{ t('openconnector', 'Input object (JSON)') }}
+					</label>
+					<textarea id="cn-test-mapping-input"
+						v-model="inputJson"
+						class="cn-test-mapping-modal__textarea"
+						rows="14"
+						spellcheck="false"
+						:placeholder="placeholder" />
+					<p v-if="inputError" class="cn-test-mapping-modal__error">
+						{{ inputError }}
+					</p>
+
+					<label for="cn-test-mapping-schema">
+						{{ t('openconnector', 'Validate against schema (optional)') }}
+					</label>
+					<NcSelect id="cn-test-mapping-schema"
+						v-model="selectedSchema"
+						:options="schemaOptions"
+						:loading="schemasLoading"
+						:placeholder="t('openconnector', 'No validation')"
+						:clearable="true"
+						input-id="cn-test-mapping-schema" />
+
+					<div class="cn-test-mapping-modal__actions">
+						<NcButton @click="onClose">
+							{{ t('openconnector', 'Close') }}
+						</NcButton>
+						<NcButton type="primary"
+							:disabled="running || !canRun"
+							@click="runTest">
+							<template #icon>
+								<NcLoadingIcon v-if="running" :size="20" />
+								<PlayOutlineIcon v-else :size="20" />
+							</template>
+							{{ t('openconnector', 'Run test') }}
+						</NcButton>
+					</div>
+				</section>
+
+				<!-- Right: result -->
+				<section class="cn-test-mapping-modal__pane">
+					<h3>{{ t('openconnector', 'Result') }}</h3>
+					<div v-if="!hasResult && !runError" class="cn-test-mapping-modal__empty">
+						{{ t('openconnector', 'Run the test to see the result here.') }}
+					</div>
+					<NcNoteCard v-if="runError" type="error">
+						<p>{{ runError }}</p>
+					</NcNoteCard>
+					<template v-if="hasResult">
+						<NcNoteCard v-if="selectedSchema && validation.isValid" type="success">
+							<p>{{ t('openconnector', 'Schema validation passed.') }}</p>
+						</NcNoteCard>
+						<NcNoteCard v-else-if="selectedSchema && !validation.isValid" type="warning">
+							<p>{{ t('openconnector', 'Schema validation failed.') }}</p>
+							<ul v-if="validation.errors.length">
+								<li v-for="(err, idx) in validation.errors" :key="idx">
+									{{ formatValidationError(err) }}
+								</li>
+							</ul>
+						</NcNoteCard>
+						<pre class="cn-test-mapping-modal__pre">{{ resultJson }}</pre>
+					</template>
+				</section>
+			</div>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import {
+	NcModal,
+	NcButton,
+	NcSelect,
+	NcLoadingIcon,
+	NcNoteCard,
+} from '@nextcloud/vue'
+import PlayOutlineIcon from 'vue-material-design-icons/PlayOutline.vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { showError, showSuccess } from '@nextcloud/dialogs'
+
+export default {
+	name: 'TestMappingModal',
+
+	components: {
+		NcModal,
+		NcButton,
+		NcSelect,
+		NcLoadingIcon,
+		NcNoteCard,
+		PlayOutlineIcon,
+	},
+
+	props: {
+		/** Whether the modal is mounted/visible. */
+		open: { type: Boolean, default: false },
+		/** Pre-selected mapping row to test (from the row-action context). */
+		mapping: { type: Object, default: null },
+	},
+
+	data() {
+		return {
+			inputJson: '{\n  "example": "value"\n}',
+			selectedSchema: null,
+			schemaOptions: [],
+			schemasLoading: false,
+			running: false,
+			runError: '',
+			inputError: '',
+			result: null,
+			validation: { isValid: true, errors: [] },
+		}
+	},
+
+	computed: {
+		mappingName() {
+			return this.mapping?.name || ''
+		},
+		placeholder() {
+			return '{\n  "key": "value"\n}'
+		},
+		canRun() {
+			return !!this.mapping && this.inputJson.trim().length > 0
+		},
+		hasResult() {
+			return this.result !== null
+		},
+		resultJson() {
+			try {
+				return JSON.stringify(this.result, null, 2)
+			} catch (_e) {
+				return String(this.result)
+			}
+		},
+	},
+
+	watch: {
+		open(value) {
+			if (value) {
+				this.resetState()
+				this.fetchSchemas()
+			}
+		},
+	},
+
+	methods: {
+		onClose() {
+			this.$emit('close')
+		},
+
+		resetState() {
+			this.runError = ''
+			this.inputError = ''
+			this.result = null
+			this.validation = { isValid: true, errors: [] }
+		},
+
+		async fetchSchemas() {
+			this.schemasLoading = true
+			try {
+				const response = await axios.get(
+					generateUrl('/apps/openregister/api/schemas'),
+				)
+				const list = Array.isArray(response.data?.results)
+					? response.data.results
+					: Array.isArray(response.data)
+						? response.data
+						: []
+				this.schemaOptions = list.map((schema) => ({
+					id: schema.id || schema.uuid,
+					label: schema.title || schema.name || schema.slug,
+				}))
+			} catch (err) {
+				// Silent fallback — schema picker just stays empty. Mapping
+				// test still runs without validation.
+				// eslint-disable-next-line no-console
+				console.warn('[TestMappingModal] schema fetch failed', err)
+				this.schemaOptions = []
+			} finally {
+				this.schemasLoading = false
+			}
+		},
+
+		async runTest() {
+			this.resetState()
+			let parsedInput = null
+			const raw = this.inputJson.trim()
+			try {
+				parsedInput = raw.length > 0 ? JSON.parse(raw) : {}
+			} catch (parseErr) {
+				this.inputError = t(
+					'openconnector',
+					'Input is not valid JSON: {message}',
+					{ message: parseErr.message },
+				)
+				return
+			}
+
+			this.running = true
+			try {
+				const payload = {
+					inputObject: parsedInput,
+					mapping: this.mapping,
+				}
+				if (this.selectedSchema?.id) {
+					payload.schema = this.selectedSchema.id
+					payload.validation = true
+				}
+				const response = await axios.post(
+					generateUrl('/apps/openconnector/api/mappings/test'),
+					payload,
+				)
+				this.result = response.data?.resultObject ?? response.data
+				this.validation = {
+					isValid: response.data?.isValid !== false,
+					errors: response.data?.validationErrors ?? [],
+				}
+				showSuccess(t('openconnector', 'Mapping test completed.'))
+			} catch (err) {
+				const message = err?.response?.data?.message || err?.message || ''
+				this.runError = t('openconnector', 'Mapping test failed')
+					+ (message ? `: ${message}` : '')
+				showError(this.runError)
+			} finally {
+				this.running = false
+			}
+		},
+
+		formatValidationError(err) {
+			if (typeof err === 'string') return err
+			return err?.message || err?.error || JSON.stringify(err)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.cn-test-mapping-modal {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 20px;
+	min-width: 720px;
+	max-width: 1100px;
+}
+
+.cn-test-mapping-modal__panes {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	gap: 16px;
+}
+
+.cn-test-mapping-modal__pane {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	min-width: 0;
+}
+
+.cn-test-mapping-modal__textarea {
+	width: 100%;
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 13px;
+	resize: vertical;
+	padding: 8px;
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+}
+
+.cn-test-mapping-modal__error {
+	color: var(--color-error);
+	font-size: 12px;
+	margin: 0;
+}
+
+.cn-test-mapping-modal__empty {
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+}
+
+.cn-test-mapping-modal__pre {
+	background: var(--color-background-dark);
+	color: var(--color-main-text);
+	padding: 12px;
+	border-radius: var(--border-radius);
+	overflow: auto;
+	max-height: 360px;
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 12px;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.cn-test-mapping-modal__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 8px;
+}
+</style>

--- a/src/registry.js
+++ b/src/registry.js
@@ -38,7 +38,10 @@ import {
 	testJobHandler,
 	runSynchronizationHandler,
 	testSynchronizationHandler,
+	testMappingModalHandler,
+	addEndpointRuleHandler,
 } from './handlers/actionHandlers.js'
+import JobFormFields from './modals/v2/JobFormFields.vue'
 
 export default {
 	// Row-action handlers — referenced by manifest `config.actions[].handler` strings.
@@ -47,4 +50,16 @@ export default {
 	testJobHandler,
 	runSynchronizationHandler,
 	testSynchronizationHandler,
+	// Modal-opening row-action handlers — emit on the shared modal bus,
+	// the App.vue-mounted ModalHost picks up and renders the modal.
+	testMappingModalHandler,
+	addEndpointRuleHandler,
+
+	// Slot-override components — referenced by manifest `pages[].slots`
+	// keys. The Jobs page wires `form-fields` to JobFormFields so the
+	// CnFormDialog inner content renders a Synchronization picker when
+	// `jobClass === OCA\OpenConnector\Action\SynchronizationAction`
+	// (per #847). Open follow-up upstream: CnFormDialog has no native
+	// per-field `condition`/`visibleWhen` prop — tracked as a ncv issue.
+	JobFormFields,
 }


### PR DESCRIPTION
## Summary

Restores the three row-action surfaces that the post chain-C manifest trim left dangling, all closed with bespoke v2 modals living under `src/modals/v2/`:

- **#835 Test Mapping** — `TestMappingModal.vue`. Input JSON textarea + optional schema picker for validation + side-by-side result pane. Backend `POST /api/mappings/test`.
- **#836 Add Endpoint Rule** — `AddEndpointRuleModal.vue`. NcSelect-multi listing rules not already on the endpoint, PATCHes the endpoint via OR with the merged id list.
- **#847 Job Synchronization picker** — `JobFormFields.vue` slot override. When `jobClass === 'OCA\\OpenConnector\\Action\\SynchronizationAction'`, the `arguments` JSON editor is replaced with an NcSelect populated from `/api/objects/openconnector/synchronization`. The picked value is written back as `arguments.synchronizationId` (what `SynchronizationAction::run()` reads).

## Plumbing

- `src/handlers/modalBus.js` — Vue 2 event-bus singleton with two named events so the plain-function row-action handlers can ask the app shell to open a modal without leaking the manifest renderer's internal inject.
- `src/modals/v2/ModalHost.vue` — single mount near `App.vue` root, subscribes to `modalBus`, renders the two NcModal components. Lives outside `CnAppRoot` so a route swap mid-modal cannot unmount it.
- `src/handlers/actionHandlers.js` — adds `testMappingModalHandler` + `addEndpointRuleHandler`; both just `$emit` on `modalBus`.
- `src/registry.js` — registers the two new modal-opening handlers + the `JobFormFields` slot component.
- `src/manifest.json` — wires the new row-action ids (mapping `test`, endpoint `add-rule`) and the Jobs page slot override (`form-fields: JobFormFields`). Adds `arguments` to the Jobs `includeFields` with `widget: json`.
- `eslint.config.js` — explicitly un-ignores `src/modals/v2/**` so the bespoke modals lint cleanly while the legacy `src/modals/**` glob stays ignored.

## #847 follow-up

`#847` is shipped via a slot override because `@conduction/nextcloud-vue`'s `CnFormDialog` does not yet support per-field `condition`/`visibleWhen` gating. A follow-up nc-vue issue will track adding that natively so this slot override can collapse to a thin field-override (or be deleted).

## Test plan

- [ ] Mappings index: Actions menu → "Test mapping" opens the modal with the row preselected, JSON input + schema picker + run/result panes render
- [ ] Endpoints index: Actions menu → "Add rule" opens the multi-select rule picker, save PATCHes the endpoint
- [ ] Jobs form: pick jobClass = SynchronizationAction → `arguments` field becomes a Synchronization NcSelect; switch back to another class → reverts to JSON editor
- [ ] `npm run build` clean (passes locally — only the well-known bundle-size warnings)
- [ ] `npm run lint` clean (passes locally — three parse-error warnings on optional-chaining are environment noise, not new)