### PR TITLE
chore(deps): bump composer config.platform.php to 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.2"
+			"php": "8.3"
 		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5297c2492a066f33452819a9e9ec5c8a",
+    "content-hash": "ad023cfbd973a7a6f9df6ac96028cade",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -11325,7 +11325,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.3"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Follow-up to #868 and #887.

#868 bumped `require.php` to ^8.3 and #887 regenerated the lock platform constraint, but `config.platform.php` was left at `"8.2"` — composer still emulates 8.2 during install, which then fails the ^8.3 requirement for azjezz/psl, php-soap/*, veewee/xml etc.

Surfaces in CI as: `Your lock file does not contain a compatible set of packages. Please run composer update.` — blocking every quality job + the dev→beta release PR (#688).