### PR TITLE
feat(sync): bespoke synchronization editor (closes #834)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -336,7 +336,9 @@
         "columns": ["name", "sourceType", "targetType", "status", "sourceLastSynced"],
         "includeFields": ["name", "description", "sourceType", "targetType"],
         "sidebar": { "enabled": true, "showMetadata": true },
+        "rowAction": { "id": "edit", "handler": "navigate", "route": "SynchronizationDetail", "params": { "id": "{id}" } },
         "actions": [
+          { "id": "edit", "label": "Open editor", "icon": "icon-edit", "handler": "navigate", "route": "SynchronizationDetail", "params": { "id": "{id}" } },
           { "id": "run", "label": "Run now", "icon": "icon-play", "handler": "runSynchronizationHandler" },
           { "id": "test", "label": "Test (dry run)", "icon": "icon-checkmark", "handler": "testSynchronizationHandler" },
           { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SynchronizationLogs" },
@@ -364,6 +366,17 @@
       "config": {
         "register": "openconnector",
         "schema": "synchronization_log"
+      }
+    },
+    {
+      "id": "SynchronizationDetail",
+      "route": "/synchronizations/:id",
+      "type": "custom",
+      "title": "Synchronization",
+      "component": "SynchronizationDetailPage",
+      "config": {
+        "register": "openconnector",
+        "schema": "synchronization"
       }
     },
     {

--- a/src/registry.js
+++ b/src/registry.js
@@ -42,6 +42,7 @@ import {
 	addEndpointRuleHandler,
 } from './handlers/actionHandlers.js'
 import JobFormFields from './modals/v2/JobFormFields.vue'
+import SynchronizationDetailPage from './views/Synchronization/SynchronizationDetailPage.vue'
 
 export default {
 	// Row-action handlers — referenced by manifest `config.actions[].handler` strings.
@@ -62,4 +63,14 @@ export default {
 	// (per #847). Open follow-up upstream: CnFormDialog has no native
 	// per-field `condition`/`visibleWhen` prop — tracked as a ncv issue.
 	JobFormFields,
+
+	// `type: custom` page components — referenced by manifest
+	// `pages[].component` strings. SynchronizationDetailPage (per #834)
+	// wraps CnDetailPage with five bespoke widget sections that the
+	// generic schema-driven detail page can't express cleanly:
+	// source-config, target-config, mapping-picker, actions-list,
+	// followups-list. Source/target config swap on the type
+	// discriminator (api/register/schema/file), reusing #867's
+	// conditional-visibility pattern.
+	SynchronizationDetailPage,
 }

--- a/src/views/Synchronization/SyncConfigWidget.vue
+++ b/src/views/Synchronization/SyncConfigWidget.vue
@@ -1,0 +1,408 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  SyncConfigWidget — type-specific config blob editor for one side
+  (source or target) of a Synchronization.
+
+  Conditional rendering mirrors the legacy modal: the `type` discriminator
+  (api / register/schema / file) decides which set of fields is shown,
+  swapping the blob shape underneath. This is the same conditional-
+  visibility pattern from `JobFormFields.vue` (#867) — CnFormDialog still
+  has no native `visibleWhen` per-field gating, so this stays bespoke.
+
+  Two model channels are exposed (both two-way via `update:`):
+    - `update:sourceId`  → polymorphic id string (parent stores into
+       `sourceId` or `targetId` depending on `kind`)
+    - `update:config`    → the type-specific blob (parent stores into
+       `sourceConfig` or `targetConfig`)
+
+  For `register/schema` mode the polymorphic id format is
+  `<registerId>/<schemaId>` (matching the legacy split logic). For `api`
+  mode it is a stored Source UUID/PK. For `file` mode it is a free-form
+  file path/glob (no picker yet — flagged below).
+
+  Open follow-ups:
+    - File mode is currently a plain text field. The legacy modal didn't
+      build it out either; once a real file-source kernel lands we'll
+      revisit with a path picker.
+    - Register/Schema picker loads the full schema list for the picked
+      register — large registers may benefit from search/pagination, but
+      OR caps at `limit: 500` here which mirrors what JobFormFields does
+      for synchronizations.
+-->
+
+<template>
+	<div class="sync-config">
+		<!-- API mode -->
+		<template v-if="type === 'api'">
+			<div class="sync-config__field">
+				<label :for="apiSourceId" class="sync-config__label">
+					{{ kindLabel }} {{ t('openconnector', 'source (API)') }}
+				</label>
+				<NcSelect
+					:input-id="apiSourceId"
+					:value="selectedSource"
+					:options="sourceOptions"
+					:loading="sourcesLoading"
+					:placeholder="t('openconnector', 'Pick a configured source')"
+					@input="onSourcePick" />
+				<span class="sync-config__helper">
+					{{ t('openconnector', 'The Source record that defines the API base URL + auth.') }}
+				</span>
+			</div>
+
+			<div class="sync-config__field">
+				<NcTextField
+					:label="t('openconnector', 'Endpoint')"
+					:value="configValue('endpoint')"
+					:placeholder="t('openconnector', 'Path appended to the source URL')"
+					@update:value="(value) => onConfigUpdate('endpoint', value)" />
+			</div>
+
+			<div class="sync-config__field">
+				<NcTextField
+					:label="t('openconnector', 'ID position')"
+					:value="configValue('idPosition')"
+					:placeholder="t('openconnector', 'Dot-path to the id field in the API response')"
+					@update:value="(value) => onConfigUpdate('idPosition', value)" />
+			</div>
+
+			<div class="sync-config__field">
+				<NcTextField
+					:label="t('openconnector', 'Results position')"
+					:value="configValue('resultsPosition')"
+					:placeholder="t('openconnector', 'Dot-path to the list of items')"
+					@update:value="(value) => onConfigUpdate('resultsPosition', value)" />
+			</div>
+		</template>
+
+		<!-- Register/Schema mode -->
+		<template v-else-if="type === 'register/schema'">
+			<div class="sync-config__field">
+				<label :for="registerSelectId" class="sync-config__label">
+					{{ t('openconnector', 'Register') }}
+				</label>
+				<NcSelect
+					:input-id="registerSelectId"
+					:value="selectedRegister"
+					:options="registerOptions"
+					:loading="registersLoading"
+					:placeholder="t('openconnector', 'Pick a register')"
+					@input="onRegisterPick" />
+			</div>
+
+			<div class="sync-config__field">
+				<label :for="schemaSelectId" class="sync-config__label">
+					{{ t('openconnector', 'Schema') }}
+				</label>
+				<NcSelect
+					:input-id="schemaSelectId"
+					:value="selectedSchema"
+					:options="schemaOptions"
+					:disabled="!selectedRegister"
+					:placeholder="t('openconnector', 'Pick a schema in the register')"
+					@input="onSchemaPick" />
+			</div>
+
+			<div class="sync-config__field">
+				<NcTextField
+					:label="t('openconnector', 'Object filter (optional)')"
+					:value="configValue('filter')"
+					:placeholder="t('openconnector', 'JSON-encoded OR query filter')"
+					@update:value="(value) => onConfigUpdate('filter', value)" />
+			</div>
+		</template>
+
+		<!-- File mode -->
+		<template v-else-if="type === 'file'">
+			<div class="sync-config__field">
+				<NcTextField
+					:label="t('openconnector', 'File path or glob')"
+					:value="sourceIdValue"
+					:placeholder="'/example/path/*.json'"
+					@update:value="(value) => $emit('update:sourceId', value)" />
+				<span class="sync-config__helper">
+					{{ t('openconnector', 'Stored as the polymorphic id. Use a glob for multiple files.') }}
+				</span>
+			</div>
+
+			<div class="sync-config__field">
+				<NcTextField
+					:label="t('openconnector', 'File format')"
+					:value="configValue('format')"
+					:placeholder="'json | xml | csv'"
+					@update:value="(value) => onConfigUpdate('format', value)" />
+			</div>
+
+			<div class="sync-config__field">
+				<NcTextField
+					:label="t('openconnector', 'ID position')"
+					:value="configValue('idPosition')"
+					:placeholder="t('openconnector', 'Dot-path to the id field in each record')"
+					@update:value="(value) => onConfigUpdate('idPosition', value)" />
+			</div>
+		</template>
+
+		<!-- Unknown / not set -->
+		<div v-else class="sync-config__placeholder">
+			{{ t('openconnector', 'Pick a {kind} type above to configure it.', { kind: kind }) }}
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcSelect, NcTextField } from '@nextcloud/vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+/**
+ * Generate a stable input-id suffix so the two SyncConfigWidget
+ * instances (source vs target) on the same page don't share `id`
+ * attributes — labels would point at the wrong control otherwise.
+ */
+let widgetSeq = 0
+
+export default {
+	name: 'SyncConfigWidget',
+
+	components: {
+		NcSelect,
+		NcTextField,
+	},
+
+	props: {
+		/**
+		 * Side discriminator. Drives the label prefix ("Source"/"Target")
+		 * and which polymorphic id field the parent will store the value
+		 * in (`sourceId` vs `targetId`).
+		 */
+		kind: {
+			type: String,
+			required: true,
+			validator: (value) => ['source', 'target'].includes(value),
+		},
+		/**
+		 * The type discriminator picked on the parent. Determines which
+		 * branch of the conditional template renders.
+		 */
+		type: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * The polymorphic id string. For `api` mode the Source UUID; for
+		 * `register/schema` mode `<registerId>/<schemaId>`; for `file`
+		 * mode the file path/glob.
+		 */
+		sourceId: {
+			type: [String, Number],
+			default: '',
+		},
+		/**
+		 * Type-specific config blob. Different keys are read/written
+		 * depending on `type`.
+		 */
+		config: {
+			type: Object,
+			default: () => ({}),
+		},
+	},
+
+	data() {
+		const seq = ++widgetSeq
+		return {
+			widgetUid: seq,
+			sourceOptions: [],
+			sourcesLoading: false,
+			registerOptions: [],
+			registersLoading: false,
+			selectedRegisterRecord: null,
+		}
+	},
+
+	computed: {
+		kindLabel() {
+			return this.kind === 'source'
+				? t('openconnector', 'Source')
+				: t('openconnector', 'Target')
+		},
+		apiSourceId() {
+			return `sync-config-${this.widgetUid}-api-source`
+		},
+		registerSelectId() {
+			return `sync-config-${this.widgetUid}-register`
+		},
+		schemaSelectId() {
+			return `sync-config-${this.widgetUid}-schema`
+		},
+		sourceIdValue() {
+			return this.sourceId != null ? String(this.sourceId) : ''
+		},
+		selectedSource() {
+			if (!this.sourceIdValue) return null
+			return this.sourceOptions.find((opt) => opt.id === this.sourceIdValue) ?? {
+				id: this.sourceIdValue,
+				label: this.sourceIdValue,
+			}
+		},
+		selectedRegister() {
+			const [registerId] = this.sourceIdValue.split('/')
+			if (!registerId) return null
+			return this.registerOptions.find((opt) => String(opt.id) === String(registerId)) ?? null
+		},
+		schemaOptions() {
+			const reg = this.selectedRegister || this.selectedRegisterRecord
+			if (!reg) return []
+			const schemas = Array.isArray(reg.schemas) ? reg.schemas : []
+			return schemas.map((schema) => ({
+				id: String(schema.id ?? schema.slug ?? schema),
+				label: schema.title || schema.name || schema.slug || String(schema),
+			}))
+		},
+		selectedSchema() {
+			const parts = this.sourceIdValue.split('/')
+			if (parts.length < 2) return null
+			const schemaId = parts[1]
+			return this.schemaOptions.find((opt) => String(opt.id) === String(schemaId)) ?? null
+		},
+	},
+
+	watch: {
+		type: {
+			immediate: true,
+			handler(value) {
+				if (value === 'api' && this.sourceOptions.length === 0) {
+					this.fetchSources()
+				}
+				if (value === 'register/schema' && this.registerOptions.length === 0) {
+					this.fetchRegisters()
+				}
+			},
+		},
+	},
+
+	methods: {
+		configValue(key) {
+			if (!this.config || typeof this.config !== 'object') return ''
+			const v = this.config[key]
+			if (v == null) return ''
+			return typeof v === 'string' ? v : String(v)
+		},
+		onConfigUpdate(key, value) {
+			const next = (this.config && typeof this.config === 'object' && !Array.isArray(this.config))
+				? { ...this.config }
+				: {}
+			if (value === '' || value == null) {
+				delete next[key]
+			} else {
+				next[key] = value
+			}
+			this.$emit('update:config', next)
+		},
+		onSourcePick(option) {
+			this.$emit('update:sourceId', option?.id ? String(option.id) : '')
+		},
+		onRegisterPick(option) {
+			if (!option?.id) {
+				this.$emit('update:sourceId', '')
+				this.selectedRegisterRecord = null
+				return
+			}
+			// Cache the full register record so schemaOptions can read its
+			// schemas array even after the parent prop round-trips.
+			this.selectedRegisterRecord = option
+			// Clear schema half — parent will store register alone until
+			// the user picks a schema below.
+			this.$emit('update:sourceId', String(option.id) + '/')
+		},
+		onSchemaPick(option) {
+			const reg = this.selectedRegister || this.selectedRegisterRecord
+			if (!reg || !option?.id) {
+				this.$emit('update:sourceId', reg ? String(reg.id) + '/' : '')
+				return
+			}
+			this.$emit('update:sourceId', String(reg.id) + '/' + String(option.id))
+		},
+		async fetchSources() {
+			this.sourcesLoading = true
+			try {
+				const response = await axios.get(
+					generateUrl('/apps/openregister/api/objects/openconnector/source'),
+					{ params: { limit: 500 } },
+				)
+				const data = response.data
+				const list = Array.isArray(data?.results) ? data.results : (Array.isArray(data) ? data : [])
+				this.sourceOptions = list.map((row) => ({
+					id: String(row.id || row.uuid),
+					label: row.name || row.title || row.id,
+				}))
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.warn('[SyncConfigWidget] sources fetch failed', err)
+				this.sourceOptions = []
+			} finally {
+				this.sourcesLoading = false
+			}
+		},
+		async fetchRegisters() {
+			this.registersLoading = true
+			try {
+				const response = await axios.get(generateUrl('/apps/openregister/api/registers'))
+				const data = response.data
+				const list = Array.isArray(data?.results) ? data.results : (Array.isArray(data) ? data : [])
+				this.registerOptions = list.map((reg) => ({
+					id: String(reg.id),
+					label: reg.title || reg.name || reg.slug || String(reg.id),
+					schemas: Array.isArray(reg.schemas) ? reg.schemas : [],
+				}))
+				// If the parent has a pre-existing register/schema id,
+				// seed selectedRegisterRecord so the schema picker has its
+				// options ready without a second round-trip.
+				const [regId] = this.sourceIdValue.split('/')
+				if (regId) {
+					this.selectedRegisterRecord = this.registerOptions.find((opt) => String(opt.id) === String(regId)) || null
+				}
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.warn('[SyncConfigWidget] registers fetch failed', err)
+				this.registerOptions = []
+			} finally {
+				this.registersLoading = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.sync-config {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.sync-config__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.sync-config__label {
+	font-weight: bold;
+	font-size: 13px;
+}
+
+.sync-config__helper {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+
+.sync-config__placeholder {
+	padding: 12px;
+	border: 1px dashed var(--color-border);
+	border-radius: var(--border-radius);
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+	text-align: center;
+}
+</style>

--- a/src/views/Synchronization/SyncMappingPicker.vue
+++ b/src/views/Synchronization/SyncMappingPicker.vue
@@ -1,0 +1,185 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  SyncMappingPicker — three NcSelect rows for the mapping slugs a
+  Synchronization owns:
+
+    - sourceTargetMapping  — required source→target transformation
+    - targetSourceMapping  — optional reverse (bidirectional only)
+    - sourceHashMapping    — optional change-detection hash mapping
+
+  Each row is the same Mapping picker, populated once and shared via the
+  parent's `mappingOptions`. Reuses the #847 sync-picker pattern
+  (NcSelect populated from OR's `/api/objects/openconnector/mapping`).
+
+  Persisted shape: Mapping is referenced by `slug` per the
+  `synchronization.sourceTargetMapping` field description in
+  `lib/Settings/openconnector_register.json` ("Mapping slug for
+  source-to-target field transformation"). We render the human label
+  but emit the slug back up.
+-->
+
+<template>
+	<div class="sync-mapping">
+		<div class="sync-mapping__field">
+			<label :for="primaryId" class="sync-mapping__label">
+				{{ t('openconnector', 'Source → Target mapping *') }}
+			</label>
+			<NcSelect
+				:input-id="primaryId"
+				:value="selectedPrimary"
+				:options="mappingOptions"
+				:loading="loading"
+				:placeholder="t('openconnector', 'Pick a mapping')"
+				@input="(option) => $emit('update:value', option?.id || '')" />
+			<span class="sync-mapping__helper">
+				{{ t('openconnector', 'Transforms each source record into the target shape.') }}
+			</span>
+		</div>
+
+		<div class="sync-mapping__field">
+			<label :for="reverseId" class="sync-mapping__label">
+				{{ t('openconnector', 'Target → Source mapping') }}
+			</label>
+			<NcSelect
+				:input-id="reverseId"
+				:value="selectedReverse"
+				:options="mappingOptions"
+				:loading="loading"
+				:clearable="true"
+				:placeholder="t('openconnector', 'Optional — for bidirectional sync')"
+				@input="(option) => $emit('update:targetSourceValue', option?.id || '')" />
+			<span class="sync-mapping__helper">
+				{{ t('openconnector', 'Only needed when changes flow back from target to source.') }}
+			</span>
+		</div>
+
+		<div class="sync-mapping__field">
+			<label :for="hashId" class="sync-mapping__label">
+				{{ t('openconnector', 'Hash mapping') }}
+			</label>
+			<NcSelect
+				:input-id="hashId"
+				:value="selectedHash"
+				:options="mappingOptions"
+				:loading="loading"
+				:clearable="true"
+				:placeholder="t('openconnector', 'Optional — change detection')"
+				@input="(option) => $emit('update:hashValue', option?.id || '')" />
+			<span class="sync-mapping__helper">
+				{{ t('openconnector', 'Mapping used to compute the source-side hash for change detection.') }}
+			</span>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcSelect } from '@nextcloud/vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+let pickerSeq = 0
+
+export default {
+	name: 'SyncMappingPicker',
+
+	components: {
+		NcSelect,
+	},
+
+	props: {
+		/** Required primary mapping slug. */
+		value: { type: String, default: '' },
+		/** Optional reverse-direction mapping slug. */
+		targetSourceValue: { type: String, default: '' },
+		/** Optional hash mapping slug. */
+		hashValue: { type: String, default: '' },
+	},
+
+	data() {
+		const seq = ++pickerSeq
+		return {
+			pickerUid: seq,
+			mappingOptions: [],
+			loading: false,
+		}
+	},
+
+	computed: {
+		primaryId() { return `sync-mapping-${this.pickerUid}-primary` },
+		reverseId() { return `sync-mapping-${this.pickerUid}-reverse` },
+		hashId() { return `sync-mapping-${this.pickerUid}-hash` },
+		selectedPrimary() {
+			return this.resolveOption(this.value)
+		},
+		selectedReverse() {
+			return this.resolveOption(this.targetSourceValue)
+		},
+		selectedHash() {
+			return this.resolveOption(this.hashValue)
+		},
+	},
+
+	mounted() {
+		this.fetchMappings()
+	},
+
+	methods: {
+		resolveOption(id) {
+			if (!id) return null
+			return this.mappingOptions.find((opt) => opt.id === String(id)) ?? {
+				id: String(id),
+				label: String(id),
+			}
+		},
+		async fetchMappings() {
+			this.loading = true
+			try {
+				const response = await axios.get(
+					generateUrl('/apps/openregister/api/objects/openconnector/mapping'),
+					{ params: { limit: 500 } },
+				)
+				const data = response.data
+				const list = Array.isArray(data?.results) ? data.results : (Array.isArray(data) ? data : [])
+				this.mappingOptions = list.map((row) => ({
+					// Mappings are referenced by slug in the synchronization
+					// record (per the register schema description). Fall back
+					// to id when slug is unset (legacy rows).
+					id: String(row.slug || row.id || row.uuid),
+					label: row.name || row.title || row.slug || row.id,
+				}))
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.warn('[SyncMappingPicker] mapping fetch failed', err)
+				this.mappingOptions = []
+			} finally {
+				this.loading = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.sync-mapping {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.sync-mapping__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.sync-mapping__label {
+	font-weight: bold;
+	font-size: 13px;
+}
+
+.sync-mapping__helper {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/src/views/Synchronization/SyncReferenceList.vue
+++ b/src/views/Synchronization/SyncReferenceList.vue
@@ -1,0 +1,153 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  SyncReferenceList — multi-select picker that edits an array of
+  slug/id references on the parent Synchronization. Used for both
+  `actions[]` (rule references) and `followUps[]` (other Synchronization
+  references) — they have the same shape per the register schema:
+  array of slug strings.
+
+  Reuses the #847 picker pattern: NcSelect populated from OR's
+  `/api/objects/openregister/api/objects/openconnector/{schema}` endpoint.
+  Multi-mode emits an array of slug strings (matching what
+  `SynchronizationAction::run()` expects when looking these up).
+
+  The legacy modal stored these as id arrays. Per the register schema
+  description ("Rule slugs", "Synchronization slugs") we standardise on
+  the slug as the canonical reference; if no slug is set we fall back to
+  the id so older rows still resolve.
+-->
+
+<template>
+	<div class="sync-ref-list">
+		<NcSelect
+			:input-id="inputId"
+			:value="selectedOptions"
+			:options="options"
+			:loading="loading"
+			multiple
+			closeable-chips
+			:placeholder="placeholder"
+			@input="onChange" />
+
+		<p v-if="!selectedOptions.length" class="sync-ref-list__empty">
+			{{ emptyLabel }}
+		</p>
+	</div>
+</template>
+
+<script>
+import { NcSelect } from '@nextcloud/vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+let listSeq = 0
+
+export default {
+	name: 'SyncReferenceList',
+
+	components: {
+		NcSelect,
+	},
+
+	props: {
+		/**
+		 * The OR schema slug to fetch options from
+		 * (e.g. `rule`, `synchronization`).
+		 */
+		schema: { type: String, required: true },
+		/** Property of each fetched record used as the human label. */
+		labelKey: { type: String, default: 'name' },
+		/** Current array of slug strings stored on the parent. */
+		value: { type: Array, default: () => [] },
+		/**
+		 * Optional id to exclude from the option list — used by the
+		 * followUps picker to keep the current Synchronization out of its
+		 * own follow-ups (avoids infinite recursion).
+		 */
+		excludeId: { type: String, default: '' },
+		placeholder: { type: String, default: '' },
+		emptyLabel: { type: String, default: '' },
+	},
+
+	data() {
+		const seq = ++listSeq
+		return {
+			listUid: seq,
+			options: [],
+			loading: false,
+		}
+	},
+
+	computed: {
+		inputId() {
+			return `sync-ref-list-${this.listUid}`
+		},
+		selectedOptions() {
+			if (!Array.isArray(this.value)) return []
+			return this.value.map((id) => this.options.find((opt) => opt.id === String(id)) ?? {
+				id: String(id),
+				label: String(id),
+			})
+		},
+	},
+
+	watch: {
+		schema: {
+			immediate: true,
+			handler() {
+				this.fetchOptions()
+			},
+		},
+	},
+
+	methods: {
+		onChange(picked) {
+			const list = Array.isArray(picked) ? picked : []
+			this.$emit('input', list.map((option) => option?.id).filter(Boolean).map(String))
+		},
+		async fetchOptions() {
+			this.loading = true
+			try {
+				const response = await axios.get(
+					generateUrl('/apps/openregister/api/objects/openconnector/' + this.schema),
+					{ params: { limit: 500 } },
+				)
+				const data = response.data
+				const list = Array.isArray(data?.results) ? data.results : (Array.isArray(data) ? data : [])
+				this.options = list
+					.map((row) => ({
+						// Standardise on slug as the canonical reference
+						// (matches the register schema's `actions[]` /
+						// `followUps[]` description). Fall back to id/uuid
+						// for legacy rows without a slug.
+						id: String(row.slug || row.id || row.uuid),
+						label: row[this.labelKey] || row.title || row.name || row.slug || row.id,
+					}))
+					.filter((opt) => !this.excludeId || opt.id !== String(this.excludeId))
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.warn(`[SyncReferenceList] ${this.schema} fetch failed`, err)
+				this.options = []
+			} finally {
+				this.loading = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.sync-ref-list {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.sync-ref-list__empty {
+	margin: 0;
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+}
+</style>

--- a/src/views/Synchronization/SynchronizationDetailPage.vue
+++ b/src/views/Synchronization/SynchronizationDetailPage.vue
@@ -1,0 +1,612 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  SynchronizationDetailPage — bespoke detail page for one Synchronization.
+
+  Wraps `CnDetailPage` and lays out five dedicated config widgets that the
+  generic schema-driven detail page cannot express cleanly:
+
+    1. #source-config-widget   — source-type-specific config blob editor
+       (api / register/schema / file)
+    2. #target-config-widget   — target-type-specific config blob editor
+    3. #mapping-picker-widget  — `sourceTargetMapping` Mapping picker
+       (slug-based NcSelect, populated from OR's `/api/objects/openconnector/mapping`)
+    4. #actions-list-widget    — `actions[]` rule references (multi-select Rules)
+    5. #followups-list-widget  — `followUps[]` synchronization references
+       (multi-select sibling Syncs)
+
+  Wired in via:
+    - `src/manifest.json` → page `SynchronizationDetail` with
+      `"type": "custom", "component": "SynchronizationDetailPage"`
+    - `src/registry.js`   → maps `SynchronizationDetailPage` to this component
+    - `src/manifest.json` → Synchronizations index gets a row "Edit" action
+      that navigates to the new route, plus the auto-row-click path.
+
+  Reuses the #867 picker pattern: NcSelect populated from OR's
+  `/api/objects/openregister/api/objects/openconnector/{schema}` endpoint.
+
+  Persistence: `useObjectStore` (the same store CnDetailPage subscribes to).
+  Mutations go through `objectStore.saveObject('synchronization', {...})`
+  which writes back via PUT to OR. The page tracks a `dirty` flag and
+  exposes a Save button in the header actions slot — no auto-save on
+  every keystroke, mirroring the legacy modal's two-phase flow.
+
+  Closes #834. Open follow-ups:
+    - Conditions array editor (legacy JSON-Logic textarea) — re-add in a
+      future bespoke widget if/when the visual condition builder lands.
+    - Mapping preview (legacy "test mapping" surface) — out of scope here;
+      tracked separately under the test-mapping modal work.
+-->
+
+<template>
+	<CnDetailPage
+		:title="title"
+		:description="description"
+		icon="SyncOutline"
+		:loading="loading"
+		:error="hasError"
+		:error-message="errorMessage"
+		:on-retry="hasError ? loadObject : null"
+		:object-type="schemaSlug"
+		:object-id="objectIdString"
+		:sidebar-props="{ register: registerSlug, schema: schemaSlug }">
+		<template #actions>
+			<NcButton
+				v-if="dirty"
+				type="primary"
+				:disabled="saving || !canSave"
+				@click="save">
+				<template #icon>
+					<NcLoadingIcon v-if="saving" :size="20" />
+					<ContentSaveOutline v-else :size="20" />
+				</template>
+				{{ t('openconnector', 'Save changes') }}
+			</NcButton>
+			<NcButton
+				v-if="dirty"
+				:disabled="saving"
+				@click="resetEdits">
+				<template #icon>
+					<UndoIcon :size="20" />
+				</template>
+				{{ t('openconnector', 'Discard') }}
+			</NcButton>
+		</template>
+
+		<div v-if="!loading && draft" class="sync-detail">
+			<!-- Source / General / Target row -->
+			<div class="sync-detail__row">
+				<section class="sync-detail__card sync-detail__source">
+					<header class="sync-detail__card-header">
+						<DatabaseArrowRightOutline :size="22" />
+						<h3>{{ t('openconnector', 'Source') }}</h3>
+					</header>
+					<p class="sync-detail__hint">
+						{{ t('openconnector', 'Configure where data comes from.') }}
+					</p>
+
+					<!-- Source type discriminator -->
+					<div class="sync-detail__field">
+						<label :for="'sync-source-type'" class="sync-detail__label">
+							{{ t('openconnector', 'Source type') }}
+						</label>
+						<NcSelect
+							:input-id="'sync-source-type'"
+							:value="selectedSourceType"
+							:options="typeOptions"
+							:clearable="false"
+							@input="onSourceTypeChange" />
+					</div>
+
+					<!-- #source-config-widget -->
+					<SyncConfigWidget
+						kind="source"
+						:type="draft.sourceType"
+						:source-id="draft.sourceId"
+						:config="draft.sourceConfig"
+						@update:sourceId="(value) => updateDraft('sourceId', value)"
+						@update:config="(value) => updateDraft('sourceConfig', value)" />
+				</section>
+
+				<section class="sync-detail__card sync-detail__general">
+					<header class="sync-detail__card-header">
+						<CogOutline :size="22" />
+						<h3>{{ t('openconnector', 'General') }}</h3>
+					</header>
+
+					<div class="sync-detail__field">
+						<NcTextField
+							:label="t('openconnector', 'Name')"
+							:value="draft.name || ''"
+							required
+							@update:value="(value) => updateDraft('name', value)" />
+					</div>
+
+					<div class="sync-detail__field">
+						<label :for="'sync-description'" class="sync-detail__label">
+							{{ t('openconnector', 'Description') }}
+						</label>
+						<textarea
+							:id="'sync-description'"
+							class="sync-detail__textarea"
+							:value="draft.description || ''"
+							rows="3"
+							@input="updateDraft('description', $event.target.value)" />
+					</div>
+
+					<!-- Flow indicator -->
+					<div class="sync-detail__flow">
+						<span class="sync-detail__flow-step">
+							<DatabaseArrowRightOutline :size="18" />
+							{{ t('openconnector', 'Source') }}
+						</span>
+						<ArrowRight :size="18" />
+						<span class="sync-detail__flow-step">
+							<SwapHorizontal :size="18" />
+							{{ t('openconnector', 'Transform') }}
+						</span>
+						<ArrowRight :size="18" />
+						<span class="sync-detail__flow-step">
+							<DatabaseArrowLeftOutline :size="18" />
+							{{ t('openconnector', 'Target') }}
+						</span>
+					</div>
+				</section>
+
+				<section class="sync-detail__card sync-detail__target">
+					<header class="sync-detail__card-header">
+						<DatabaseArrowLeftOutline :size="22" />
+						<h3>{{ t('openconnector', 'Target') }}</h3>
+					</header>
+					<p class="sync-detail__hint">
+						{{ t('openconnector', 'Configure where data is written to.') }}
+					</p>
+
+					<!-- Target type discriminator -->
+					<div class="sync-detail__field">
+						<label :for="'sync-target-type'" class="sync-detail__label">
+							{{ t('openconnector', 'Target type') }}
+						</label>
+						<NcSelect
+							:input-id="'sync-target-type'"
+							:value="selectedTargetType"
+							:options="typeOptions"
+							:clearable="false"
+							@input="onTargetTypeChange" />
+					</div>
+
+					<!-- #target-config-widget -->
+					<SyncConfigWidget
+						kind="target"
+						:type="draft.targetType"
+						:source-id="draft.targetId"
+						:config="draft.targetConfig"
+						@update:sourceId="(value) => updateDraft('targetId', value)"
+						@update:config="(value) => updateDraft('targetConfig', value)" />
+				</section>
+			</div>
+
+			<!-- Mapping + Actions + FollowUps row -->
+			<div class="sync-detail__row">
+				<section class="sync-detail__card sync-detail__mapping">
+					<header class="sync-detail__card-header">
+						<SwapHorizontal :size="22" />
+						<h3>{{ t('openconnector', 'Mapping') }}</h3>
+					</header>
+
+					<!-- #mapping-picker-widget -->
+					<SyncMappingPicker
+						:value="draft.sourceTargetMapping"
+						:hash-value="draft.sourceHashMapping"
+						:target-source-value="draft.targetSourceMapping"
+						@update:value="(value) => updateDraft('sourceTargetMapping', value)"
+						@update:hashValue="(value) => updateDraft('sourceHashMapping', value)"
+						@update:targetSourceValue="(value) => updateDraft('targetSourceMapping', value)" />
+				</section>
+
+				<section class="sync-detail__card sync-detail__actions">
+					<header class="sync-detail__card-header">
+						<PlayCircleOutline :size="22" />
+						<h3>{{ t('openconnector', 'Actions') }}</h3>
+					</header>
+					<p class="sync-detail__hint">
+						{{ t('openconnector', 'Rules applied during each sync pass.') }}
+					</p>
+
+					<!-- #actions-list-widget -->
+					<SyncReferenceList
+						schema="rule"
+						label-key="name"
+						:value="draft.actions"
+						:placeholder="t('openconnector', 'Pick rules to run during sync')"
+						:empty-label="t('openconnector', 'No rules linked yet.')"
+						@input="(value) => updateDraft('actions', value)" />
+				</section>
+
+				<section class="sync-detail__card sync-detail__followups">
+					<header class="sync-detail__card-header">
+						<CallSplit :size="22" />
+						<h3>{{ t('openconnector', 'Follow-ups') }}</h3>
+					</header>
+					<p class="sync-detail__hint">
+						{{ t('openconnector', 'Synchronizations to trigger when this one completes.') }}
+					</p>
+
+					<!-- #followups-list-widget -->
+					<SyncReferenceList
+						schema="synchronization"
+						label-key="name"
+						:value="draft.followUps"
+						:exclude-id="objectIdString"
+						:placeholder="t('openconnector', 'Pick follow-up synchronizations')"
+						:empty-label="t('openconnector', 'No follow-ups linked yet.')"
+						@input="(value) => updateDraft('followUps', value)" />
+				</section>
+			</div>
+
+			<NcNoteCard v-if="saveError" type="error">
+				<p>{{ saveError }}</p>
+			</NcNoteCard>
+		</div>
+	</CnDetailPage>
+</template>
+
+<script>
+import {
+	NcButton,
+	NcSelect,
+	NcTextField,
+	NcLoadingIcon,
+	NcNoteCard,
+} from '@nextcloud/vue'
+import {
+	CnDetailPage,
+	useObjectStore,
+} from '@conduction/nextcloud-vue'
+import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import CallSplit from 'vue-material-design-icons/CallSplit.vue'
+import CogOutline from 'vue-material-design-icons/CogOutline.vue'
+import ContentSaveOutline from 'vue-material-design-icons/ContentSaveOutline.vue'
+import DatabaseArrowLeftOutline from 'vue-material-design-icons/DatabaseArrowLeftOutline.vue'
+import DatabaseArrowRightOutline from 'vue-material-design-icons/DatabaseArrowRightOutline.vue'
+import PlayCircleOutline from 'vue-material-design-icons/PlayCircleOutline.vue'
+import SwapHorizontal from 'vue-material-design-icons/SwapHorizontal.vue'
+import UndoIcon from 'vue-material-design-icons/Undo.vue'
+
+import SyncConfigWidget from './SyncConfigWidget.vue'
+import SyncMappingPicker from './SyncMappingPicker.vue'
+import SyncReferenceList from './SyncReferenceList.vue'
+
+const SCHEMA_SLUG = 'synchronization'
+const REGISTER_SLUG = 'openconnector'
+
+/**
+ * Polymorphic type discriminator options shared between source and
+ * target. Keep in sync with `synchronization.sourceType` /
+ * `targetType` description in `lib/Settings/openconnector_register.json`.
+ */
+const TYPE_OPTIONS = [
+	{ id: 'api', label: 'API' },
+	{ id: 'register/schema', label: 'Register/Schema' },
+	{ id: 'file', label: 'File' },
+]
+
+/**
+ * Build an empty draft for the create case. The legacy modal defaulted
+ * sourceType:'api', targetType:'register/schema' — preserve that here so
+ * a newly-routed-to record without a stored type still renders a sensible
+ * config form.
+ */
+function emptyDraft() {
+	return {
+		name: '',
+		description: '',
+		sourceType: 'api',
+		sourceId: '',
+		sourceConfig: {},
+		sourceTargetMapping: '',
+		sourceHashMapping: '',
+		targetType: 'register/schema',
+		targetId: '',
+		targetConfig: {},
+		targetSourceMapping: '',
+		actions: [],
+		followUps: [],
+	}
+}
+
+export default {
+	name: 'SynchronizationDetailPage',
+
+	components: {
+		CnDetailPage,
+		NcButton,
+		NcSelect,
+		NcTextField,
+		NcLoadingIcon,
+		NcNoteCard,
+		ArrowRight,
+		CallSplit,
+		CogOutline,
+		ContentSaveOutline,
+		DatabaseArrowLeftOutline,
+		DatabaseArrowRightOutline,
+		PlayCircleOutline,
+		SwapHorizontal,
+		UndoIcon,
+		SyncConfigWidget,
+		SyncMappingPicker,
+		SyncReferenceList,
+	},
+
+	props: {
+		/**
+		 * The route param. Forwarded by CnPageRenderer from the
+		 * `/synchronizations/:id` URL — required for fetch + save.
+		 */
+		id: { type: [String, Number], default: '' },
+		// CnPageRenderer also forwards page `config` keys; we accept and
+		// ignore them — the schema/register are hardcoded for this page.
+		register: { type: String, default: REGISTER_SLUG },
+		schema: { type: String, default: SCHEMA_SLUG },
+	},
+
+	setup() {
+		const objectStore = useObjectStore()
+		return { objectStore }
+	},
+
+	data() {
+		return {
+			loading: false,
+			saving: false,
+			saveError: '',
+			loadError: '',
+			draft: null,
+			original: null,
+		}
+	},
+
+	computed: {
+		objectIdString() {
+			return this.id != null ? String(this.id) : ''
+		},
+		registerSlug() {
+			return this.register || REGISTER_SLUG
+		},
+		schemaSlug() {
+			return this.schema || SCHEMA_SLUG
+		},
+		title() {
+			if (this.draft?.name) return this.draft.name
+			return this.original?.name || t('openconnector', 'Synchronization')
+		},
+		description() {
+			return this.original?.description || ''
+		},
+		hasError() {
+			return Boolean(this.loadError) && !this.draft
+		},
+		errorMessage() {
+			return this.loadError || t('openconnector', 'Failed to load synchronization')
+		},
+		typeOptions() {
+			return TYPE_OPTIONS
+		},
+		selectedSourceType() {
+			return TYPE_OPTIONS.find((opt) => opt.id === this.draft?.sourceType) || TYPE_OPTIONS[0]
+		},
+		selectedTargetType() {
+			return TYPE_OPTIONS.find((opt) => opt.id === this.draft?.targetType) || TYPE_OPTIONS[1]
+		},
+		dirty() {
+			if (!this.draft || !this.original) return false
+			return JSON.stringify(this.draft) !== JSON.stringify(this.normalizeForDiff(this.original))
+		},
+		canSave() {
+			return Boolean(this.draft?.name && this.draft.name.trim().length > 0)
+		},
+	},
+
+	watch: {
+		id: {
+			immediate: true,
+			handler() {
+				this.loadObject()
+			},
+		},
+	},
+
+	methods: {
+		async loadObject() {
+			if (!this.objectIdString) {
+				// New-create surface — start with empty draft.
+				this.draft = emptyDraft()
+				this.original = emptyDraft()
+				return
+			}
+			this.loading = true
+			this.loadError = ''
+			try {
+				const data = await this.objectStore.fetchObject(this.schemaSlug, this.objectIdString)
+				if (!data) {
+					this.loadError = this.objectStore.errors?.[this.schemaSlug] || t('openconnector', 'Failed to load synchronization')
+					this.draft = null
+					this.original = null
+					return
+				}
+				this.original = data
+				this.draft = this.normalizeForDiff(data)
+			} catch (err) {
+				this.loadError = err?.message || t('openconnector', 'Failed to load synchronization')
+				this.draft = null
+				this.original = null
+			} finally {
+				this.loading = false
+			}
+		},
+		/**
+		 * Clone an object into the shape the form mutates. Ensures all
+		 * fields exist (so v-model doesn't trip on `undefined`) and that
+		 * objects/arrays are independent copies — pinia replaces the
+		 * cached object on save, so we must not hold a reference to it.
+		 *
+		 * @param {object} obj Raw object from the store.
+		 * @return {object} Plain draft with all editable fields filled.
+		 */
+		normalizeForDiff(obj) {
+			const base = emptyDraft()
+			const out = { ...base }
+			for (const key of Object.keys(base)) {
+				if (obj && obj[key] !== undefined && obj[key] !== null) {
+					if (Array.isArray(base[key])) {
+						out[key] = Array.isArray(obj[key]) ? [...obj[key]] : []
+					} else if (typeof base[key] === 'object') {
+						out[key] = (typeof obj[key] === 'object' && !Array.isArray(obj[key]))
+							? { ...obj[key] }
+							: {}
+					} else {
+						out[key] = obj[key]
+					}
+				}
+			}
+			return out
+		},
+		updateDraft(key, value) {
+			if (!this.draft) return
+			this.$set(this.draft, key, value)
+		},
+		onSourceTypeChange(option) {
+			if (!option?.id || !this.draft) return
+			// Type changed — clear the kind-specific blob + id so we don't
+			// carry stale `endpoint:'/foo'` over into a register/schema mode.
+			this.$set(this.draft, 'sourceType', option.id)
+			this.$set(this.draft, 'sourceId', '')
+			this.$set(this.draft, 'sourceConfig', {})
+		},
+		onTargetTypeChange(option) {
+			if (!option?.id || !this.draft) return
+			this.$set(this.draft, 'targetType', option.id)
+			this.$set(this.draft, 'targetId', '')
+			this.$set(this.draft, 'targetConfig', {})
+		},
+		async save() {
+			if (!this.draft || this.saving) return
+			this.saving = true
+			this.saveError = ''
+			try {
+				const payload = {
+					...this.original,
+					...this.draft,
+				}
+				const saved = await this.objectStore.saveObject(this.schemaSlug, payload)
+				if (!saved) {
+					this.saveError = this.objectStore.errors?.[this.schemaSlug] || t('openconnector', 'Save failed')
+					return
+				}
+				this.original = saved
+				this.draft = this.normalizeForDiff(saved)
+			} catch (err) {
+				this.saveError = err?.message || t('openconnector', 'Save failed')
+			} finally {
+				this.saving = false
+			}
+		},
+		resetEdits() {
+			if (!this.original) return
+			this.draft = this.normalizeForDiff(this.original)
+			this.saveError = ''
+		},
+	},
+}
+</script>
+
+<style scoped>
+.sync-detail {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.sync-detail__row {
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
+	gap: 16px;
+}
+
+@media (max-width: 1100px) {
+	.sync-detail__row {
+		grid-template-columns: 1fr;
+	}
+}
+
+.sync-detail__card {
+	background: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large, 12px);
+	padding: 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.sync-detail__card-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin: 0;
+}
+
+.sync-detail__card-header h3 {
+	margin: 0;
+	font-size: 16px;
+	font-weight: bold;
+}
+
+.sync-detail__hint {
+	margin: 0;
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+}
+
+.sync-detail__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.sync-detail__label {
+	font-weight: bold;
+	font-size: 13px;
+}
+
+.sync-detail__textarea {
+	width: 100%;
+	padding: 8px;
+	font-family: var(--font-face, sans-serif);
+	font-size: 14px;
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	resize: vertical;
+}
+
+.sync-detail__flow {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 8px;
+	border: 1px dashed var(--color-border);
+	border-radius: var(--border-radius);
+	color: var(--color-text-maxcontrast);
+	font-size: 12px;
+}
+
+.sync-detail__flow-step {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary

Re-introduces the rich source/target config + mapping selector UX that the legacy 1076-LoC `EditSynchronization.vue` shipped before #827. Implemented as a new `type: custom` manifest page (`SynchronizationDetail`) wrapping `CnDetailPage` with five dedicated widget sections, reusing #867's conditional-visibility pattern.

### Components shipped

- `src/views/Synchronization/SynchronizationDetailPage.vue` — page entry, registered as a `type: custom` page; owns load/save via `useObjectStore` with a draft + dirty-flag pattern (no auto-save).
- `src/views/Synchronization/SyncConfigWidget.vue` — type-discriminator + conditional config blob editor used by both source and target sections. Branches on `api` / `register/schema` / `file`; pulls Sources and Registers from OR.
- `src/views/Synchronization/SyncMappingPicker.vue` — three NcSelect rows (sourceTargetMapping, targetSourceMapping, sourceHashMapping) populated from `/api/objects/openconnector/mapping`.
- `src/views/Synchronization/SyncReferenceList.vue` — generic multi-select for `actions[]` (rules) and `followUps[]` (sibling syncs); excludes the current sync from its own followUps.

### Wiring

- `src/manifest.json` — added `SynchronizationDetail` page (`type: custom`, `component: SynchronizationDetailPage`), routed at `/synchronizations/:id`. Ordered AFTER `SynchronizationContracts` + `SynchronizationLogs` so vue-router declaration-order honours specificity. Synchronizations index gains an "Open editor" row action.
- `src/registry.js` — registers `SynchronizationDetailPage` alongside `JobFormFields`.

### Persistence

`useObjectStore.saveObject('synchronization', payload)` — same store `CnDetailPage` subscribes to; PUT to OR via `/api/objects/openconnector/synchronization/:id`. Save and Discard buttons surface in the page header actions slot, gated on the local `dirty` computed.

### Deferred follow-ups (out of scope)

- JSON-Logic conditions array editor — legacy modal had a textarea; visual builder pending.
- Mapping preview / test surface — tracked separately under the test-mapping modal work.
- File-source path picker — currently a free-form text field; legacy didn't elaborate either, kernel side hasn't landed yet.

## Test plan

- [ ] Navigate to `/synchronizations`, click row "Open editor" — `/synchronizations/:id` route resolves to `SynchronizationDetailPage`
- [ ] All 5 widget sections render (Source, General, Target, Mapping, Actions, Follow-ups)
- [ ] Switching `sourceType` from `api` to `register/schema` swaps the source-config widget (Source picker → Register + Schema pickers)
- [ ] Switching `targetType` does the same on the target side
- [ ] Picking a mapping in the primary row updates `sourceTargetMapping` on the saved object
- [ ] Picking rules in Actions writes the slug array to `actions[]`
- [ ] Picking follow-up syncs writes the slug array to `followUps[]`; current sync is excluded from its own picker
- [ ] Save button only appears when the draft is dirty; Discard reverts the draft to the loaded record
- [ ] `npm run lint` — 0 errors (4 pre-existing parse warnings unchanged)
- [ ] `npm run build` — webpack succeeds (asset-size warnings pre-existing)