### PR TITLE
style(phpcs): fix lib/Action debt (advances #889)

### DIFF
--- a/lib/Action/EventAction.php
+++ b/lib/Action/EventAction.php
@@ -1,23 +1,49 @@
 <?php
+/**
+ * OpenConnector Event Action.
+ *
+ * Placeholder action that can be hooked into the cron job list and invoked
+ * when an event-driven job fires.
+ *
+ * @category Action
+ * @package  OCA\OpenConnector\Action
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Action;
 
 use OCA\OpenConnector\Service\CallService;
 
 /**
- * This class is used to run the action tasks for the OpenConnector app. It hooks into the cron job list and runs the classes that are set as the job class in the job.
- *
- * @package OCA\OpenConnector\Cron
+ * Runs event-driven actions wired into the OpenConnector cron job list.
  */
 class EventAction
 {
 
+    /**
+     * Service used to execute outbound calls.
+     *
+     * @var CallService
+     */
     private CallService $callService;
 
+    /**
+     * Constructor.
+     *
+     * @param CallService $callService Service used to execute outbound calls.
+     */
     public function __construct(
         CallService $callService,
     ) {
         $this->callService = $callService;
+
     }//end __construct()
 
     /**
@@ -31,8 +57,9 @@ class EventAction
      */
     public function run(array $argument=[]): array
     {
-        // @todo: implement this
-        // Let's report back about what we have just done
+        // @todo Implement this.
+        // Let's report back about what we have just done.
         return [];
+
     }//end run()
 }//end class

--- a/lib/Action/PingAction.php
+++ b/lib/Action/PingAction.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * OpenConnector Ping Action.
+ *
+ * Cron action that executes a simple GET / ping call against a configured
+ * source and records the call log entry.
+ *
+ * @category Action
+ * @package  OCA\OpenConnector\Action
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Action;
 
@@ -6,45 +23,61 @@ use OCA\OpenConnector\Service\CallService;
 use OCA\OpenRegister\Service\ObjectService as OrObjectService;
 
 /**
- * This class is used to run the action tasks for the OpenConnector app. It hooks into the cron job list and runs the classes that are set as the job class in the job.
- *
- * @package OCA\OpenConnector\Cron
+ * Runs ping actions wired into the OpenConnector cron job list.
  */
 class PingAction
 {
 
+    /**
+     * Service used to execute outbound calls.
+     *
+     * @var CallService
+     */
     private CallService $callService;
 
+    /**
+     * OpenRegister object service used to resolve sources.
+     *
+     * @var OrObjectService
+     */
     private OrObjectService $orObjectService;
 
+    /**
+     * Constructor.
+     *
+     * @param CallService     $callService     Service used to execute outbound calls.
+     * @param OrObjectService $orObjectService Service used to resolve sources.
+     */
     public function __construct(
         CallService $callService,
         OrObjectService $orObjectService,
     ) {
         $this->callService     = $callService;
         $this->orObjectService = $orObjectService;
+
     }//end __construct()
 
     /**
      * Executes a simple API-call (ping / GET) on a source by using the callService.
-     * The method logs actions performed during execution and returns a stack trace of the operations.
      *
-     * @todo Make this method more generic to support additional actions.
-     * @todo Add logging or better handling for cases when 'sourceId' is not provided.
+     * The method logs actions performed during execution and returns a stack trace of the operations.
      *
      * @param array $arguments An array of arguments including optional 'sourceId' to define the source for the call.
      *
      * @return array An array containing the execution stack trace of the actions performed.
+     *
+     * @todo Make this method more generic to support additional actions.
+     * @todo Add logging or better handling for cases when 'sourceId' is not provided.
      */
     public function run(array $arguments=[]): array
     {
         $response = [];
         $response['stackTrace'][] = 'Running PingAction';
 
-        // For now we only have one action, so this is a bit overkill, but it's a good starting point
+        // For now we only have one action, so this is a bit overkill, but it is a good starting point.
         $sourceId = null;
-        if (isset($arguments['sourceId']) === false || empty($arguments['sourceId'])) {
-            // @todo log and / or not default to just using the first source
+        if (isset($arguments['sourceId']) === false || empty($arguments['sourceId']) === true) {
+            // @todo Log and / or not default to just using the first source.
             $response['stackTrace'][] = "No sourceId in arguments, skipping ping";
             return $response;
         }
@@ -63,7 +96,8 @@ class PingAction
 
         $response['stackTrace'][] = "Created callLog with uuid: ".$callLog->getUuid();
 
-        // Let's report back about what we have just done
+        // Let's report back about what we have just done.
         return $response;
+
     }//end run()
 }//end class

--- a/lib/Action/SynchronizationAction.php
+++ b/lib/Action/SynchronizationAction.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * OpenConnector Synchronization Action.
+ *
+ * Cron action that runs the synchronization process for a given
+ * synchronization ID, delegating to the SynchronizationService.
+ *
+ * @category Action
+ * @package  OCA\OpenConnector\Action
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Action;
 
@@ -8,56 +25,71 @@ use OCA\OpenRegister\Service\ObjectService as OrObjectService;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 /**
- * This action handles the synchronization of data from the source to the target.
- *
- * @package OCA\OpenConnector\Cron
+ * Handles the synchronization of data from a source to the target.
  */
 class SynchronizationAction
 {
 
+    /**
+     * Synchronization service used to perform the actual sync.
+     *
+     * @var SynchronizationService
+     */
     private SynchronizationService $syncService;
 
+    /**
+     * OpenRegister object service used to resolve synchronization records.
+     *
+     * @var OrObjectService
+     */
     private OrObjectService $orObjectService;
 
+    /**
+     * Constructor.
+     *
+     * @param SynchronizationService $syncService     Synchronization service used to perform the sync.
+     * @param OrObjectService        $orObjectService Service used to resolve synchronization records.
+     */
     public function __construct(
         SynchronizationService $syncService,
         OrObjectService $orObjectService,
     ) {
         $this->syncService     = $syncService;
         $this->orObjectService = $orObjectService;
+
     }//end __construct()
 
     /**
      * Executes the synchronization process based on the provided arguments.
+     *
      * This method checks for a valid synchronization ID, processes a synchronization contract if provided,
      * or performs a general synchronization action. It returns a stack trace of operations performed.
-     *
-     * @todo Make this method more generic to handle different synchronization processes.
-     * @todo Implement proper error handling when 'synchronizationId' is missing or invalid.
-     * @todo Improve handling for testing purposes and synchronization contract logic.
      *
      * @param array $argument An array of arguments that can include 'synchronizationId' and 'synchronizationContractId'.
      *
      * @return array Returns an array containing the stack trace of actions performed and any warnings or messages.
      *
      * @throws Exception Throws an exception if the synchronization process fails or encounters an error.
+     *
+     * @todo Make this method more generic to handle different synchronization processes.
+     * @todo Implement proper error handling when 'synchronizationId' is missing or invalid.
+     * @todo Improve handling for testing purposes and synchronization contract logic.
      */
     public function run(array $argument=[]): array
     {
-
         $response = [];
 
-        // if we do not have a synchronization Id then everything is wrong
+        // If we do not have a synchronization Id then everything is wrong.
         $response['message'] = $response['stackTrace'][] = 'Check for a valid synchronization ID';
         if (isset($argument['synchronizationId']) === false) {
-            // @todo: implement error handling
+            // @todo Implement error handling.
             $response['level']        = 'ERROR';
             $response['stackTrace'][] = $response['message'] = 'No synchronization ID provided';
 
             return $response;
         }
 
-        // Let's find a synchronization
+        // Let's find a synchronization.
         $response['stackTrace'][] = 'Getting synchronization: '.$argument['synchronizationId'];
         $synchronization          = $this->orObjectService->find(
             id: (string) $argument['synchronizationId'],
@@ -71,7 +103,7 @@ class SynchronizationAction
             return $response;
         }
 
-        // Doing the synchronization
+        // Doing the synchronization.
         $response['stackTrace'][] = 'Doing the synchronization';
         try {
             $objects = $this->syncService->synchronize($synchronization);
@@ -94,12 +126,17 @@ class SynchronizationAction
 
         $objectCount = 0;
         if (is_array($objects) === true) {
-            $objectCount = $objects['result']['contracts'] ? count($objects['result']['contracts']) : $objects['result']['objects']['found'];
+            if (empty($objects['result']['contracts']) === false) {
+                $objectCount = count($objects['result']['contracts']);
+            } else {
+                $objectCount = $objects['result']['objects']['found'];
+            }
         }
 
         $response['stackTrace'][] = $response['message'] = 'Synchronized '.$objectCount.' successfully';
 
-        // Let's report back about what we have just done
+        // Let's report back about what we have just done.
         return $response;
+
     }//end run()
 }//end class


### PR DESCRIPTION
## Summary

Mechanical PHPCS debt sweep for ``lib/Action/`` — 3 files moved from a combined 25 errors to 0 errors.

Touched: ``EventAction.php``, ``PingAction.php``, ``SynchronizationAction.php``.

Rules addressed in this batch:
- Missing file doc comment / ``@author`` / ``@license``
- Missing member variable doc comment
- Missing doc comment for ``__construct``
- ``@return`` / ``@throws`` tags cannot be grouped with parameter tags
- Inline comments must end in full-stops / start with capital letter
- Implicit true comparisons (``empty($x)`` → ``empty($x) === true``)
- Inline IF statement (``$x ? a : b`` → explicit ``if`` block in ``SynchronizationAction::run``)
- Function spacing (auto-fixed by ``phpcbf``)

Residual on these files: 2 ``@spec`` warnings per file (informational, ADR-003, non-blocking per ``phpcs.xml``).

Part of #889. Unblocks #688 (dev→beta release PR).

## Test plan

- [x] ``vendor/bin/phpcs --standard=phpcs.xml lib/Action/`` reports 0 errors
- [ ] CI passes