### PR TITLE
style(phpcs): fix lib/Cron debt (advances #889)

### DIFF
--- a/lib/Cron/JobTask.php
+++ b/lib/Cron/JobTask.php
@@ -1,32 +1,34 @@
 <?php
-
 /**
- * JobTask
+ * OpenConnector JobTask.
  *
  * Background job task for executing jobs in the OpenConnector application.
  * This task runs scheduled jobs by delegating execution to the JobService.
  *
  * @category Cron
  * @package  OCA\OpenConnector\Cron
- * @author   OpenConnector Development Team
- * @license  AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/openconnector
- * @version  1.0.0
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
  */
 
 namespace OCA\OpenConnector\Cron;
 
 use OCA\OpenConnector\Service\JobService;
-use OCP\BackgroundJob\TimedJob;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
 
 /**
- * Background job task for executing scheduled jobs
+ * Background job task for executing scheduled jobs.
  *
- * This task serves as a simple wrapper around the JobService,
- * handling the execution of individual jobs based on their
- * scheduled intervals and configurations.
+ * This task serves as a simple wrapper around the JobService, handling the
+ * execution of individual jobs based on their scheduled intervals.
  *
  * @psalm-api
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -35,47 +37,46 @@ class JobTask extends TimedJob
 {
 
     /**
-     * Job service for handling job execution logic
+     * Job service for handling job execution logic.
+     *
+     * @var JobService
      */
     private readonly JobService $jobService;
 
     /**
-     * JobTask constructor
+     * Constructor.
      *
-     * Initializes the job task with required dependencies and
-     * configures the background job settings.
+     * Initializes the job task with required dependencies and configures the
+     * background job settings.
      *
-     * @param ITimeFactory $time       Time factory for job scheduling
-     * @param JobService   $jobService Service for handling job execution
-     *
-     * @psalm-param ITimeFactory $time
-     * @psalm-param JobService $jobService
+     * @param ITimeFactory $time       Time factory for job scheduling.
+     * @param JobService   $jobService Service for handling job execution.
      */
     public function __construct(
         ITimeFactory $time,
         JobService $jobService
     ) {
-        parent::__construct($time);
+        parent::__construct(time: $time);
         $this->jobService = $jobService;
 
-        // Run every 5 minutes
-        $this->setInterval(300);
+        // Run every 5 minutes.
+        $this->setInterval(seconds: 300);
 
-        // Set as time insensitive to run during low-load periods
-        $this->setTimeSensitivity(IJob::TIME_SENSITIVE);
+        // Set as time sensitive to honour the cron schedule.
+        $this->setTimeSensitivity(sensitivity: IJob::TIME_SENSITIVE);
 
-        // Only run one instance of this job at a time
-        $this->setAllowParallelRuns(false);
+        // Only run one instance of this job at a time.
+        $this->setAllowParallelRuns(allow: false);
+
     }//end __construct()
 
     /**
-     * Execute the job task
+     * Execute the job task.
      *
-     * This method delegates job execution to the JobService,
-     * which handles all the complex business logic for job
-     * validation, execution, and logging.
+     * This method delegates job execution to the JobService, which handles
+     * all the complex business logic for job validation and logging.
      *
-     * @param mixed $argument The job arguments containing jobId and optional parameters
+     * @param mixed $argument The job arguments containing jobId and optional parameters.
      *
      * @return void
      *
@@ -84,7 +85,8 @@ class JobTask extends TimedJob
      */
     public function run(mixed $argument): void
     {
-        // Delegate job execution to the service layer
+        // Delegate job execution to the service layer.
         $this->jobService->run();
+
     }//end run()
 }//end class

--- a/lib/Cron/LogCleanUpTask.php
+++ b/lib/Cron/LogCleanUpTask.php
@@ -1,31 +1,35 @@
 <?php
-
 /**
- * LogCleanUpTask
+ * OpenConnector LogCleanUpTask.
  *
- * Background job task for cleaning up old logs in the OpenConnector application.
- * This task removes expired call logs and job logs to maintain system performance.
+ * Background job task for cleaning up old logs in the OpenConnector
+ * application. Removes expired call logs and job logs to maintain
+ * database performance.
  *
  * @category Cron
  * @package  OCA\OpenConnector\Cron
- * @author   OpenConnector Development Team
- * @license  AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/openconnector
- * @version  1.0.0
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
  */
 
 namespace OCA\OpenConnector\Cron;
 
 use OCA\OpenRegister\Service\ObjectService as OrObjectService;
