### PR TITLE
fix(sync): register 'synchronization' object type in SynchronizationDetailPage

### DIFF
--- a/src/views/Synchronization/SynchronizationDetailPage.vue
+++ b/src/views/Synchronization/SynchronizationDetailPage.vue
@@ -351,8 +351,15 @@ export default {
 		schema: { type: String, default: SCHEMA_SLUG },
 	},
 
-	setup() {
+	setup(props) {
 		const objectStore = useObjectStore()
+		// Register the type so objectStore.fetchObject/saveObject can resolve
+		// the schema → register pair for URL building. Mirrors the pattern in
+		// RuleDetailPage / MappingDetailPage; without this, fetchObject throws
+		// "Object type 'synchronization' is not registered in the store".
+		if (typeof objectStore.registerObjectType === 'function') {
+			objectStore.registerObjectType(SCHEMA_SLUG, props.schema || SCHEMA_SLUG, props.register || REGISTER_SLUG)
+		}
 		return { objectStore }
 	},
 


### PR DESCRIPTION
Caught during browser smoke-test of the wave that just merged.

`SynchronizationDetailPage` (#872) was missing the `registerObjectType()` call in its `setup()`, so the first `fetchObject()` call threw `Object type 'synchronization' is not registered in the store` and the page rendered an empty error state with only a Retry button.

Mirrors the pattern already used by `RuleDetailPage` (line 195) and `MappingDetailPage` (line 274) — the store needs schema → register resolution for URL building.

## Verified

Tested in the dev container at http://localhost:8080 with admin:admin. Before fix: "Synchronization" heading + lone Retry button. After fix: all 6 widget sections (Source / General / Target / Mapping / Actions / Follow-ups) render and type-discriminator conditional fields (API source config, register/schema target, etc.) all swap correctly.

Same browser session also verified the rest of the wave end-to-end:
- #874 MappingDetailPage — 3-tab transformation-rules editor (Mapping/Cast/Unset) + Test mapping button + Add mapping rule dialog
- #873 RuleDetailPage — Basics + visual condition tree + Then(action) type combobox with conditional fields + Raw JSON toggle
- #875 viewLogsHandler — clicking 'View logs' on a Source row landed at `/sources/logs?source=<uuid>` exactly as designed
- Dashboard — all 6 KPI tiles + 6 charts + date-range picker rendering