### PR TITLE
feat(rules): bespoke Rule editor with visual condition + action builder (closes #833)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -318,7 +318,8 @@
     {
       "id": "RuleDetail",
       "route": "/rules/:id",
-      "type": "detail",
+      "type": "custom",
+      "component": "RuleDetailPage",
       "title": "Rule",
       "config": {
         "register": "openconnector",

--- a/src/registry.js
+++ b/src/registry.js
@@ -42,6 +42,7 @@ import {
 	addEndpointRuleHandler,
 } from './handlers/actionHandlers.js'
 import JobFormFields from './modals/v2/JobFormFields.vue'
+import RuleDetailPage from './views/Rule/RuleDetailPage.vue'
 
 export default {
 	// Row-action handlers — referenced by manifest `config.actions[].handler` strings.
@@ -62,4 +63,12 @@ export default {
 	// (per #847). Open follow-up upstream: CnFormDialog has no native
 	// per-field `condition`/`visibleWhen` prop — tracked as a ncv issue.
 	JobFormFields,
+
+	// Full-page custom components — referenced by manifest pages whose
+	// `type` is `custom`. RuleDetailPage upgrades /rules/:id from the
+	// stock detail layout to a bespoke editor with a visual JsonLogic
+	// condition tree + action-specific parameter form (#833). The
+	// stock detail type wasn't expressive enough for the recursive
+	// condition builder, hence the promotion to a custom page.
+	RuleDetailPage,
 }

--- a/src/views/Rule/RuleActionConfig.vue
+++ b/src/views/Rule/RuleActionConfig.vue
@@ -1,0 +1,378 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  RuleActionConfig — picks the rule action type and renders the
+  parameter form for that action. Mirrors the legacy EditRule modal's
+  `typeOptions` switch but only ships rich forms for the two most-
+  used actions in v1:
+    - synchronization → Synchronization picker + "retain response"
+    - error → HTTP code + title + message + includeJsonLogicResult
+  All other action types fall through to a JSON editor for the
+  matching `configuration[<type>]` sub-object, matching what
+  RuleService::processCustomRule actually reads at evaluation time.
+
+  Picker pattern follows #867's JobFormFields.vue: load
+  synchronizations once on demand from
+  `/apps/openregister/api/objects/openconnector/synchronization`.
+
+  Out of scope (deferred to follow-up): rich forms for fetch_file,
+  write_file, save_object, extend_input, extend_external_input. Each
+  has a non-trivial param surface (file paths, schema pickers,
+  property maps) that warrants its own component — tracked as a
+  follow-up issue alongside drag-reorder.
+-->
+<template>
+	<div class="rule-action-config">
+		<div class="rule-action-config__row">
+			<label class="rule-action-config__label" :for="'rule-action-type-' + uid">
+				{{ t('openconnector', 'Action type') }}
+			</label>
+			<NcSelect
+				:input-id="'rule-action-type-' + uid"
+				:value="selectedTypeOption"
+				:options="typeOptions"
+				:clearable="false"
+				:placeholder="t('openconnector', 'Pick an action type')"
+				@input="onTypePick" />
+			<p class="rule-action-config__hint">
+				{{ t('openconnector', 'Selecting an action type changes which configuration fields are required below. The rule engine matches on this value at evaluation time.') }}
+			</p>
+		</div>
+
+		<!-- Synchronization-specific parameters -->
+		<div v-if="actionType === 'synchronization'" class="rule-action-config__params">
+			<label class="rule-action-config__label" :for="'rule-action-sync-' + uid">
+				{{ t('openconnector', 'Synchronization') }}
+			</label>
+			<NcSelect
+				:input-id="'rule-action-sync-' + uid"
+				:value="selectedSynchronization"
+				:options="synchronizationOptions"
+				:loading="synchronizationsLoading"
+				:placeholder="t('openconnector', 'Select a synchronization')"
+				@input="onSynchronizationPick" />
+			<NcCheckboxRadioSwitch
+				type="switch"
+				:checked="!!retainResponse"
+				@update:checked="onRetainResponseToggle">
+				{{ t('openconnector', 'Retain original response') }}
+			</NcCheckboxRadioSwitch>
+			<span class="rule-action-config__helper">
+				{{ t('openconnector', 'When enabled, the synchronization runs but the rule preserves the original response body instead of replacing it.') }}
+			</span>
+		</div>
+
+		<!-- Error-specific parameters -->
+		<div v-else-if="actionType === 'error'" class="rule-action-config__params">
+			<NcTextField
+				:label="t('openconnector', 'HTTP status code')"
+				type="number"
+				:value="errorCodeString"
+				placeholder="500"
+				@update:value="(value) => updateNested('error', 'code', value === '' ? null : Number(value))" />
+			<NcTextField
+				:label="t('openconnector', 'Error title')"
+				:value="errorTitle"
+				:placeholder="t('openconnector', 'Something went wrong')"
+				@update:value="(value) => updateNested('error', 'name', value)" />
+			<label class="rule-action-config__label" :for="'rule-action-error-msg-' + uid">
+				{{ t('openconnector', 'Error message') }}
+			</label>
+			<textarea
+				:id="'rule-action-error-msg-' + uid"
+				class="rule-action-config__textarea"
+				:value="errorMessage"
+				:placeholder="t('openconnector', 'We encountered an unexpected problem')"
+				rows="3"
+				@input="updateNested('error', 'message', $event.target.value)" />
+			<NcCheckboxRadioSwitch
+				type="switch"
+				:checked="!!includeJsonLogicResult"
+				@update:checked="(value) => updateNested('error', 'includeJsonLogicResult', value)">
+				{{ t('openconnector', 'Include JSON Logic results in errors array') }}
+			</NcCheckboxRadioSwitch>
+		</div>
+
+		<!-- Fallback: raw JSON editor for the matching configuration[<type>] slot -->
+		<div v-else-if="actionType" class="rule-action-config__params">
+			<label class="rule-action-config__label" :for="'rule-action-raw-' + uid">
+				{{ rawEditorLabel }}
+			</label>
+			<textarea
+				:id="'rule-action-raw-' + uid"
+				class="rule-action-config__textarea rule-action-config__textarea--code"
+				:value="rawDraft"
+				:placeholder="'{ }'"
+				spellcheck="false"
+				rows="8"
+				@input="onRawInput($event.target.value)" />
+			<span
+				class="rule-action-config__helper"
+				:class="{ 'rule-action-config__helper--error': rawError }">
+				{{ rawError || t('openconnector', 'Rich form coming in a follow-up. Edit the raw JSON for now — it is written back as configuration.{type}.', { type: actionType }) }}
+			</span>
+		</div>
+	</div>
+</template>
+
+<script>
+import {
+	NcCheckboxRadioSwitch,
+	NcSelect,
+	NcTextField,
+} from '@nextcloud/vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+/**
+ * Canonical list of rule action types. Lifted from the legacy modal's
+ * `typeOptions.options` — the rule engine in RuleService::processCustomRule
+ * and EndpointService matches the `configuration.type` value against
+ * these strings, so adding/removing here without a backend change
+ * breaks evaluation.
+ */
+const ACTION_TYPES = [
+	{ id: 'error', label: 'Error' },
+	{ id: 'mapping', label: 'Mapping' },
+	{ id: 'synchronization', label: 'Synchronization' },
+	{ id: 'javascript', label: 'JavaScript' },
+	{ id: 'authentication', label: 'Authentication' },
+	{ id: 'download', label: 'Download' },
+	{ id: 'upload', label: 'Upload' },
+	{ id: 'locking', label: 'Locking' },
+	{ id: 'fetch_file', label: 'Fetch File' },
+	{ id: 'write_file', label: 'Write File' },
+	{ id: 'fileparts_create', label: 'Fileparts Create' },
+	{ id: 'filepart_upload', label: 'Filepart Upload' },
+	{ id: 'save_object', label: 'Save object' },
+	{ id: 'extend_input', label: 'Extend input' },
+	{ id: 'extend_external_input', label: 'Extend external input' },
+]
+
+let actionUidCounter = 0
+
+export default {
+	name: 'RuleActionConfig',
+
+	components: {
+		NcCheckboxRadioSwitch,
+		NcSelect,
+		NcTextField,
+	},
+
+	props: {
+		/**
+		 * Current `configuration` blob from the rule object. The action
+		 * type lives at `configuration.type`; the action-specific
+		 * sub-config lives at `configuration[<type>]`.
+		 * @type {object}
+		 */
+		configuration: { type: Object, default: () => ({}) },
+	},
+
+	data() {
+		return {
+			uid: ++actionUidCounter,
+			synchronizationOptions: [],
+			synchronizationsLoading: false,
+			/** Draft JSON string for the fallback editor, keyed by action type. */
+			rawDrafts: {},
+			rawError: '',
+		}
+	},
+
+	computed: {
+		actionType() {
+			return this.configuration?.type || ''
+		},
+		typeOptions() {
+			return ACTION_TYPES.map((entry) => ({ id: entry.id, label: this.t('openconnector', entry.label) }))
+		},
+		selectedTypeOption() {
+			return this.typeOptions.find((option) => option.id === this.actionType) || null
+		},
+		syncConfig() {
+			const value = this.configuration?.synchronization
+			return value && typeof value === 'object' ? value : {}
+		},
+		retainResponse() {
+			return !!this.syncConfig.retainResponse
+		},
+		synchronizationId() {
+			return this.syncConfig.synchronization || this.syncConfig.synchronizationId || ''
+		},
+		selectedSynchronization() {
+			const id = String(this.synchronizationId)
+			if (!id) return null
+			return this.synchronizationOptions.find((option) => option.id === id) ?? {
+				id,
+				label: id,
+			}
+		},
+		errorConfig() {
+			const value = this.configuration?.error
+			return value && typeof value === 'object' ? value : {}
+		},
+		errorCodeString() {
+			return this.errorConfig.code != null ? String(this.errorConfig.code) : ''
+		},
+		errorTitle() {
+			return this.errorConfig.name || ''
+		},
+		errorMessage() {
+			return this.errorConfig.message || ''
+		},
+		includeJsonLogicResult() {
+			return !!this.errorConfig.includeJsonLogicResult
+		},
+		rawDraft() {
+			const draft = this.rawDrafts[this.actionType]
+			if (draft !== undefined) return draft
+			const raw = this.configuration?.[this.actionType]
+			if (raw === undefined || raw === null) return ''
+			if (typeof raw === 'string') return raw
+			try { return JSON.stringify(raw, null, 2) } catch (_e) { return String(raw) }
+		},
+		rawEditorLabel() {
+			return this.t('openconnector', 'Raw configuration for {type}', { type: this.actionType })
+		},
+	},
+
+	watch: {
+		actionType: {
+			immediate: true,
+			handler(value) {
+				if (value === 'synchronization' && this.synchronizationOptions.length === 0) {
+					this.fetchSynchronizations()
+				}
+			},
+		},
+	},
+
+	methods: {
+		onTypePick(option) {
+			if (!option) return
+			const next = { ...(this.configuration || {}), type: option.id }
+			this.$emit('update', next)
+		},
+
+		onSynchronizationPick(option) {
+			const nextSync = { ...this.syncConfig }
+			if (option?.id) {
+				nextSync.synchronization = String(option.id)
+			} else {
+				delete nextSync.synchronization
+				delete nextSync.synchronizationId
+			}
+			const next = { ...(this.configuration || {}), synchronization: nextSync }
+			this.$emit('update', next)
+		},
+
+		onRetainResponseToggle(value) {
+			const nextSync = { ...this.syncConfig, retainResponse: !!value }
+			const next = { ...(this.configuration || {}), synchronization: nextSync }
+			this.$emit('update', next)
+		},
+
+		updateNested(section, key, value) {
+			const current = this.configuration?.[section]
+			const base = current && typeof current === 'object' ? current : {}
+			const nextSection = { ...base, [key]: value }
+			const next = { ...(this.configuration || {}), [section]: nextSection }
+			this.$emit('update', next)
+		},
+
+		onRawInput(value) {
+			this.$set(this.rawDrafts, this.actionType, value)
+			const trimmed = value.trim()
+			if (trimmed.length === 0) {
+				this.rawError = ''
+				const next = { ...(this.configuration || {}) }
+				delete next[this.actionType]
+				this.$emit('update', next)
+				return
+			}
+			try {
+				const parsed = JSON.parse(trimmed)
+				this.rawError = ''
+				const next = { ...(this.configuration || {}), [this.actionType]: parsed }
+				this.$emit('update', next)
+			} catch (parseErr) {
+				this.rawError = this.t('openconnector', 'Invalid JSON: {message}', { message: parseErr.message })
+			}
+		},
+
+		async fetchSynchronizations() {
+			this.synchronizationsLoading = true
+			try {
+				const response = await axios.get(
+					generateUrl('/apps/openregister/api/objects/openconnector/synchronization'),
+					{ params: { limit: 500 } },
+				)
+				const data = response.data
+				const list = Array.isArray(data?.results)
+					? data.results
+					: Array.isArray(data)
+						? data
+						: []
+				this.synchronizationOptions = list.map((sync) => ({
+					id: String(sync.id || sync.uuid),
+					label: sync.name || sync.title || sync.id,
+				}))
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.warn('[RuleActionConfig] synchronization fetch failed', err)
+				this.synchronizationOptions = []
+			} finally {
+				this.synchronizationsLoading = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.rule-action-config {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.rule-action-config__row,
+.rule-action-config__params {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.rule-action-config__label {
+	font-weight: bold;
+}
+
+.rule-action-config__hint,
+.rule-action-config__helper {
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+}
+
+.rule-action-config__helper--error {
+	color: var(--color-error);
+}
+
+.rule-action-config__textarea {
+	width: 100%;
+	padding: 8px;
+	font-family: var(--font-face, sans-serif);
+	font-size: 14px;
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	resize: vertical;
+}
+
+.rule-action-config__textarea--code {
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 13px;
+}
+</style>

--- a/src/views/Rule/RuleConditionGroup.vue
+++ b/src/views/Rule/RuleConditionGroup.vue
@@ -1,0 +1,238 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  RuleConditionGroup — recursive boolean group in the visual condition
+  tree. Renders as `{ "and": [...children] }` or `{ "or": [...children] }`
+  JsonLogic. Each child is either another RuleConditionGroup (sub-tree)
+  or a RuleConditionLeaf (predicate).
+
+  We classify a child as a "group" when its top-level operator key is
+  exactly `and` or `or` and the value is an array; everything else is
+  treated as a leaf (the leaf component itself is forgiving about
+  malformed shapes).
+
+  MVP scope (closes #833): boolean grouping + add/remove children;
+  drag-reorder is deferred (tracked as a v2 follow-up). Users wanting
+  exotic constructs (negation around a group, comparisons across two
+  refs) can still drop down to the raw JSON editor on the parent page.
+-->
+<template>
+	<div class="rule-condition-group" data-testid="rule-condition-group">
+		<div class="rule-condition-group__header">
+			<NcSelect
+				class="rule-condition-group__op"
+				:input-id="'rule-condition-group-op-' + uid"
+				:value="selectedOperator"
+				:options="operatorOptions"
+				:clearable="false"
+				@input="onOperatorPick" />
+			<span class="rule-condition-group__hint">
+				{{ operatorHint }}
+			</span>
+			<div class="rule-condition-group__spacer" />
+			<NcButton
+				v-if="removable"
+				:aria-label="t('openconnector', 'Remove group')"
+				type="tertiary-no-background"
+				@click="$emit('remove')">
+				<template #icon>
+					<Close :size="18" />
+				</template>
+			</NcButton>
+		</div>
+		<div class="rule-condition-group__children">
+			<template v-for="(child, index) in children">
+				<RuleConditionGroup
+					v-if="isGroup(child)"
+					:key="'group-' + index"
+					:node="child"
+					:removable="true"
+					@update="(value) => updateChild(index, value)"
+					@remove="removeChild(index)" />
+				<RuleConditionLeaf
+					v-else
+					:key="'leaf-' + index"
+					:node="child"
+					@update="(value) => updateChild(index, value)"
+					@remove="removeChild(index)" />
+			</template>
+			<NcEmptyContent
+				v-if="children.length === 0"
+				:name="t('openconnector', 'No conditions yet')"
+				:description="t('openconnector', 'Add a condition or sub-group to start matching incoming data.')">
+				<template #icon>
+					<FilterVariant :size="32" />
+				</template>
+			</NcEmptyContent>
+		</div>
+		<div class="rule-condition-group__actions">
+			<NcButton type="secondary" @click="addLeaf">
+				<template #icon>
+					<Plus :size="18" />
+				</template>
+				{{ t('openconnector', 'Add condition') }}
+			</NcButton>
+			<NcButton type="tertiary" @click="addGroup">
+				<template #icon>
+					<FormatListGroup :size="18" />
+				</template>
+				{{ t('openconnector', 'Add group') }}
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcEmptyContent, NcSelect } from '@nextcloud/vue'
+import Close from 'vue-material-design-icons/Close.vue'
+import FilterVariant from 'vue-material-design-icons/FilterVariant.vue'
+import FormatListGroup from 'vue-material-design-icons/FormatListGroup.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import RuleConditionLeaf from './RuleConditionLeaf.vue'
+
+let groupUidCounter = 0
+
+const GROUP_OPERATORS = ['and', 'or']
+
+export default {
+	name: 'RuleConditionGroup',
+
+	components: {
+		NcButton,
+		NcEmptyContent,
+		NcSelect,
+		Close,
+		FilterVariant,
+		FormatListGroup,
+		Plus,
+		RuleConditionLeaf,
+	},
+
+	props: {
+		/**
+		 * JsonLogic group node — `{ and: [...] }` or `{ or: [...] }`.
+		 * Anything else gets coerced to an empty `and` group so the
+		 * UI never shows an inconsistent root.
+		 *
+		 * @type {object}
+		 */
+		node: { type: Object, default: () => ({ and: [] }) },
+		/**
+		 * Whether to render the per-group remove button. The root
+		 * group on the parent page sets this to false so the user
+		 * cannot delete the whole condition tree by accident.
+		 */
+		removable: { type: Boolean, default: false },
+	},
+
+	data() {
+		return {
+			uid: ++groupUidCounter,
+		}
+	},
+
+	computed: {
+		currentOperator() {
+			const keys = Object.keys(this.node || {})
+			const found = keys.find((key) => GROUP_OPERATORS.includes(key))
+			return found || 'and'
+		},
+		children() {
+			const value = this.node?.[this.currentOperator]
+			return Array.isArray(value) ? value : []
+		},
+		operatorOptions() {
+			return [
+				{ id: 'and', label: this.t('openconnector', 'ALL of (AND)') },
+				{ id: 'or', label: this.t('openconnector', 'ANY of (OR)') },
+			]
+		},
+		selectedOperator() {
+			return this.operatorOptions.find((option) => option.id === this.currentOperator)
+				?? this.operatorOptions[0]
+		},
+		operatorHint() {
+			return this.currentOperator === 'and'
+				? this.t('openconnector', 'Every child below must match.')
+				: this.t('openconnector', 'At least one child below must match.')
+		},
+	},
+
+	methods: {
+		isGroup(child) {
+			if (!child || typeof child !== 'object' || Array.isArray(child)) return false
+			const keys = Object.keys(child)
+			return keys.length === 1 && GROUP_OPERATORS.includes(keys[0]) && Array.isArray(child[keys[0]])
+		},
+		onOperatorPick(option) {
+			if (!option) return
+			this.$emit('update', { [option.id]: this.children.slice() })
+		},
+		updateChild(index, value) {
+			const next = this.children.slice()
+			next[index] = value
+			this.$emit('update', { [this.currentOperator]: next })
+		},
+		removeChild(index) {
+			const next = this.children.slice()
+			next.splice(index, 1)
+			this.$emit('update', { [this.currentOperator]: next })
+		},
+		addLeaf() {
+			const next = this.children.slice()
+			next.push({ '==': [{ var: '' }, ''] })
+			this.$emit('update', { [this.currentOperator]: next })
+		},
+		addGroup() {
+			const next = this.children.slice()
+			next.push({ and: [] })
+			this.$emit('update', { [this.currentOperator]: next })
+		},
+	},
+}
+</script>
+
+<style scoped>
+.rule-condition-group {
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+	padding: 12px;
+	background: var(--color-main-background);
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.rule-condition-group__header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.rule-condition-group__op {
+	min-width: 220px;
+}
+
+.rule-condition-group__hint {
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+}
+
+.rule-condition-group__spacer {
+	flex: 1;
+}
+
+.rule-condition-group__children {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding-left: 16px;
+	border-left: 2px solid var(--color-border);
+}
+
+.rule-condition-group__actions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+</style>

--- a/src/views/Rule/RuleConditionLeaf.vue
+++ b/src/views/Rule/RuleConditionLeaf.vue
@@ -1,0 +1,232 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  RuleConditionLeaf — one predicate in the visual condition tree.
+
+  A leaf is a (var, operator, value) triple. JsonLogic represents this
+  as `{ "<op>": [ { "var": "<path>" }, <literal> ] }` for binary ops,
+  or `{ "<op>": [ { "var": "<path>" } ] }` for unary ones (e.g. `!`,
+  `!!`). This component owns the inputs for those three slots and
+  emits the rebuilt JsonLogic node up to RuleConditionGroup.
+
+  Scope is MVP: a hand-picked subset of operators (==, !=, >, >=, <,
+  <=, in, !in, exists). String/number/boolean values share one text
+  input — JsonLogic is type-flexible at evaluation time, so coercion
+  is deferred to the rule engine. The advanced operators (`some`,
+  `all`, regex `match`, arithmetic) are out of scope for v1; users
+  who need them can still hand-edit the JSON via the raw editor
+  fallback in RuleDetailPage.
+
+  Closes #833 (leaf-half of the visual builder).
+-->
+<template>
+	<div class="rule-condition-leaf" data-testid="rule-condition-leaf">
+		<NcTextField
+			class="rule-condition-leaf__var"
+			:label="t('openconnector', 'Field')"
+			:value="varPath"
+			:placeholder="t('openconnector', 'e.g. body.status')"
+			@update:value="onVarInput" />
+		<NcSelect
+			class="rule-condition-leaf__op"
+			:input-id="'rule-condition-op-' + uid"
+			:value="selectedOperator"
+			:options="operatorOptions"
+			:clearable="false"
+			:placeholder="t('openconnector', 'Operator')"
+			@input="onOperatorPick" />
+		<NcTextField
+			v-if="needsValue"
+			class="rule-condition-leaf__value"
+			:label="t('openconnector', 'Value')"
+			:value="valueString"
+			:placeholder="t('openconnector', 'Comparison value')"
+			@update:value="onValueInput" />
+		<span v-else class="rule-condition-leaf__value rule-condition-leaf__value--placeholder">
+			{{ t('openconnector', '(no value needed)') }}
+		</span>
+		<NcButton
+			class="rule-condition-leaf__remove"
+			:aria-label="t('openconnector', 'Remove condition')"
+			type="tertiary-no-background"
+			@click="$emit('remove')">
+			<template #icon>
+				<Close :size="18" />
+			</template>
+		</NcButton>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcSelect, NcTextField } from '@nextcloud/vue'
+import Close from 'vue-material-design-icons/Close.vue'
+
+/**
+ * Operators the visual builder exposes. Each entry maps a JsonLogic
+ * operator string to a human label plus a flag for whether the
+ * second operand (the value) is required. Unary operators (`!`, `!!`)
+ * are emitted with a single-element args array.
+ *
+ * @type {Array<{ id: string, label: string, unary: boolean }>}
+ */
+const OPERATORS = [
+	{ id: '==', label: 'equals', unary: false },
+	{ id: '!=', label: 'does not equal', unary: false },
+	{ id: '>', label: 'greater than', unary: false },
+	{ id: '>=', label: 'greater than or equal', unary: false },
+	{ id: '<', label: 'less than', unary: false },
+	{ id: '<=', label: 'less than or equal', unary: false },
+	{ id: 'in', label: 'in (string contains / array member)', unary: false },
+	{ id: '!!', label: 'exists / truthy', unary: true },
+	{ id: '!', label: 'missing / falsy', unary: true },
+]
+
+let leafUidCounter = 0
+
+export default {
+	name: 'RuleConditionLeaf',
+
+	components: {
+		NcButton,
+		NcSelect,
+		NcTextField,
+		Close,
+	},
+
+	props: {
+		/**
+		 * The JsonLogic node this leaf renders. Shape is one of:
+		 *   `{ "<op>": [ { "var": "<path>" }, <literal> ] }` (binary)
+		 *   `{ "<op>": [ { "var": "<path>" } ] }`            (unary)
+		 *
+		 * Anything else is treated as an empty leaf so the UI never
+		 * blanks the user out of a malformed-but-recoverable node.
+		 *
+		 * @type {object}
+		 */
+		node: { type: Object, default: () => ({ '==': [{ var: '' }, ''] }) },
+	},
+
+	data() {
+		return {
+			uid: ++leafUidCounter,
+		}
+	},
+
+	computed: {
+		operatorOptions() {
+			return OPERATORS.map((op) => ({ id: op.id, label: this.t('openconnector', op.label) }))
+		},
+		currentOperator() {
+			const keys = Object.keys(this.node || {})
+			const op = keys.find((key) => OPERATORS.some((entry) => entry.id === key))
+			return op || '=='
+		},
+		selectedOperator() {
+			return this.operatorOptions.find((option) => option.id === this.currentOperator)
+				?? this.operatorOptions[0]
+		},
+		needsValue() {
+			const op = OPERATORS.find((entry) => entry.id === this.currentOperator)
+			return op ? !op.unary : true
+		},
+		args() {
+			const value = this.node?.[this.currentOperator]
+			return Array.isArray(value) ? value : []
+		},
+		varPath() {
+			const first = this.args[0]
+			if (first && typeof first === 'object' && Object.prototype.hasOwnProperty.call(first, 'var')) {
+				return String(first.var ?? '')
+			}
+			if (typeof first === 'string') return first
+			return ''
+		},
+		rawValue() {
+			return this.args.length > 1 ? this.args[1] : ''
+		},
+		valueString() {
+			const raw = this.rawValue
+			if (raw === null || raw === undefined) return ''
+			if (typeof raw === 'object') {
+				try { return JSON.stringify(raw) } catch (_e) { return String(raw) }
+			}
+			return String(raw)
+		},
+	},
+
+	methods: {
+		onVarInput(value) {
+			this.emitUpdate({ varPath: value })
+		},
+		onOperatorPick(option) {
+			if (!option) return
+			this.emitUpdate({ operator: option.id })
+		},
+		onValueInput(value) {
+			this.emitUpdate({ rawValue: this.coerce(value) })
+		},
+		/**
+		 * Best-effort literal coercion. Numbers and booleans get
+		 * recognised so JsonLogic's `>`/`<` actually compare numerics
+		 * instead of lexicographic strings. Anything else stays as a
+		 * string — users wanting nested var refs or complex literals
+		 * are expected to drop down to the raw JSON editor.
+		 *
+		 * @param {string} raw User-entered text.
+		 * @return {*} Coerced value.
+		 */
+		coerce(raw) {
+			if (raw === '') return ''
+			if (raw === 'true') return true
+			if (raw === 'false') return false
+			if (raw === 'null') return null
+			if (/^-?\d+$/.test(raw)) return Number(raw)
+			if (/^-?\d+\.\d+$/.test(raw)) return Number(raw)
+			return raw
+		},
+		/**
+		 * Rebuild the JsonLogic node and emit. Done in one place so
+		 * the operator change can both flip the operator key AND
+		 * trim the value arg for unary operators.
+		 *
+		 * @param {{ varPath?: string, operator?: string, rawValue?: * }} patch
+		 *   Partial change — fields omitted come from current state.
+		 * @return {void}
+		 */
+		emitUpdate(patch) {
+			const operator = patch.operator ?? this.currentOperator
+			const varPath = patch.varPath ?? this.varPath
+			const opEntry = OPERATORS.find((entry) => entry.id === operator)
+			const isUnary = !!opEntry?.unary
+			const value = isUnary ? undefined : (patch.rawValue !== undefined ? patch.rawValue : this.rawValue)
+			const args = isUnary ? [{ var: varPath }] : [{ var: varPath }, value]
+			this.$emit('update', { [operator]: args })
+		},
+	},
+}
+</script>
+
+<style scoped>
+.rule-condition-leaf {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 220px minmax(0, 1fr) auto;
+	gap: 8px;
+	align-items: end;
+	padding: 8px;
+	background: var(--color-background-hover);
+	border-radius: var(--border-radius);
+}
+
+.rule-condition-leaf__value--placeholder {
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+	padding: 8px 0;
+}
+
+@media (max-width: 720px) {
+	.rule-condition-leaf {
+		grid-template-columns: 1fr;
+	}
+}
+</style>

--- a/src/views/Rule/RuleDetailPage.vue
+++ b/src/views/Rule/RuleDetailPage.vue
@@ -1,0 +1,441 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  RuleDetailPage — bespoke `type: custom` page wrapping CnDetailPage to
+  give Rules the visual condition + action builder the legacy
+  EditRule modal never had.
+
+  Why a full custom page (not just an index-page slot like JobFormFields)?
+  CnIndexPage's CnFormDialog gives you per-field overrides, but Rules
+  need three structurally-distinct surfaces on the same edit screen:
+    1. Basic fields (name/description/timing/order)
+    2. A recursive condition tree (this is what's actually NEW vs #828)
+    3. An action picker + action-specific parameter form
+
+  Trying to cram (2) and (3) into a dialog produced an editor that was
+  visually-cramped + impossible to keep open while testing the resulting
+  rule against incoming data. Promoting the rule edit surface to a
+  full page mirrors what the legacy 1888-LoC modal effectively was,
+  just decomposed into reusable Vue components.
+
+  Data flow:
+    - Mount → register `rule` object type → fetchObject(`rule`, id)
+    - The fetched object is the source of truth; local `draft` is a
+      shallow clone the user edits.
+    - Save → saveObject(`rule`, draft) → re-set the draft from the
+      server response (handles slug/uuid/updated normalisation).
+
+  Tracked deferrals (filed as v2 follow-ups):
+    - Drag-reorder children within a group
+    - Rich parameter forms for fetch_file / write_file / save_object /
+      extend_input / extend_external_input (currently fall through to
+      raw JSON via RuleActionConfig)
+    - Operator extensions in RuleConditionLeaf (some/all/regex)
+
+  Closes #833.
+-->
+<template>
+	<CnDetailPage
+		:title="pageTitle"
+		:description="t('openconnector', 'Configure when this rule fires and what it does. Conditions are evaluated as JSON Logic against the incoming request/data.')"
+		icon="icon-toggle"
+		:loading="loading"
+		:error="!!error"
+		:error-message="errorMessage"
+		:on-retry="onRetry"
+		:empty="!loading && !error && !draft">
+		<template #actions>
+			<NcButton
+				type="secondary"
+				:disabled="saving"
+				@click="onCancel">
+				{{ t('openconnector', 'Cancel') }}
+			</NcButton>
+			<NcButton
+				type="primary"
+				:disabled="saving || !dirty"
+				@click="onSave">
+				<template #icon>
+					<NcLoadingIcon v-if="saving" :size="20" />
+					<ContentSave v-else :size="20" />
+				</template>
+				{{ saving ? t('openconnector', 'Saving…') : t('openconnector', 'Save') }}
+			</NcButton>
+		</template>
+
+		<!-- Basic fields -->
+		<CnDetailCard :title="t('openconnector', 'Basics')" icon="icon-info">
+			<div class="rule-detail-page__grid">
+				<NcTextField
+					:label="t('openconnector', 'Name')"
+					:value="draft && draft.name ? String(draft.name) : ''"
+					@update:value="(value) => updateField('name', value)" />
+				<NcTextField
+					:label="t('openconnector', 'Timing')"
+					:value="draft && draft.timing ? String(draft.timing) : ''"
+					:placeholder="t('openconnector', 'e.g. before, after, on_error')"
+					@update:value="(value) => updateField('timing', value)" />
+				<NcTextField
+					:label="t('openconnector', 'Order')"
+					type="number"
+					:value="draft && draft.order != null ? String(draft.order) : ''"
+					:placeholder="'0'"
+					@update:value="(value) => updateField('order', value === '' ? null : Number(value))" />
+				<div class="rule-detail-page__grid-full">
+					<label class="rule-detail-page__label" :for="'rule-description'">
+						{{ t('openconnector', 'Description') }}
+					</label>
+					<textarea
+						id="rule-description"
+						class="rule-detail-page__textarea"
+						:value="draft && draft.description ? String(draft.description) : ''"
+						rows="3"
+						@input="updateField('description', $event.target.value)" />
+				</div>
+			</div>
+		</CnDetailCard>
+
+		<!-- Visual condition builder -->
+		<CnDetailCard
+			id="conditions-builder"
+			:title="t('openconnector', 'When (conditions)')"
+			icon="icon-filter">
+			<template #actions>
+				<NcButton
+					type="tertiary"
+					:aria-label="rawConditions ? t('openconnector', 'Switch back to visual builder') : t('openconnector', 'Edit conditions as raw JSON')"
+					@click="rawConditions = !rawConditions">
+					<template #icon>
+						<CodeJson :size="18" />
+					</template>
+					{{ rawConditions ? t('openconnector', 'Visual builder') : t('openconnector', 'Raw JSON') }}
+				</NcButton>
+			</template>
+			<RuleConditionGroup
+				v-if="!rawConditions"
+				:node="rootConditionGroup"
+				:removable="false"
+				@update="onConditionsUpdate" />
+			<div v-else class="rule-detail-page__raw-conditions">
+				<textarea
+					class="rule-detail-page__textarea rule-detail-page__textarea--code"
+					:value="rawConditionsDraft"
+					spellcheck="false"
+					rows="10"
+					@input="onRawConditionsInput($event.target.value)" />
+				<span
+					class="rule-detail-page__helper"
+					:class="{ 'rule-detail-page__helper--error': rawConditionsError }">
+					{{ rawConditionsError || t('openconnector', 'Edit the JSON Logic directly. Saved into the rule conditions field exactly as typed.') }}
+				</span>
+			</div>
+		</CnDetailCard>
+
+		<!-- Action picker + per-action parameter form -->
+		<CnDetailCard
+			id="action-config"
+			:title="t('openconnector', 'Then (action)')"
+			icon="icon-play">
+			<RuleActionConfig
+				:configuration="draft && draft.configuration ? draft.configuration : {}"
+				@update="onConfigurationUpdate" />
+		</CnDetailCard>
+	</CnDetailPage>
+</template>
+
+<script>
+import {
+	NcButton,
+	NcLoadingIcon,
+	NcTextField,
+} from '@nextcloud/vue'
+import { CnDetailCard, CnDetailPage, useObjectStore } from '@conduction/nextcloud-vue'
+import CodeJson from 'vue-material-design-icons/CodeJson.vue'
+import ContentSave from 'vue-material-design-icons/ContentSave.vue'
+import RuleConditionGroup from './RuleConditionGroup.vue'
+import RuleActionConfig from './RuleActionConfig.vue'
+
+const OBJECT_TYPE = 'rule'
+
+/**
+ * Default empty root-group used when a rule has no conditions yet (or
+ * when the persisted value is not a recognisable group). Mirrors what
+ * RuleConditionGroup itself falls back to, but centralised here so the
+ * "raw JSON" editor and the visual builder both round-trip the same
+ * default shape.
+ */
+const EMPTY_ROOT_GROUP = { and: [] }
+
+export default {
+	name: 'RuleDetailPage',
+
+	components: {
+		NcButton,
+		NcLoadingIcon,
+		NcTextField,
+		CnDetailCard,
+		CnDetailPage,
+		CodeJson,
+		ContentSave,
+		RuleConditionGroup,
+		RuleActionConfig,
+	},
+
+	props: {
+		/** Route param `:id` — the rule's UUID (forwarded by CnPageRenderer). */
+		id: { type: [String, Number], default: '' },
+		/** Manifest `config.register` — passed through resolvedProps. */
+		register: { type: String, default: 'openconnector' },
+		/** Manifest `config.schema` — passed through resolvedProps. */
+		schema: { type: String, default: 'rule' },
+	},
+
+	setup(props) {
+		const objectStore = useObjectStore()
+		if (typeof objectStore.registerObjectType === 'function') {
+			objectStore.registerObjectType(OBJECT_TYPE, props.schema || 'rule', props.register || 'openconnector')
+		}
+		return { objectStore }
+	},
+
+	data() {
+		return {
+			/** Local working copy of the rule object. Null until first fetch resolves. */
+			draft: null,
+			/** Snapshot of the last persisted version — used to compute `dirty`. */
+			pristine: null,
+			loading: false,
+			saving: false,
+			error: null,
+			rawConditions: false,
+			rawConditionsDraft: '',
+			rawConditionsError: '',
+		}
+	},
+
+	computed: {
+		pageTitle() {
+			if (!this.draft) return this.t('openconnector', 'Rule')
+			return this.draft.name ? `${this.t('openconnector', 'Rule')}: ${this.draft.name}` : this.t('openconnector', 'Rule')
+		},
+		errorMessage() {
+			if (!this.error) return ''
+			if (typeof this.error === 'string') return this.error
+			return this.error.message || this.t('openconnector', 'An error occurred')
+		},
+		/**
+		 * The conditions JsonLogic node coerced into a top-level group
+		 * shape (`{and:[...]}` or `{or:[...]}`). Legacy data may have
+		 * stored conditions as a string (CodeMirror text), an array,
+		 * or a single leaf — all of those normalise here so the visual
+		 * builder always has a group to render.
+		 */
+		rootConditionGroup() {
+			const raw = this.draft?.conditions
+			return this.normaliseConditions(raw)
+		},
+		dirty() {
+			if (!this.draft || !this.pristine) return false
+			try {
+				return JSON.stringify(this.draft) !== JSON.stringify(this.pristine)
+			} catch (_e) {
+				return true
+			}
+		},
+	},
+
+	watch: {
+		id: {
+			immediate: true,
+			handler(value) {
+				if (value) this.load()
+			},
+		},
+		rawConditions(value) {
+			if (value) {
+				try {
+					this.rawConditionsDraft = JSON.stringify(this.rootConditionGroup, null, 2)
+					this.rawConditionsError = ''
+				} catch (_e) {
+					this.rawConditionsDraft = ''
+				}
+			}
+		},
+	},
+
+	methods: {
+		/**
+		 * Normalise persisted `conditions` into a root group node.
+		 * Accepts:
+		 *   - null/undefined → empty AND
+		 *   - JSON string (legacy CodeMirror text) → parse + recurse
+		 *   - Array → wrap as `{and: [...]}`
+		 *   - Leaf object → wrap as `{and: [<leaf>]}`
+		 *   - Group object (and/or) → returned as-is
+		 *
+		 * Centralising here means the visual builder gets a sane root
+		 * even from older rule rows that were saved via the legacy
+		 * raw-JSON editor.
+		 *
+		 * @param {*} raw The persisted conditions value.
+		 * @return {object} A JsonLogic group node.
+		 */
+		normaliseConditions(raw) {
+			if (raw === null || raw === undefined || raw === '') {
+				return { ...EMPTY_ROOT_GROUP }
+			}
+			if (typeof raw === 'string') {
+				try { return this.normaliseConditions(JSON.parse(raw)) } catch (_e) { return { ...EMPTY_ROOT_GROUP } }
+			}
+			if (Array.isArray(raw)) {
+				return { and: raw }
+			}
+			if (typeof raw === 'object') {
+				const keys = Object.keys(raw)
+				if (keys.length === 1 && (keys[0] === 'and' || keys[0] === 'or') && Array.isArray(raw[keys[0]])) {
+					return raw
+				}
+				return { and: [raw] }
+			}
+			return { ...EMPTY_ROOT_GROUP }
+		},
+
+		async load() {
+			this.loading = true
+			this.error = null
+			try {
+				const fetched = await this.objectStore.fetchObject(OBJECT_TYPE, this.id)
+				if (!fetched) {
+					const storeError = this.objectStore.errors?.[OBJECT_TYPE]
+					this.error = storeError || new Error(this.t('openconnector', 'Rule not found'))
+					return
+				}
+				this.draft = JSON.parse(JSON.stringify(fetched))
+				this.pristine = JSON.parse(JSON.stringify(fetched))
+			} catch (err) {
+				this.error = err
+			} finally {
+				this.loading = false
+			}
+		},
+
+		updateField(key, value) {
+			if (!this.draft) return
+			this.$set(this.draft, key, value)
+		},
+
+		onConditionsUpdate(node) {
+			if (!this.draft) return
+			this.$set(this.draft, 'conditions', node)
+		},
+
+		onConfigurationUpdate(next) {
+			if (!this.draft) return
+			this.$set(this.draft, 'configuration', next)
+		},
+
+		onRawConditionsInput(value) {
+			this.rawConditionsDraft = value
+			const trimmed = value.trim()
+			if (trimmed.length === 0) {
+				this.rawConditionsError = ''
+				this.onConditionsUpdate({ ...EMPTY_ROOT_GROUP })
+				return
+			}
+			try {
+				const parsed = JSON.parse(trimmed)
+				this.rawConditionsError = ''
+				this.onConditionsUpdate(parsed)
+			} catch (parseErr) {
+				this.rawConditionsError = this.t('openconnector', 'Invalid JSON: {message}', { message: parseErr.message })
+			}
+		},
+
+		async onSave() {
+			if (!this.draft || this.saving) return
+			this.saving = true
+			this.error = null
+			try {
+				const saved = await this.objectStore.saveObject(OBJECT_TYPE, this.draft)
+				if (!saved) {
+					const storeError = this.objectStore.errors?.[OBJECT_TYPE]
+					this.error = storeError || new Error(this.t('openconnector', 'Saving failed'))
+					return
+				}
+				this.draft = JSON.parse(JSON.stringify(saved))
+				this.pristine = JSON.parse(JSON.stringify(saved))
+			} catch (err) {
+				this.error = err
+			} finally {
+				this.saving = false
+			}
+		},
+
+		onCancel() {
+			if (!this.pristine) return
+			this.draft = JSON.parse(JSON.stringify(this.pristine))
+			this.rawConditionsError = ''
+			if (this.rawConditions) {
+				try {
+					this.rawConditionsDraft = JSON.stringify(this.rootConditionGroup, null, 2)
+				} catch (_e) { /* noop */ }
+			}
+		},
+
+		onRetry() {
+			this.load()
+		},
+	},
+}
+</script>
+
+<style scoped>
+.rule-detail-page__grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+	gap: 12px;
+}
+
+.rule-detail-page__grid-full {
+	grid-column: 1 / -1;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.rule-detail-page__label {
+	font-weight: bold;
+}
+
+.rule-detail-page__textarea {
+	width: 100%;
+	padding: 8px;
+	font-family: var(--font-face, sans-serif);
+	font-size: 14px;
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	resize: vertical;
+}
+
+.rule-detail-page__textarea--code {
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 13px;
+}
+
+.rule-detail-page__raw-conditions {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.rule-detail-page__helper {
+	color: var(--color-text-maxcontrast);
+	font-size: 12px;
+}
+
+.rule-detail-page__helper--error {
+	color: var(--color-error);
+}
+</style>


### PR DESCRIPTION
## Summary

Closes #833. Replaces the legacy 1888-LoC `EditRule.vue` modal with a bespoke `RuleDetailPage` (`type: custom`) that finally gives Rules the visual condition + action builder the JSON-textarea modal never had.

Three composable surfaces on one page:

- **Basics card** — name, description, timing, order via plain inputs.
- **Conditions builder** (`#conditions-builder`) — recursive `RuleConditionGroup` (AND/OR) containing `RuleConditionLeaf` predicates (var/operator/value). Emits JsonLogic exactly as the rule engine consumes it (`RuleService::processCustomRule` + `EndpointService::checkRuleConditions`). Toggle to raw JSON editor for power users.
- **Action config** (`#action-config`) — `RuleActionConfig` with the 15 canonical action types + rich forms for `synchronization` (sync picker reusing the #867/#847 pattern) and `error` (code/title/message/includeJsonLogicResult). Other action types fall through to a raw JSON editor for `configuration[<type>]`.

Persistence is via `useObjectStore` on the `rule` slug; the page registers the object type on mount, fetches on `id` change, saves on dirty-only, and round-trips the server response.

## Components shipped

- `src/views/Rule/RuleDetailPage.vue` — wraps `CnDetailPage`, registers in `customComponents` as `RuleDetailPage`.
- `src/views/Rule/RuleConditionGroup.vue` — recursive AND/OR group.
- `src/views/Rule/RuleConditionLeaf.vue` — single predicate row with operator dropdown (==, !=, >, >=, <, <=, in, !!, !).
- `src/views/Rule/RuleActionConfig.vue` — action picker + per-action parameter form.
- Manifest: `RuleDetail` upgraded from `type: detail` to `type: custom` + `component: RuleDetailPage`.
- Registry: `RuleDetailPage` added to the customComponents map.

## Deferred follow-ups (v2)

- Drag-reorder within a group (MVP relies on add-then-delete).
- Rich parameter forms for `fetch_file` / `write_file` / `save_object` / `extend_input` / `extend_external_input` — each non-trivial enough to warrant its own component, currently usable via the raw JSON fallback.
- Extended JsonLogic operators in `RuleConditionLeaf` (`some` / `all` / regex / arithmetic) — same raw-JSON escape hatch.

## Test plan

- [ ] `/rules` → click a row → page renders with header + three cards (Basics, When, Then)
- [ ] Add condition / add group / remove condition / toggle AND↔OR persists the JsonLogic shape
- [ ] Switch to "Raw JSON" view, edit, switch back — value round-trips through the visual builder
- [ ] Pick action type `Synchronization` → sync picker loads + selection writes back as `configuration.synchronization.synchronization`
- [ ] Pick action type `Error` → code/title/message inputs write back under `configuration.error.*`
- [ ] Pick an action type with no rich form → raw JSON editor appears for `configuration[<type>]`
- [ ] Save persists; cancel restores pristine; dirty-tracking disables Save when unchanged