### PR TITLE
feat(mapping-editor): drag-reorder + live preview (closes #876)

### DIFF
--- a/src/views/wrappers/MappingDetailPage.vue
+++ b/src/views/wrappers/MappingDetailPage.vue
@@ -26,12 +26,18 @@
   store re-fetches automatically, so the rules editor reacts to the
   fresh values without a manual reload.
 
+  Right of the rules editor sits a **live preview pane** (closes #876):
+  a JSON textarea for a sample input plus a read-only pretty-printed
+  output of `POST /api/mappings/test`. Debounced at 400 ms; re-fires on
+  every rule edit or sample-input change. Server-side errors render
+  inline; a "Reset preview" button clears the sample and result.
+
   The "Test mapping" header action re-uses the existing v2 modal pattern
   from #867: emit `EVENT_OPEN_TEST_MAPPING` on `modalBus`, the App.vue
   `ModalHost` picks it up and mounts `TestMappingModal` with the current
   mapping pre-selected.
 
-  Closes ConductionNL/openconnector#832.
+  Closes ConductionNL/openconnector#832 and #876.
 -->
 <template>
 	<CnDetailPage
@@ -79,21 +85,71 @@
 				</dl>
 			</section>
 
-			<!-- Rules editor -->
-			<section class="cn-mapping-detail__card">
-				<h3 class="cn-mapping-detail__section-title">
-					{{ t('openconnector', 'Transformation rules') }}
-				</h3>
-				<MappingRulesEditor
-					:mapping-rules="mappingRules"
-					:cast-rules="castRules"
-					:unset-rules="unsetRules"
-					:pass-through="!!mapping.passThrough"
-					:saving="saving"
-					@update-mapping="onUpdateMapping"
-					@update-cast="onUpdateCast"
-					@update-unset="onUpdateUnset" />
-			</section>
+			<!-- Rules + preview, side by side -->
+			<div class="cn-mapping-detail__split">
+				<section class="cn-mapping-detail__card cn-mapping-detail__rules">
+					<h3 class="cn-mapping-detail__section-title">
+						{{ t('openconnector', 'Transformation rules') }}
+					</h3>
+					<MappingRulesEditor
+						:mapping-rules="mappingRules"
+						:cast-rules="castRules"
+						:unset-rules="unsetRules"
+						:pass-through="!!mapping.passThrough"
+						:saving="saving"
+						@update-mapping="onUpdateMapping"
+						@update-cast="onUpdateCast"
+						@update-unset="onUpdateUnset" />
+				</section>
+
+				<section class="cn-mapping-detail__card cn-mapping-detail__preview">
+					<div class="cn-mapping-detail__preview-header">
+						<h3 class="cn-mapping-detail__section-title">
+							{{ t('openconnector', 'Live preview') }}
+						</h3>
+						<NcButton type="tertiary"
+							:disabled="previewLoading"
+							@click="resetPreview">
+							<template #icon>
+								<RestoreIcon :size="18" />
+							</template>
+							{{ t('openconnector', 'Reset preview') }}
+						</NcButton>
+					</div>
+					<p class="cn-mapping-detail__hint">
+						{{ t('openconnector', 'Edit the sample input below; the output re-renders as you type and on every rule change.') }}
+					</p>
+
+					<label for="cn-mapping-detail__sample-input" class="cn-mapping-detail__field-label">
+						{{ t('openconnector', 'Sample input (JSON)') }}
+					</label>
+					<textarea id="cn-mapping-detail__sample-input"
+						v-model="sampleInput"
+						class="cn-mapping-detail__textarea"
+						rows="8"
+						spellcheck="false"
+						:placeholder="samplePlaceholder" />
+					<p v-if="sampleParseError" class="cn-mapping-detail__error">
+						{{ sampleParseError }}
+					</p>
+
+					<div class="cn-mapping-detail__preview-output">
+						<div class="cn-mapping-detail__field-label cn-mapping-detail__preview-output-label">
+							<span>{{ t('openconnector', 'Output') }}</span>
+							<NcLoadingIcon v-if="previewLoading" :size="16" />
+						</div>
+						<NcNoteCard v-if="previewError" type="error">
+							<p>{{ previewError }}</p>
+						</NcNoteCard>
+						<pre v-else-if="previewOutput !== null"
+							class="cn-mapping-detail__pre"><!--
+							-->{{ formattedPreview }}</pre>
+						<p v-else class="cn-mapping-detail__preview-empty">
+							{{ t('openconnector', 'Output will appear here once a sample input and rules produce a result.') }}
+						</p>
+					</div>
+				</section>
+			</div>
 		</div>
 	</CnDetailPage>
 </template>
@@ -103,12 +159,24 @@ import { CnDetailPage, useObjectStore } from '@conduction/nextcloud-vue'
 import {
 	NcButton,
 	NcCheckboxRadioSwitch,
+	NcLoadingIcon,
+	NcNoteCard,
 } from '@nextcloud/vue'
 import PlayOutlineIcon from 'vue-material-design-icons/PlayOutline.vue'
+import RestoreIcon from 'vue-material-design-icons/Restore.vue'
 import { showError, showSuccess } from '@nextcloud/dialogs'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import debounce from 'lodash/debounce.js'
 
 import MappingRulesEditor from './MappingRulesEditor.vue'
 import { modalBus, EVENT_OPEN_TEST_MAPPING } from '../../handlers/modalBus.js'
+
+/** Default sample input shown until the user edits the textarea. */
+const DEFAULT_SAMPLE = '{}'
+
+/** Debounce delay for preview requests, in milliseconds. */
+const PREVIEW_DEBOUNCE_MS = 400
 
 /**
  * Normalise the `mapping` field (Twig-template map) of a Mapping object to
@@ -161,7 +229,10 @@ export default {
 		MappingRulesEditor,
 		NcButton,
 		NcCheckboxRadioSwitch,
+		NcLoadingIcon,
+		NcNoteCard,
 		PlayOutlineIcon,
+		RestoreIcon,
 	},
 
 	props: {
@@ -195,6 +266,11 @@ export default {
 		return {
 			objectType: 'mapping',
 			saving: false,
+			sampleInput: DEFAULT_SAMPLE,
+			sampleParseError: '',
+			previewLoading: false,
+			previewError: '',
+			previewOutput: null,
 		}
 	},
 
@@ -254,11 +330,58 @@ export default {
 		unsetRules() {
 			return asUnsetList(this.mapping?.unset)
 		},
+		samplePlaceholder() {
+			return '{\n  "name": "hello"\n}'
+		},
+		formattedPreview() {
+			try {
+				return JSON.stringify(this.previewOutput, null, 2)
+			} catch (_e) {
+				return String(this.previewOutput)
+			}
+		},
+		/**
+		 * Combined reactivity key for the preview watcher. Recomputing this
+		 * forces the debounced preview to refire whenever the rule shape or
+		 * sample input changes.
+		 */
+		previewSignal() {
+			return JSON.stringify({
+				mapping: this.mappingRules,
+				cast: this.castRules,
+				unset: this.unsetRules,
+				passThrough: !!this.mapping?.passThrough,
+				input: this.sampleInput,
+			})
+		},
+	},
+
+	watch: {
+		previewSignal: {
+			immediate: false,
+			handler() {
+				this.schedulePreview()
+			},
+		},
 	},
 
 	mounted() {
 		this.ensureRegistered()
-		this.reload()
+		const fetch = this.reload()
+		// Trigger the first preview render once data lands.
+		Promise.resolve(fetch).finally(() => this.schedulePreview())
+	},
+
+	beforeDestroy() {
+		if (this.schedulePreview && this.schedulePreview.cancel) {
+			this.schedulePreview.cancel()
+		}
+	},
+
+	created() {
+		// Bind the debounced function on the instance so each component gets
+		// its own timer and `.cancel()` works on teardown.
+		this.schedulePreview = debounce(this.runPreview, PREVIEW_DEBOUNCE_MS)
 	},
 
 	methods: {
@@ -335,6 +458,64 @@ export default {
 		onTogglePassThrough(value) {
 			return this.persistPatch({ passThrough: !!value })
 		},
+
+		/**
+		 * Issue the live-preview request against `/api/mappings/test`. The
+		 * inflight indicator is shown next to the Output label so it
+		 * doesn't block edits in the rules table on the left.
+		 */
+		async runPreview() {
+			if (!this.hasMapping) return
+			let parsed
+			const raw = (this.sampleInput || '').trim()
+			try {
+				parsed = raw.length > 0 ? JSON.parse(raw) : {}
+			} catch (parseErr) {
+				this.sampleParseError = this.t(
+					'openconnector',
+					'Sample input is not valid JSON: {message}',
+					{ message: parseErr.message },
+				)
+				this.previewLoading = false
+				return
+			}
+			this.sampleParseError = ''
+			this.previewLoading = true
+			this.previewError = ''
+			try {
+				const response = await axios.post(
+					generateUrl('/apps/openconnector/api/mappings/test'),
+					{
+						inputObject: parsed,
+						mapping: this.mapping,
+					},
+				)
+				this.previewOutput = response.data?.resultObject ?? response.data ?? null
+			} catch (err) {
+				const status = err?.response?.status
+				const message = err?.response?.data?.message
+					|| err?.response?.data?.error
+					|| err?.message
+					|| ''
+				this.previewError = this.t('openconnector', 'Preview failed')
+					+ (status ? ` (${status})` : '')
+					+ (message ? `: ${message}` : '')
+			} finally {
+				this.previewLoading = false
+			}
+		},
+
+		/** Clear sample input + output and cancel any pending request. */
+		resetPreview() {
+			if (this.schedulePreview && this.schedulePreview.cancel) {
+				this.schedulePreview.cancel()
+			}
+			this.sampleInput = DEFAULT_SAMPLE
+			this.sampleParseError = ''
+			this.previewOutput = null
+			this.previewError = ''
+			this.previewLoading = false
+		},
 	},
 }
 </script>
@@ -381,5 +562,103 @@ export default {
 	margin: 4px 0 0 0;
 	font-size: 12px;
 	color: var(--color-text-maxcontrast);
+}
+
+.cn-mapping-detail__split {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	gap: 24px;
+}
+
+@media (max-width: 1100px) {
+	.cn-mapping-detail__split {
+		grid-template-columns: minmax(0, 1fr);
+	}
+}
+
+.cn-mapping-detail__rules,
+.cn-mapping-detail__preview {
+	min-width: 0;
+}
+
+.cn-mapping-detail__preview {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.cn-mapping-detail__preview-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 4px;
+}
+
+.cn-mapping-detail__preview-header .cn-mapping-detail__section-title {
+	margin: 0;
+}
+
+.cn-mapping-detail__field-label {
+	display: block;
+	font-weight: 500;
+	font-size: 13px;
+	color: var(--color-text-maxcontrast);
+	margin-top: 8px;
+}
+
+.cn-mapping-detail__preview-output-label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.cn-mapping-detail__textarea {
+	width: 100%;
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 13px;
+	resize: vertical;
+	padding: 8px;
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+}
+
+.cn-mapping-detail__error {
+	color: var(--color-error);
+	font-size: 12px;
+	margin: 4px 0 0 0;
+}
+
+.cn-mapping-detail__preview-output {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin-top: 4px;
+}
+
+.cn-mapping-detail__pre {
+	background: var(--color-background-dark);
+	color: var(--color-main-text);
+	padding: 12px;
+	border-radius: var(--border-radius);
+	overflow: auto;
+	max-height: 360px;
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 12px;
+	white-space: pre-wrap;
+	word-break: break-word;
+	margin: 0;
+}
+
+.cn-mapping-detail__preview-empty {
+	margin: 0;
+	padding: 16px;
+	text-align: center;
+	color: var(--color-text-maxcontrast);
+	border: 1px dashed var(--color-border);
+	border-radius: var(--border-radius);
+	font-style: italic;
+	font-size: 13px;
 }
 </style>

--- a/src/views/wrappers/MappingRulesEditor.vue
+++ b/src/views/wrappers/MappingRulesEditor.vue
@@ -17,6 +17,11 @@
   updated collection so the parent can persist it through `useObjectStore`
   in one call. We never mutate the props directly.
 
+  Rule order matters for cascading transformations. Each row carries a
+  drag handle (MDI drag-vertical) on the left and is `tabindex="0"` so
+  ArrowUp/ArrowDown can move it within its tab. Reordering rebuilds the
+  collection in the new order and emits it like any other mutation.
+
   Unset rules are only meaningful when `passThrough` is enabled on the
   parent mapping (otherwise there's nothing to remove). The Add button on
   the Unset tab is disabled in that case, mirroring the legacy behaviour.
@@ -39,11 +44,12 @@
 		<!-- Mapping rules tab -->
 		<section v-if="activeTab === 'mapping'" class="cn-rules-editor__panel">
 			<p class="cn-rules-editor__help">
-				{{ t('openconnector', 'Each mapping rule maps a target property to a Twig template that produces its value from the input object.') }}
+				{{ t('openconnector', 'Each mapping rule maps a target property to a Twig template that produces its value from the input object. Drag the handle to change rule order — order matters for cascading transformations.') }}
 			</p>
 			<table v-if="mappingRowList.length" class="cn-rules-editor__table">
 				<thead>
 					<tr>
+						<th class="cn-rules-editor__col-handle" aria-hidden="true" />
 						<th>{{ t('openconnector', 'Target property') }}</th>
 						<th>{{ t('openconnector', 'Template') }}</th>
 						<th class="cn-rules-editor__col-actions">
@@ -51,8 +57,29 @@
 						</th>
 					</tr>
 				</thead>
-				<tbody>
-					<tr v-for="row in mappingRowList" :key="row.key">
+				<VueDraggable v-model="mappingDraft"
+					tag="tbody"
+					handle=".cn-rules-editor__drag-handle"
+					:disabled="saving"
+					:animation="150"
+					ghost-class="cn-rules-editor__row--ghost"
+					drag-class="cn-rules-editor__row--dragging"
+					@end="onMappingReorder">
+					<tr v-for="(row, index) in mappingDraft"
+						:key="row.key"
+						tabindex="0"
+						class="cn-rules-editor__row"
+						@keydown.up.prevent="moveRow('mapping', index, -1)"
+						@keydown.down.prevent="moveRow('mapping', index, 1)">
+						<td class="cn-rules-editor__col-handle">
+							<button type="button"
+								class="cn-rules-editor__drag-handle"
+								:aria-label="t('openconnector', 'Drag to reorder')"
+								:disabled="saving"
+								tabindex="-1">
+								<DragVerticalIcon :size="18" />
+							</button>
+						</td>
 						<td class="cn-rules-editor__cell-key">
 							{{ row.key }}
 						</td>
@@ -78,7 +105,7 @@
 							</NcButton>
 						</td>
 					</tr>
-				</tbody>
+				</VueDraggable>
 			</table>
 			<p v-else class="cn-rules-editor__empty">
 				{{ t('openconnector', 'No mapping rules yet. Add one to start shaping the output.') }}
@@ -101,6 +128,7 @@
 			<table v-if="castRowList.length" class="cn-rules-editor__table">
 				<thead>
 					<tr>
+						<th class="cn-rules-editor__col-handle" aria-hidden="true" />
 						<th>{{ t('openconnector', 'Property') }}</th>
 						<th>{{ t('openconnector', 'Cast type') }}</th>
 						<th class="cn-rules-editor__col-actions">
@@ -108,8 +136,29 @@
 						</th>
 					</tr>
 				</thead>
-				<tbody>
-					<tr v-for="row in castRowList" :key="row.key">
+				<VueDraggable v-model="castDraft"
+					tag="tbody"
+					handle=".cn-rules-editor__drag-handle"
+					:disabled="saving"
+					:animation="150"
+					ghost-class="cn-rules-editor__row--ghost"
+					drag-class="cn-rules-editor__row--dragging"
+					@end="onCastReorder">
+					<tr v-for="(row, index) in castDraft"
+						:key="row.key"
+						tabindex="0"
+						class="cn-rules-editor__row"
+						@keydown.up.prevent="moveRow('cast', index, -1)"
+						@keydown.down.prevent="moveRow('cast', index, 1)">
+						<td class="cn-rules-editor__col-handle">
+							<button type="button"
+								class="cn-rules-editor__drag-handle"
+								:aria-label="t('openconnector', 'Drag to reorder')"
+								:disabled="saving"
+								tabindex="-1">
+								<DragVerticalIcon :size="18" />
+							</button>
+						</td>
 						<td class="cn-rules-editor__cell-key">
 							{{ row.key }}
 						</td>
@@ -135,7 +184,7 @@
 							</NcButton>
 						</td>
 					</tr>
-				</tbody>
+				</VueDraggable>
 			</table>
 			<p v-else class="cn-rules-editor__empty">
 				{{ t('openconnector', 'No cast rules yet.') }}
@@ -155,17 +204,39 @@
 			<p class="cn-rules-editor__help">
 				{{ t('openconnector', 'Unset rules remove a property from the output object. They only apply when pass-through is enabled.') }}
 			</p>
-			<table v-if="unsetRules.length" class="cn-rules-editor__table">
+			<table v-if="unsetDraft.length" class="cn-rules-editor__table">
 				<thead>
 					<tr>
+						<th class="cn-rules-editor__col-handle" aria-hidden="true" />
 						<th>{{ t('openconnector', 'Property') }}</th>
 						<th class="cn-rules-editor__col-actions">
 							{{ t('openconnector', 'Actions') }}
 						</th>
 					</tr>
 				</thead>
-				<tbody>
-					<tr v-for="(property, index) in unsetRules" :key="property + '-' + index">
+				<VueDraggable v-model="unsetDraft"
+					tag="tbody"
+					handle=".cn-rules-editor__drag-handle"
+					:disabled="saving"
+					:animation="150"
+					ghost-class="cn-rules-editor__row--ghost"
+					drag-class="cn-rules-editor__row--dragging"
+					@end="onUnsetReorder">
+					<tr v-for="(property, index) in unsetDraft"
+						:key="property + '-' + index"
+						tabindex="0"
+						class="cn-rules-editor__row"
+						@keydown.up.prevent="moveRow('unset', index, -1)"
+						@keydown.down.prevent="moveRow('unset', index, 1)">
+						<td class="cn-rules-editor__col-handle">
+							<button type="button"
+								class="cn-rules-editor__drag-handle"
+								:aria-label="t('openconnector', 'Drag to reorder')"
+								:disabled="saving"
+								tabindex="-1">
+								<DragVerticalIcon :size="18" />
+							</button>
+						</td>
 						<td class="cn-rules-editor__cell-key">
 							{{ property }}
 						</td>
@@ -188,7 +259,7 @@
 							</NcButton>
 						</td>
 					</tr>
-				</tbody>
+				</VueDraggable>
 			</table>
 			<p v-else class="cn-rules-editor__empty">
 				{{ t('openconnector', 'No unset rules yet.') }}
@@ -224,8 +295,40 @@ import { NcButton } from '@nextcloud/vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import DragVerticalIcon from 'vue-material-design-icons/DragVertical.vue'
+import { VueDraggable } from 'vue-draggable-plus'
 
 import EditMappingRuleDialog from './EditMappingRuleDialog.vue'
+
+/**
+ * Convert a keyed-rules object into an ordered array of `{ key, value }`
+ * row records the drag-and-drop component can mutate in place.
+ *
+ * @param {object} obj Source keyed object.
+ * @return {Array<{key: string, value: any}>} Ordered row list.
+ */
+function objectToRowList(obj) {
+	if (!obj || typeof obj !== 'object') return []
+	return Object.keys(obj).map((key) => ({ key, value: obj[key] }))
+}
+
+/**
+ * Rebuild a keyed-rules object from an ordered row list. JS object key
+ * iteration is insertion-ordered for string keys, so the returned object
+ * serialises in the row list's order.
+ *
+ * @param {Array<{key: string, value: any}>} rows Ordered row list.
+ * @return {object} Rebuilt keyed-rules object.
+ */
+function rowListToObject(rows) {
+	const out = {}
+	for (const row of rows) {
+		if (row && typeof row.key === 'string') {
+			out[row.key] = row.value
+		}
+	}
+	return out
+}
 
 export default {
 	name: 'MappingRulesEditor',
@@ -235,6 +338,8 @@ export default {
 		PlusIcon,
 		PencilIcon,
 		DeleteIcon,
+		DragVerticalIcon,
+		VueDraggable,
 		EditMappingRuleDialog,
 	},
 
@@ -269,6 +374,17 @@ export default {
 	data() {
 		return {
 			activeTab: 'mapping',
+			/**
+			 * Local draft copies of the three rule collections. Drag-and-drop
+			 * mutates these arrays in place; we then commit a reconstructed
+			 * collection back to the parent via the existing update events.
+			 *
+			 * Kept in sync with the props via the watcher below — parent
+			 * persists are the source of truth.
+			 */
+			mappingDraft: objectToRowList(this.mappingRules),
+			castDraft: objectToRowList(this.castRules),
+			unsetDraft: [...this.unsetRules],
 			/**
 			 * @type {null|{
 			 *   kind: 'mapping'|'cast'|'unset',
@@ -311,6 +427,27 @@ export default {
 				key,
 				value: this.castRules[key],
 			}))
+		},
+	},
+
+	watch: {
+		mappingRules: {
+			handler(next) {
+				this.mappingDraft = objectToRowList(next)
+			},
+			deep: true,
+		},
+		castRules: {
+			handler(next) {
+				this.castDraft = objectToRowList(next)
+			},
+			deep: true,
+		},
+		unsetRules: {
+			handler(next) {
+				this.unsetDraft = [...next]
+			},
+			deep: true,
 		},
 	},
 
@@ -425,6 +562,57 @@ export default {
 			const next = this.unsetRules.filter((entry) => entry !== property)
 			this.$emit('update-unset', next)
 		},
+
+		/** Drag-end handler: emit a rebuilt object in the new order. */
+		onMappingReorder() {
+			this.$emit('update-mapping', rowListToObject(this.mappingDraft))
+		},
+		onCastReorder() {
+			this.$emit('update-cast', rowListToObject(this.castDraft))
+		},
+		onUnsetReorder() {
+			this.$emit('update-unset', [...this.unsetDraft])
+		},
+
+		/**
+		 * Keyboard reorder. Swaps the focused row with its neighbour in the
+		 * given direction and commits via the same reorder path the drag
+		 * handler uses.
+		 *
+		 * @param {'mapping'|'cast'|'unset'} kind Which collection.
+		 * @param {number} index Current row index.
+		 * @param {number} direction -1 to move up, 1 to move down.
+		 */
+		moveRow(kind, index, direction) {
+			let list
+			if (kind === 'mapping') list = this.mappingDraft
+			else if (kind === 'cast') list = this.castDraft
+			else list = this.unsetDraft
+			const target = index + direction
+			if (target < 0 || target >= list.length) return
+			const next = [...list]
+			const [moved] = next.splice(index, 1)
+			next.splice(target, 0, moved)
+			if (kind === 'mapping') {
+				this.mappingDraft = next
+				this.onMappingReorder()
+			} else if (kind === 'cast') {
+				this.castDraft = next
+				this.onCastReorder()
+			} else {
+				this.unsetDraft = next
+				this.onUnsetReorder()
+			}
+			// Restore focus on the new row position so successive arrow
+			// presses keep moving the same logical row.
+			this.$nextTick(() => {
+				const rows = this.$el.querySelectorAll(
+					`section.cn-rules-editor__panel .cn-rules-editor__row`,
+				)
+				const row = rows[target]
+				if (row && typeof row.focus === 'function') row.focus()
+			})
+		},
 	},
 }
 </script>
@@ -501,6 +689,63 @@ export default {
 .cn-rules-editor__table th {
 	font-weight: 600;
 	background: var(--color-background-hover);
+}
+
+.cn-rules-editor__row {
+	transition: background-color 0.1s ease, box-shadow 0.1s ease;
+	outline: none;
+}
+
+.cn-rules-editor__row:hover {
+	background: var(--color-background-hover);
+}
+
+.cn-rules-editor__row:focus {
+	background: var(--color-background-hover);
+	box-shadow: inset 2px 0 0 var(--color-primary-element, var(--color-primary));
+}
+
+.cn-rules-editor__row--ghost {
+	opacity: 0.4;
+	background: var(--color-primary-element-light, var(--color-background-dark));
+}
+
+.cn-rules-editor__row--dragging {
+	background: var(--color-main-background);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.cn-rules-editor__col-handle {
+	width: 32px;
+	padding-right: 0;
+	padding-left: 8px;
+	vertical-align: middle;
+}
+
+.cn-rules-editor__drag-handle {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: transparent;
+	border: none;
+	padding: 4px;
+	cursor: grab;
+	color: var(--color-text-maxcontrast);
+	border-radius: var(--border-radius);
+}
+
+.cn-rules-editor__drag-handle:hover {
+	background: var(--color-background-dark);
+	color: var(--color-main-text);
+}
+
+.cn-rules-editor__drag-handle:active {
+	cursor: grabbing;
+}
+
+.cn-rules-editor__drag-handle:disabled {
+	cursor: not-allowed;
+	opacity: 0.4;
 }
 
 .cn-rules-editor__cell-key {


### PR DESCRIPTION
## Summary

Two follow-ups for #874's bespoke MappingDetailPage:

- **Drag-to-reorder rules.** Each row in the Mapping / Cast / Unset tabs gets an MDI `drag-vertical` grip handle on the left; rows are `tabindex="0"` so ArrowUp / ArrowDown move the focused row within its tab. Drag-end and keyboard-move both rebuild the collection in the new order and emit through the existing `update-mapping` / `update-cast` / `update-unset` channels.
- **Live preview pane.** The detail page is now a 50/50 split (collapses on `<1100px`): rules editor on the left, preview pane on the right. The preview holds a JSON sample-input textarea and a read-only output pre below. Every rule edit OR sample-input edit fires a 400 ms-debounced `POST /api/mappings/test`. Inflight shows a small `NcLoadingIcon` next to the Output label (does not block edits). Server-side errors surface as an inline `NcNoteCard` with status code + message. A "Reset preview" button cancels pending requests and clears both sample + output. Bad JSON in the sample renders an inline parse-error below the textarea without firing the request.

Files touched (matches the brief's allow-list):
- `src/views/wrappers/MappingRulesEditor.vue` — adds `VueDraggable` per tab, drag handles, keyboard reorder, local draft arrays with deep watchers.
- `src/views/wrappers/MappingDetailPage.vue` — adds preview card, debounced `runPreview`, reset button, two-column grid.

Build is green (`npm run build` — only pre-existing bundle-size warnings). Lint script crashes on `@nextcloud/no-deprecations` (`info.xml` missing `<max-version>` on the `<peer-app>` element) — a pre-existing repo-config issue independent of this change and outside the file-touch boundary.

## Known limitation (please read before merging)

OpenRegister's PUT path does not preserve client-side JSON object key ordering. Verified via direct API tests against `/api/objects/openconnector/mapping/<id>`: sending `{zeta, alpha, beta, gamma}` after a record with `{beta, alpha, gamma}` came back as `{beta, zeta, alpha, gamma}` — original keys retained their storage order, the new key got inserted between them, and the client-supplied order was discarded.

**Effect**: the drag-reorder UI works locally — rows reorder visually, the new order persists in the editor's draft state, and the parent PUT fires — but on the next fetch the rows snap back to the original storage order. The preview pane is unaffected (it sends the live in-memory mapping, not a re-fetched one).

The clean fix is either:
1. An `_order` sidecar field on the Mapping schema that `MappingService::executeMapping` honors when iterating rules, or
2. A schema change storing rules as an ordered array of `{property, template}` pairs.

Both options need PHP + schema work outside this PR's `src/views/wrappers/` scope. Recommend a follow-up issue.

## Test plan

- [x] `npm run build` — green (pre-existing bundle-size warnings only).
- [x] Bundle deployed to dev container; mapping detail page loads with 3 drag-handle icons visible and a "Live preview" pane mounted side-by-side with the rules editor.
- [x] Preview pane fires `POST /api/mappings/test` (verified — returns the same `resultObject` the existing TestMappingModal would produce).
- [x] Reset preview clears both sample + output.
- [ ] Drag-reorder *visual* — works (rows reorder during the session).
- [ ] Drag-reorder *persistence* — blocked on OR PUT key-order behaviour described above. Local PUT fires, server stores, but order on re-fetch is not the dragged order.