### PR TITLE
fix: port findByUuid→find + _object double-wrap guard + joblogs migration

### DIFF
--- a/lib/Migration/Version1Date20250826103500.php
+++ b/lib/Migration/Version1Date20250826103500.php
@@ -108,15 +108,14 @@ class Version1Date20250826103500 extends SimpleMigrationStep
             return $schema;
         }
 
-        // Change the column to TEXT type to allow longer messages
-        // In Nextcloud migrations, we use changeColumn to modify existing columns
-        $table->changeColumn(
-                'message',
-                [
-                    'type'    => \Doctrine\DBAL\Types\Type::getType(Types::TEXT),
-                    'notnull' => true,
-                ]
-                );
+        // Drop the existing column and recreate it with TEXT type
+        // Nextcloud migrations work better with drop/add pattern for type changes — Doctrine's
+        // changeColumn silently no-ops the type change in some DB backends, leaving the column
+        // stuck at VARCHAR(255) and causing job-log truncation errors at runtime.
+        $table->dropColumn('message');
+        $table->addColumn('message', Types::TEXT)
+                ->setNotnull(true)
+                ->setDefault('success');
 
         $output->info('Updated message column in openconnector_job_logs table to TEXT type');
 

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -644,7 +644,12 @@ class SynchronizationService
             $result['objects']['found'] = count($objectList);
 
             if ($sourceConfig['resultsPosition'] === '_object') {
-                $objectList = [$objectList];
+                // Only wrap when the source returned an associative object — a sequential
+                // list slipped through here causes the downstream loop to see a single
+                // [[…items]] element and miss every row.
+                if (array_is_list($objectList) === false) {
+                    $objectList = [$objectList];
+                }
                 $result['objects']['found'] = count($objectList);
             }
 
@@ -2069,7 +2074,11 @@ class SynchronizationService
             usesPagination: $usesPagination
         );
 
-        if (array_is_list($objects) === false) {
+        // For non-`_object` sources, an associative array means the source returned a single
+        // record at the root and we need to wrap it for the downstream foreach. For
+        // `_object` sources the wrap is the caller's responsibility (see line ~646) and
+        // doing it twice produces a [[…items]] payload that loses every row.
+        if (($sourceConfig['resultsPosition'] ?? null) !== '_object' && array_is_list($objects) === false) {
             $objects = [$objects];
         }
 
@@ -3162,7 +3171,7 @@ class SynchronizationService
 
         try {
             $objectService = $this->containerInterface->get('OCA\OpenRegister\Service\ObjectService');
-            $objectEntity  = $objectService->findByUuid(uuid: $objectId);
+            $objectEntity  = $objectService->find(id: $objectId);
             $file          = $fileService->saveFile(
                 objectEntity: $objectEntity,
                 fileName: $filename,
@@ -3190,7 +3199,7 @@ class SynchronizationService
             if ($shouldPublish && $file !== null) {
                 try {
                     $objectService = $this->containerInterface->get('OCA\OpenRegister\Service\ObjectService');
-                    $objectEntity  = $objectService->findByUuid(uuid: $objectId);
+                    $objectEntity  = $objectService->find(id: $objectId);
                     $fileService->publishFile(object: $objectEntity, file: $filename);
                 } catch (Exception $e) {
                     // Log but don't fail the entire operation
@@ -3672,7 +3681,7 @@ class SynchronizationService
 
         // Get the object entity and file service
         $objectService = $this->containerInterface->get('OCA\OpenRegister\Service\ObjectService');
-        $objectEntity  = $objectService->findByUuid(uuid: $objectId);
+        $objectEntity  = $objectService->find(id: $objectId);
         $fileService   = $this->containerInterface->get('OCA\OpenRegister\Service\FileService');
 
         // Check if associative array (multiple files with metadata)
@@ -4243,7 +4252,7 @@ class SynchronizationService
             // Get the object entity
             $objectService = $this->containerInterface->get('OCA\OpenRegister\Service\ObjectService');
             try {
-                $objectEntity = $objectService->findByUuid(uuid: $objectId);
+                $objectEntity = $objectService->find(id: $objectId);
             } catch (DoesNotExistException $e) {
                 // It is possible we are trying to delete files for an object id where the object has not been persisted yet (for example a zgw informatieobject can have a beforehand generated uuid)
                 return 0;


### PR DESCRIPTION
Salvaged from two stale hotfix branches being deleted in the >4-week branch triage sweep.

**`lib/Migration/Version1Date20250826103500.php`** (from `hotfix/cronerror`, original commit `2057c0c3` by Ruben, 2025-09-14):
- Swap `changeColumn('message', TEXT)` for the drop+add pattern
- Doctrine's `changeColumn` silently no-ops the type change on some DB backends, leaving the column at VARCHAR(255) and producing job-log truncation errors at runtime

**`lib/Service/SynchronizationService.php`** (from `hotfix/fix-forward-compatibility`):
- 4× `$objectService->findByUuid(uuid: …)` → `$objectService->find(id: …)` at lines 3165 / 3193 / 3675 / 4246 — OREG 1.0.0 dropped `findByUuid` (commit `becd5b78` by Robert, 2026-04-22)
- Guard the `resultsPosition === '_object'` wrap with `array_is_list($x) === false` so a sequential list at root doesn't get double-wrapped into `[[…items]]` (line ~646) (commit `81067a3d` by Barry, 2026-04-14)
- Skip the legacy associative-wrap branch when the source already declared `resultsPosition: _object` (line ~2077) — the caller above now owns that wrap; doing it twice produces the same `[[…items]]` swallow