### PR TITLE
feat(logs): pre-filter logs page by parent row (closes #837)

### DIFF
--- a/src/handlers/actionHandlers.js
+++ b/src/handlers/actionHandlers.js
@@ -32,6 +32,7 @@ import {
 	EVENT_OPEN_TEST_MAPPING,
 	EVENT_OPEN_ADD_ENDPOINT_RULE,
 } from './modalBus.js'
+import { getRouter } from './routerRef.js'
 
 /**
  * Extract a stable id from a row. OR returns rows with `id` set; legacy
@@ -153,4 +154,65 @@ export function testMappingModalHandler({ item }) {
  */
 export function addEndpointRuleHandler({ item }) {
 	modalBus.$emit(EVENT_OPEN_ADD_ENDPOINT_RULE, { endpoint: item })
+}
+
+// Query-aware "View logs" navigation. See #837 + nc-vue#330.
+//
+// Each parent index page (Sources / Endpoints / Jobs / Synchronizations /
+// CloudEvents) has a "View logs" row action that navigates to the
+// corresponding *Logs page. Using `handler: "navigate"` lands on the
+// UNFILTERED log list and forces the user to filter manually. This
+// handler pushes the same route with `?<queryParam>=<rowId>` on the URL
+// so the destination log page can pre-apply the filter.
+//
+// The destination route + query-param key are looked up by `actionId`
+// rather than passed through manifest fields, because the nc-vue
+// registry-handler signature (`{ actionId, item }`) does not forward the
+// rest of the action object — adding fields like `queryParam` on the
+// manifest requires nc-vue#330 to land first. Once that PR ships, this
+// handler can be deleted and the manifest entries can go back to
+// `handler: "navigate"` with a declarative `queryParam` field.
+const VIEW_LOGS_TARGETS = {
+	'view-source-logs': { route: 'SourceLogs', queryParam: 'source' },
+	'view-endpoint-logs': { route: 'EndpointLogs', queryParam: 'endpoint' },
+	'view-job-logs': { route: 'JobLogs', queryParam: 'job' },
+	'view-synchronization-logs': { route: 'SynchronizationLogs', queryParam: 'synchronization' },
+	'view-cloud-event-logs': { route: 'CloudEventLogs', queryParam: 'event' },
+}
+
+/**
+ * Navigate from a parent index row to the corresponding logs page with
+ * the parent id pre-filled as a URL query param.
+ *
+ * Resolves the destination route + query-param key from
+ * `VIEW_LOGS_TARGETS` keyed by `actionId`. Falls back to the unfiltered
+ * route when the action id is unknown (defensive — keeps the existing
+ * "go to logs" UX rather than dead-clicking).
+ *
+ * @param {{ actionId: string, item: object }} ctx Row-action context from CnIndexPage.
+ */
+export function viewLogsHandler({ actionId, item }) {
+	const target = VIEW_LOGS_TARGETS[actionId]
+	if (!target) {
+		// eslint-disable-next-line no-console
+		console.warn(`[openconnector] viewLogsHandler: unknown actionId "${actionId}"`)
+		return
+	}
+	const router = getRouter()
+	if (!router) {
+		// eslint-disable-next-line no-console
+		console.warn('[openconnector] viewLogsHandler: router not set; cannot navigate')
+		return
+	}
+	router.push({
+		name: target.route,
+		query: { [target.queryParam]: rowId(item) },
+	}).catch((err) => {
+		// vue-router throws NavigationDuplicated when pushing the same
+		// route twice; swallow that specific case, surface anything else.
+		if (err && err.name !== 'NavigationDuplicated') {
+			// eslint-disable-next-line no-console
+			console.warn('[openconnector] viewLogsHandler navigation failed', err)
+		}
+	})
 }

--- a/src/handlers/routerRef.js
+++ b/src/handlers/routerRef.js
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Module-scoped vue-router holder. main.js sets the reference once the
+// router is constructed; row-action handlers in `actionHandlers.js` read
+// it to perform query-aware navigation (`viewLogsHandler` for #837).
+//
+// Why not use `this.$router` inside the handler? CnIndexPage's
+// `resolveHandler` invokes registry handlers with `{ actionId, item }` —
+// no Vue component context, no `$router`. We avoid changing nc-vue's
+// handler signature contract by stashing the router instance here at
+// app boot and pulling it from a 2-line side-effect import.
+//
+// The reserved-keyword `handler: "navigate"` does NOT need this — that
+// path runs inside CnIndexPage where `this.$router` is available. This
+// holder exists strictly for the custom-registry path until nc-vue#330
+// (queryParam on the navigate handler + CnLogsPage filter pre-fill) ships.
+
+let routerInstance = null
+
+/**
+ * Store the app's vue-router instance for later retrieval by registry
+ * handlers. Idempotent — calling twice with the same instance is fine;
+ * calling with a different instance overwrites (test harnesses do this).
+ *
+ * @param {import('vue-router').default} router The constructed router.
+ */
+export function setRouter(router) {
+	routerInstance = router
+}
+
+/**
+ * Retrieve the app's vue-router instance. Returns null when called
+ * before `setRouter` (e.g. in unit tests that import the handler in
+ * isolation). Callers MUST handle the null case — typically a
+ * console.warn + early return.
+ *
+ * @return {import('vue-router').default|null}
+ */
+export function getRouter() {
+	return routerInstance
+}

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ import pinia from './pinia.js'
 import App from './App.vue'
 import bundledManifest from './manifest.json'
 import customComponents from './registry.js'
+import { setRouter } from './handlers/routerRef.js'
 
 // Library CSS — must be an explicit import (webpack tree-shakes side-effect imports from aliased packages)
 import '@conduction/nextcloud-vue/css/index.css'
@@ -88,6 +89,14 @@ const router = new VueRouter({
 	base: generateUrl('/apps/openconnector'),
 	routes: routesFromManifest(bundledManifest),
 })
+
+// Expose the router instance to registry-resolved row-action handlers
+// (CnIndexPage invokes those with `{ actionId, item }` — no Vue
+// component context, so `this.$router` is not available). See #837 /
+// nc-vue#330 — the `viewLogsHandler` reads it for query-aware navigation
+// until nc-vue gains a `queryParam` field on the built-in `navigate`
+// handler.
+setRouter(router)
 
 tryLoadTranslations()
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -145,7 +145,7 @@
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "test", "label": "Test connection", "icon": "icon-checkmark", "handler": "testSourceHandler" },
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SourceLogs" }
+          { "id": "view-source-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" }
         ]
       }
     },
