### PR TITLE
chore(deps): bump PHP requirement to ^8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
 		]
 	},
 	"require": {
-		"php": "^8.1",
+		"php": "^8.3",
 		"ext-dom": "*",
 		"ext-libxml": "*",
 		"ext-simplexml": "*",


### PR DESCRIPTION
Brings composer `require.php` from `^8.1` (or `^8.2`) to `^8.3`. Container + CI already use PHP 8.3; this just tightens the formal constraint. Part of the fleet-wide PHP 8.3 sweep.