### PR TITLE
docs: port README license policy + prometheus-metrics admin doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,17 @@ Full documentation is available at **[conductionnl.github.io/openconnector](http
 
 ## License
 
-EUPL-1.2
+This project is licensed under the [EUPL-1.2](LICENSE).
+
+### Dependency license policy
+
+All dependencies (PHP and JavaScript) are automatically checked against an approved license allowlist during CI. The following SPDX license families are approved for use in dependencies:
+
+- **Permissive:** MIT, ISC, BSD-2-Clause, BSD-3-Clause, 0BSD, Apache-2.0, Unlicense, CC0-1.0, CC-BY-3.0, CC-BY-4.0, Zlib, BlueOak-1.0.0, Artistic-2.0, BSL-1.0
+- **Copyleft (EUPL-compatible):** LGPL-2.0/2.1/3.0, GPL-2.0/3.0, AGPL-3.0, EUPL-1.1/1.2, MPL-2.0
+- **Font licenses:** OFL-1.0, OFL-1.1
+
+Dependencies with licenses not on this list will fail CI unless explicitly approved in `.license-overrides.json` with a documented justification.
 
 ## Authors
 

--- a/docs/administrators/prometheus-metrics.md
+++ b/docs/administrators/prometheus-metrics.md
@@ -1,0 +1,74 @@
+# Prometheus Metrics & Health Check
+
+OpenConnector exposes Prometheus-compatible metrics and a health check endpoint for production monitoring.
+
+## Endpoints
+
+| Endpoint | Method | Auth | Format |
+|---|---|---|---|
+| `/api/metrics` | GET | Admin required | Prometheus text exposition |
+| `/api/health` | GET | Admin required | JSON |
+
+## Available Metrics
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `openconnector_info` | gauge | version, php_version, nextcloud_version | Application version info (always 1) |
+| `openconnector_up` | gauge | — | 1 if healthy, 0 if degraded |
+| `openconnector_sources_total` | gauge | type | Source count by type (rest, soap, json, xml, etc.) |
+| `openconnector_calls_total` | counter | status | API call count by HTTP status code |
+| `openconnector_synchronizations_total` | gauge | — | Total configured synchronizations |
+| `openconnector_synchronization_runs_total` | counter | status | Sync log entries by result |
+| `openconnector_endpoints_total` | gauge | — | Total registered endpoints |
+| `openconnector_jobs_total` | gauge | — | Total configured background jobs |
+| `openconnector_job_runs_total` | counter | status | Job log entries by status |
+| `openconnector_mappings_total` | gauge | — | Total configured mappings |
+| `openconnector_rules_total` | gauge | — | Total configured rules |
+
+## Prometheus Configuration
+
+```yaml
+scrape_configs:
+  - job_name: 'openconnector'
+    scrape_interval: 30s
+    scheme: http
+    basic_auth:
+      username: admin
+      password: your-password
+    metrics_path: /index.php/apps/openconnector/api/metrics
+    static_configs:
+      - targets: ['your-nextcloud-host:8080']
+```
+
+## Health Check
+
+The health endpoint returns JSON:
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "database": "ok",
+    "sources_table": "ok"
+  }
+}
+```
+
+**Status values:**
+- `ok` — All checks passed
+- `degraded` — Some checks failed (app works but with limitations)
+- `error` — Critical check failed (database unreachable)
+
+Use for Kubernetes liveness/readiness probes:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /index.php/apps/openconnector/api/health
+    port: 80
+    httpHeaders:
+      - name: Authorization
+        value: Basic YWRtaW46YWRtaW4=
+  initialDelaySeconds: 30
+  periodSeconds: 60
+```


### PR DESCRIPTION
Salvaged from two stale PRs being closed in the >4-week triage sweep:

- **README "Dependency license policy" section** (from #677): documents the SPDX allowlist that `.license-overrides.json` + CI already enforce
- **`docs/administrators/prometheus-metrics.md`** (from #695): operator guide covering the `/api/metrics` endpoint shape, Prometheus scrape config, and Kubernetes liveness/readiness probe examples — the MetricsController was already merged into dev but the admin-facing doc wasn't