@@ -182,7 +182,7 @@
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
           { "id": "add-rule", "label": "Add rule", "icon": "icon-add", "handler": "addEndpointRuleHandler" },
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "EndpointLogs" }
+          { "id": "view-endpoint-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" }
         ]
       }
     },
@@ -259,7 +259,7 @@
         "actions": [
           { "id": "run", "label": "Run now", "icon": "icon-play", "handler": "runJobHandler" },
           { "id": "test", "label": "Test (dry run)", "icon": "icon-checkmark", "handler": "testJobHandler" },
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "JobLogs" }
+          { "id": "view-job-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" }
         ]
       },
       "slots": {
@@ -343,7 +343,7 @@
           { "id": "edit", "label": "Open editor", "icon": "icon-edit", "handler": "navigate", "route": "SynchronizationDetail", "params": { "id": "{id}" } },
           { "id": "run", "label": "Run now", "icon": "icon-play", "handler": "runSynchronizationHandler" },
           { "id": "test", "label": "Test (dry run)", "icon": "icon-checkmark", "handler": "testSynchronizationHandler" },
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SynchronizationLogs" },
+          { "id": "view-synchronization-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" },
           { "id": "view-contracts", "label": "View contracts", "icon": "icon-file", "handler": "navigate", "route": "SynchronizationContracts" }
         ]
       }
@@ -393,7 +393,7 @@
         "includeFields": ["source", "type", "subject", "data"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "actions": [
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "CloudEventLogs" }
+          { "id": "view-cloud-event-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" }
         ]
       }
     },

--- a/src/registry.js
+++ b/src/registry.js
@@ -40,6 +40,7 @@ import {
 	testSynchronizationHandler,
 	testMappingModalHandler,
 	addEndpointRuleHandler,
+	viewLogsHandler,
 } from './handlers/actionHandlers.js'
 import JobFormFields from './modals/v2/JobFormFields.vue'
 import MappingDetailPage from './views/wrappers/MappingDetailPage.vue'
@@ -57,6 +58,11 @@ export default {
 	// the App.vue-mounted ModalHost picks up and renders the modal.
 	testMappingModalHandler,
 	addEndpointRuleHandler,
+	// Query-aware navigation handler for "View logs" row actions on
+	// parent index pages (#837). Pushes `?<queryParam>=<rowId>` onto the
+	// destination *Logs route. Will be retired once nc-vue#330 lands a
+	// declarative `queryParam` field on the built-in `navigate` handler.
+	viewLogsHandler,
 
 	// Slot-override components — referenced by manifest `pages[].slots`
 	// keys. The Jobs page wires `form-fields` to JobFormFields so the


### PR DESCRIPTION
## Summary

\"View logs\" row actions on Sources / Endpoints / Jobs / Synchronizations / CloudEvents index pages now navigate to the destination *Logs page with `?<queryParam>=<rowId>` pre-applied, instead of dumping the user into the unfiltered list.

- New `viewLogsHandler` registry handler resolves destination route + query-param key from `VIEW_LOGS_TARGETS` keyed by `actionId`
- New `routerRef.js` module-scoped router holder — CnIndexPage's registry-handler signature (`{ actionId, item }`) carries no Vue component context, so `this.$router` isn't available; `main.js` calls `setRouter(router)` at boot
- Manifest: 5 \"View logs\" actions swapped from `handler: \"navigate\"` to `handler: \"viewLogsHandler\"` with distinct action ids

## Backstop

Will be retired once **nc-vue#330** adds a declarative `queryParam` field on the built-in `navigate` handler + CnLogsPage filter pre-fill. Once that ships, the custom handler + routerRef holder go away and manifest entries return to `handler: \"navigate\"`.

## Test plan

- [ ] Click \"View logs\" on a Source row → lands on `/sources/logs?source=<uuid>` with filter pre-applied
- [ ] Same for Endpoints / Jobs / Synchronizations / CloudEvents
- [ ] Clicking same action twice doesn't surface NavigationDuplicated error
- [ ] Unknown action id (manifest typo) logs a console.warn, doesn't crash

Closes #837.