-use OCP\BackgroundJob\TimedJob;
-use OCP\BackgroundJob\IJob;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
 
 /**
- * Background job task for cleaning up expired logs
+ * Background job task for cleaning up expired logs.
  *
- * This task runs periodically to remove old call logs and job logs
- * from the database to prevent database bloat and maintain performance.
+ * Runs periodically to remove old call logs and job logs from the database
+ * and prevent storage bloat.
  *
  * @psalm-api
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -34,30 +38,29 @@ use OCP\AppFramework\Utility\ITimeFactory;
 class LogCleanUpTask extends TimedJob
 {
     /**
-     * LogCleanUpTask constructor
+     * Constructor.
      *
-     * Initializes the log cleanup task with required dependencies
-     * and configures the background job settings.
+     * Initializes the log cleanup task with required dependencies and
+     * configures the background job settings.
      *
-     * @param ITimeFactory    $time            Time factory for job scheduling
-     * @param OrObjectService $orObjectService OR object service for log operations
-     *
-     * @psalm-param ITimeFactory $time
+     * @param ITimeFactory    $time            Time factory for job scheduling.
+     * @param OrObjectService $orObjectService OR object service for log operations.
      */
     public function __construct(
         ITimeFactory $time,
         private readonly OrObjectService $orObjectService
     ) {
-        parent::__construct($time);
+        parent::__construct(time: $time);
 
-        // Run every minute @todo change to hour
-        $this->setInterval(60);
+        // Run every minute. @todo change to hour.
+        $this->setInterval(seconds: 60);
 
-        // Delay until low-load time
-        $this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+        // Delay until low-load time.
+        $this->setTimeSensitivity(sensitivity: IJob::TIME_INSENSITIVE);
 
-        // Only run one instance of this job at a time
-        $this->setAllowParallelRuns(true);
+        // Only run one instance of this job at a time.
+        $this->setAllowParallelRuns(allow: true);
+
     }//end __construct()
 
     /**
@@ -66,7 +69,8 @@ class LogCleanUpTask extends TimedJob
      * Finds all objects with a non-null `expires` field that is in the past,
      * then deletes them one by one via OR ObjectService.
      *
-     * @param  string $schema The schema slug to clean up.
+     * @param string $schema The schema slug to clean up.
+     *
      * @return void
      */
     private function cleanupSchema(string $schema): void
@@ -90,15 +94,16 @@ class LogCleanUpTask extends TimedJob
                 // Continue with remaining objects even if one deletion fails.
             }
         }
+
     }//end cleanupSchema()
 
     /**
-     * Execute the log cleanup task
+     * Execute the log cleanup task.
      *
-     * This method removes expired logs from all log schemas
-     * to maintain database performance and prevent storage bloat.
+     * This method removes expired logs from all log schemas to maintain
+     * database performance and prevent storage bloat.
      *
-     * @param mixed $argument Task arguments (not used in this implementation)
+     * @param mixed $argument Task arguments (not used in this implementation).
      *
      * @return void
      *
@@ -107,16 +112,17 @@ class LogCleanUpTask extends TimedJob
      */
     public function run(mixed $argument): void
     {
-        // Clear expired call logs
-        $this->cleanupSchema('call_log');
+        // Clear expired call logs.
+        $this->cleanupSchema(schema: 'call_log');
 
-        // Clear expired job logs
-        $this->cleanupSchema('job_log');
+        // Clear expired job logs.
+        $this->cleanupSchema(schema: 'job_log');
 
-        // Clear expired synchronization contract logs
-        $this->cleanupSchema('synchronization_contract_log');
+        // Clear expired synchronization contract logs.
+        $this->cleanupSchema(schema: 'synchronization_contract_log');
 
-        // Clear expired synchronization logs
-        $this->cleanupSchema('synchronization_log');
+        // Clear expired synchronization logs.
+        $this->cleanupSchema(schema: 'synchronization_log');
+
     }//end run()
 }//end class


### PR DESCRIPTION
## Summary

PHPCS debt sweep for ``lib/Cron/`` — 2 files moved from 31 errors to 0 errors.

Touched: ``JobTask.php``, ``LogCleanUpTask.php``.

Rules addressed:
- File docblock ``@author``/``@license``/``@version`` re-format (Conduction canonical form)
- Missing ``@var`` on member variables
- Inline comments must end in full-stops / capital letters
- Named-arguments sniff: ``parent::__construct(time: \$time)``, ``\$this->setInterval(seconds: 300)``, etc.

Part of #889.

## Test plan

- [x] ``vendor/bin/phpcs --standard=phpcs.xml lib/Cron/`` reports 0 errors
- [ ] CI passes