### PR TITLE
chore(info.xml): canonicalize PHP min, NC version range, licence spelling

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,8 +23,8 @@ The OpenConnector Nextcloud app provides a ESB-framework to work together in an 
 	<bugs>https://github.com/ConductionNL/OpenConnector/issues</bugs>
     <repository>https://github.com/ConductionNL/OpenConnector</repository>
 	<dependencies>
-        <nextcloud min-version="28" max-version="32"/>
-        <php min-version="8.0" min-int-size="64"/>
+        <nextcloud min-version="28" max-version="34"/>
+        <php min-version="8.3" min-int-size="64"/>
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>
@@ -35,7 +35,7 @@ The OpenConnector Nextcloud app provides a ESB-framework to work together in an 
 
         <!-- Chain B/C OR cutover: openconnector now stores domain data in OpenRegister.
              OR's ObjectService is required to boot openconnector controllers. -->
-        <nextcloud-app id="openregister" min-version="0.2.0"/>
+        <nextcloud min-version="0.2.0" max-version="34"-app id="openregister"/>
 	</dependencies>
 
 	<background-jobs>


### PR DESCRIPTION
## Summary

Canonicalize `appinfo/info.xml` per the fleet drift research in
[nextcloud-app-template/docs/fleet-drift-deeper.md §4](https://github.com/ConductionNL/nextcloud-app-template/blob/development/docs/fleet-drift-deeper.md#4-appinfoinfoxml--significant-drift).

- `<php min-version="8.3">` — matches `composer require.php` (`^8.3` fleet-wide)
- `<nextcloud min-version="28" max-version="34">` — converge on the fleet's standard support range
- `<licence>agpl</licence>` — fix the casing/value drift (the fleet had 4 spellings: `agpl`, `eupl`, `EUPL-1.2`, `AGPL-3.0-or-later`)

Per-app fields (`<id>`, `<name>`, `<description>`, `<version>`, `<screenshot>`, etc.) are preserved.

## Licence note

We stay on the `agpl` workaround per the [EUPL store-listing pattern](https://github.com/ConductionNL/.github/blob/main/conduction/feedback_conduction-apps-eupl-license.md). The upstream fix landed in nextcloud/server#60212 (NC 34) and nextcloud/appstore#1754. Switch to `EUPL-1.2` once the fleet floor reaches NC 34 — tracked in ConductionNL/.github#98.

## How this PR was made

Opened by `hydra/scripts/fleet-sync/info-xml.sh` — see
[the script](https://github.com/ConductionNL/hydra/blob/development/scripts/fleet-sync/info-xml.sh)
for the canonical values + rewrite logic. The script reads
`appinfo/info.xml`, surgically rewrites the three canonical fields,
and opens a PR per fleet app.