### PR TITLE
fix(sync): migrate updateTargetOpenRegister delete to scoped ObjectService API

### DIFF
--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -1217,12 +1217,13 @@ class SynchronizationService
                 }
 
                 foreach ($targetIdsToDelete as $targetIdToDelete) {
-                    // Scope-check the cleanup candidate before deleting it. `updateTargetOpenRegister`'s
-                    // `delete` branch calls `$objectService->delete(['id' => $uuid])` with no
-                    // register/schema scope, so a contract whose `targetId` UUID accidentally
-                    // collides with an object living in a foreign register/schema would otherwise
-                    // delete that foreign object. We verify here that the object actually lives in
-                    // this sync's register/schema before invoking the unscoped delete path.
+                    // Scope-check the cleanup candidate before deleting it. Defence in depth:
+                    // `updateTargetOpenRegister`'s `delete` branch now invokes the scoped
+                    // `deleteObject($uuid, $register, $schema)` API (OR#1638 / hydra#309), but
+                    // we still verify here that the object actually lives in this sync's
+                    // register/schema. This avoids audit noise and an unnecessary OR call when
+                    // a contract's `targetId` UUID accidentally collides with an object in a
+                    // foreign register/schema.
                     //
                     // _rbac / _multitenancy are off because the previous SQL-level guard this
                     // replaces (the JOIN against `openregister_objects` in the pre-cutover code)
@@ -1592,7 +1593,10 @@ class SynchronizationService
                 $contractData['targetLastAction'] = ($contractData['targetId'] !== null) ? 'update' : 'create';
                 break;
             case 'delete':
-                $objectService->delete(object: ['id' => $contractData['targetId']]);
+                // Use the scoped delete API (OR#1638) so a UUID collision across magic
+                // tables cannot silently delete a foreign-scope object. Register and
+                // schema are derived from $syncData['targetId'] above.
+                $objectService->deleteObject(uuid: $contractData['targetId'], register: $register, schema: $schema);
                 $contractData['targetId']         = null;
                 $contractData['targetLastAction'] = 'delete';
                 break;

--- a/tests/Unit/Service/SynchronizationServiceCleanupTest.php
+++ b/tests/Unit/Service/SynchronizationServiceCleanupTest.php
@@ -39,17 +39,20 @@ use ReflectionMethod;
  * Tests the scope-checked cleanup behaviour in deleteInvalidObjects.
  *
  * The cleanup pass must verify each candidate target lives in the sync's
- * register/schema before invoking the unscoped `objectService->delete(['id' => $uuid])`
- * inside `updateTargetOpenRegister`. Without this guard a UUID collision
- * across magic tables would silently delete a foreign-scope object.
+ * register/schema before invoking the scoped `objectService->deleteObject($uuid, $register, $schema)`
+ * inside `updateTargetOpenRegister`. The scoped API (OR#1638 / hydra#309) prevents a UUID
+ * collision across magic tables from silently deleting a foreign-scope object; this
+ * pre-flight guard provides defence in depth and avoids unnecessary OR calls + audit noise
+ * when a contract's `targetId` UUID accidentally collides with an object in a foreign
+ * register/schema.
  */
 class SynchronizationServiceCleanupTest extends TestCase
 {
 
-    private const SYNC_UUID = 'sync-uuid-1';
-    private const REGISTER_ID = '1';
-    private const SCHEMA_ID = '2';
-    private const TARGET_IN_SCOPE = 'object-in-scope-uuid';
+    private const SYNC_UUID           = 'sync-uuid-1';
+    private const REGISTER_ID         = '1';
+    private const SCHEMA_ID           = '2';
+    private const TARGET_IN_SCOPE     = 'object-in-scope-uuid';
     private const TARGET_OUT_OF_SCOPE = 'object-out-of-scope-uuid';
 
     /**
@@ -66,7 +69,6 @@ class SynchronizationServiceCleanupTest extends TestCase
      * @var LoggerInterface&MockObject
      */
     private $logger;
-
 
     /**
      * Set up test fixtures.
@@ -107,7 +109,6 @@ class SynchronizationServiceCleanupTest extends TestCase
             ->getMock();
     }//end setUp()
 
-
     /**
      * Build a Synchronization OR-object stub with `targetType: register/schema`
      * and `targetId: {registerId}/{schemaId}`.
@@ -125,7 +126,6 @@ class SynchronizationServiceCleanupTest extends TestCase
             self::SYNC_UUID
         );
     }//end makeSync()
-
 
     /**
      * Build a SynchronizationContract OR-object stub bound to this sync.
@@ -148,7 +148,6 @@ class SynchronizationServiceCleanupTest extends TestCase
         );
     }//end makeContract()
 
-
     /**
      * Map ORObjectService::find parameter names to positional indices.
      *
@@ -169,7 +168,6 @@ class SynchronizationServiceCleanupTest extends TestCase
         return $positions;
     }//end findParamPositions()
 
-
     /**
      * In-scope orphan: target object lives in this sync's register/schema → delete proceeds.
      *
@@ -177,9 +175,9 @@ class SynchronizationServiceCleanupTest extends TestCase
      */
     public function testInScopeOrphanIsDeleted(): void
     {
-        $sync     = $this->makeSync();
-        $contract = $this->makeContract(self::TARGET_IN_SCOPE);
-        $pos      = $this->findParamPositions();
+        $sync         = $this->makeSync();
+        $contract     = $this->makeContract(self::TARGET_IN_SCOPE);
+        $pos          = $this->findParamPositions();
         $targetEntity = ObjectServiceMockBuilder::objectEntity($this, [], self::TARGET_IN_SCOPE);
 
         // First findAll: enumerate contracts for the sync. Second findAll: re-lookup by targetId.
@@ -209,7 +207,6 @@ class SynchronizationServiceCleanupTest extends TestCase
         $this->assertSame(1, $deleted, 'In-scope orphan should be deleted');
     }//end testInScopeOrphanIsDeleted()
 
-
     /**
      * Cross-scope contract: target UUID does NOT live in this sync's register/schema → skip delete.
      *
@@ -236,7 +233,6 @@ class SynchronizationServiceCleanupTest extends TestCase
         $this->assertSame(0, $deleted, 'Out-of-scope contract must not trigger deletion');
     }//end testCrossScopeContractIsSkipped()
 
-
     /**
      * Scope-check throws DoesNotExistException → swallowed silently, no delete.
      *
@@ -259,7 +255,6 @@ class SynchronizationServiceCleanupTest extends TestCase
 
         $this->assertSame(0, $deleted);
     }//end testDoesNotExistExceptionIsSwallowed()
-
 
     /**
      * Scope-check throws an unexpected Throwable → warning logged, candidate skipped, loop continues.
@@ -297,7 +292,6 @@ class SynchronizationServiceCleanupTest extends TestCase
         $this->assertSame(0, $deleted);
     }//end testUnexpectedThrowableLogsWarningAndContinues()
 
-
     /**
      * Malformed targetId (no `/` separator) → warning logged, no contracts inspected.
      *
@@ -327,7 +321,6 @@ class SynchronizationServiceCleanupTest extends TestCase
         $this->assertSame(0, $deleted);
     }//end testMalformedTargetIdLogsWarningAndBails()
 
-
     /**
      * Mixed batch: one in-scope, one out-of-scope → only in-scope orphan deleted.
      *
@@ -335,10 +328,10 @@ class SynchronizationServiceCleanupTest extends TestCase
      */
     public function testInScopeAndOutOfScopeMixedBatch(): void
     {
-        $sync       = $this->makeSync();
-        $inScope    = $this->makeContract(self::TARGET_IN_SCOPE, 'origin-a');
-        $outOfScope = $this->makeContract(self::TARGET_OUT_OF_SCOPE, 'origin-b');
-        $pos        = $this->findParamPositions();
+        $sync         = $this->makeSync();
+        $inScope      = $this->makeContract(self::TARGET_IN_SCOPE, 'origin-a');
+        $outOfScope   = $this->makeContract(self::TARGET_OUT_OF_SCOPE, 'origin-b');
+        $pos          = $this->findParamPositions();
         $targetEntity = ObjectServiceMockBuilder::objectEntity($this, [], self::TARGET_IN_SCOPE);
 
         // First findAll: list of contracts. Subsequent findAlls: per-target re-lookup.
@@ -363,6 +356,4 @@ class SynchronizationServiceCleanupTest extends TestCase
 
         $this->assertSame(1, $deleted, 'Only in-scope orphan should be deleted in mixed batch');
     }//end testInScopeAndOutOfScopeMixedBatch()
-
-
 }//end class


### PR DESCRIPTION
## Summary

- Migrates the `'delete'` branch of `SynchronizationService::updateTargetOpenRegister` from the now-deprecated unscoped `ObjectService::delete(['id' => $uuid])` form to the scoped `deleteObject($uuid, $register, $schema)` API landed in OR#1638 (merged via openregister#1643).
- `$register` and `$schema` are already in scope on lines just above the call site (extracted from `$syncData['targetId']`).
- Refreshes the explanatory comment on the upstream cleanup-guard pre-flight check (it now describes the guard as defence-in-depth around a scoped delete, not a workaround for an unscoped one).
- Drive-by phpcbf auto-fix of 22 pre-existing whitespace / assignment-alignment violations in `SynchronizationServiceCleanupTest.php` (per `fix-all-issues-encountered` policy).

## Why

`ObjectService::delete(['id' => $uuid])` accepts a UUID without register/schema scope. With magic-table partitioning a UUID collision across magic tables could silently delete a foreign-scope object. OR#1638 deprecates that form and introduces the scoped `deleteObject($uuid, $register, $schema)` that prevents this at the API boundary.

## Fleet context (hydra#309)

This PR is the only call-site fix needed across the fleet. The full fleet sweep (`git grep` on `origin/development` of all 10 Conduction apps) found:

| App | MIGRATE | INTENTIONAL | NEEDS DESIGN |
|---|---|---|---|
| openconnector | 1 (this PR) | 0 | 0 |
| openregister | 0 (internal `$this->delete` only) | – | – |
| opencatalogi, decidesk, mydash, docudesk, procest, pipelinq, larpingapp, softwarecatalog | 0 | – | – |

All other apps already use `deleteObject` / `deleteFromId` exclusively.

## Test plan

- [x] PHPCS strict passes on `lib/Service/SynchronizationService.php` and the touched test file (in container with PHP 8.3).
- [x] PHP syntax check (`php -l`) clean.
- [ ] `SynchronizationServiceCleanupTest` is pre-existing red on `origin/development` (`getUuid` mock vs final method on the post-OR#1638 ObjectService) — same failure before and after this PR. Not introduced here; out of scope.
- [ ] Manual: trigger a sync with `mutationType=delete` and verify the target object in the correct register/schema is removed; verify a contract whose `targetId` happens to UUID-collide with a foreign-schema object does NOT delete that foreign object (the cleanup-pass `find(register, schema)` pre-flight + the scoped `deleteObject(register, schema)` together provide two-layer protection).

Refs: hydra#309, openregister#1638