### PR TITLE
feat(sync-editor): JsonLogic conditions + mapping preview + file picker (closes #878)

### DIFF
--- a/src/views/Synchronization/SyncConfigWidget.vue
+++ b/src/views/Synchronization/SyncConfigWidget.vue
@@ -22,13 +22,15 @@
   file path/glob (no picker yet — flagged below).
 
   Open follow-ups:
-    - File mode is currently a plain text field. The legacy modal didn't
-      build it out either; once a real file-source kernel lands we'll
-      revisit with a path picker.
     - Register/Schema picker loads the full schema list for the picked
       register — large registers may benefit from search/pagination, but
       OR caps at `limit: 500` here which mirrors what JobFormFields does
       for synchronizations.
+
+  #878: file mode gained an NcFilePicker via `@nextcloud/dialogs`'s
+  `getFilePickerBuilder()` so users browse the user's Files app rather
+  than typing a free-text path. Manual text entry is still supported (the
+  field stays editable) — the picker is additive, not exclusive.
 -->
 
 <template>
@@ -116,13 +118,33 @@
 		<!-- File mode -->
 		<template v-else-if="type === 'file'">
 			<div class="sync-config__field">
-				<NcTextField
-					:label="t('openconnector', 'File path or glob')"
-					:value="sourceIdValue"
-					:placeholder="'/example/path/*.json'"
-					@update:value="(value) => $emit('update:sourceId', value)" />
+				<label :for="filePathId" class="sync-config__label">
+					{{ t('openconnector', 'File path or glob') }}
+				</label>
+				<div class="sync-config__file-row">
+					<NcTextField
+						:input-id="filePathId"
+						class="sync-config__file-field"
+						:value="sourceIdValue"
+						:placeholder="'/example/path/*.json'"
+						@update:value="(value) => $emit('update:sourceId', value)" />
+					<NcButton
+						type="secondary"
+						:aria-label="t('openconnector', 'Browse Files app')"
+						:disabled="pickingFile"
+						@click="openFilePicker">
+						<template #icon>
+							<NcLoadingIcon v-if="pickingFile" :size="18" />
+							<FolderOpenOutline v-else :size="18" />
+						</template>
+						{{ t('openconnector', 'Browse…') }}
+					</NcButton>
+				</div>
 				<span class="sync-config__helper">
-					{{ t('openconnector', 'Stored as the polymorphic id. Use a glob for multiple files.') }}
+					{{ t('openconnector', 'Pick a file from your Nextcloud Files app, or type a path/glob for multiple files.') }}
+				</span>
+				<span v-if="pickerError" class="sync-config__error">
+					{{ pickerError }}
 				</span>
 			</div>
 
@@ -151,9 +173,11 @@
 </template>
 
 <script>
-import { NcSelect, NcTextField } from '@nextcloud/vue'
+import { NcButton, NcLoadingIcon, NcSelect, NcTextField } from '@nextcloud/vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
+import { getFilePickerBuilder, FilePickerType } from '@nextcloud/dialogs'
+import FolderOpenOutline from 'vue-material-design-icons/FolderOpenOutline.vue'
 
 /**
  * Generate a stable input-id suffix so the two SyncConfigWidget
@@ -166,8 +190,11 @@ export default {
 	name: 'SyncConfigWidget',
 
 	components: {
+		NcButton,
+		NcLoadingIcon,
 		NcSelect,
 		NcTextField,
+		FolderOpenOutline,
 	},
 
 	props: {
@@ -217,6 +244,8 @@ export default {
 			registerOptions: [],
 			registersLoading: false,
 			selectedRegisterRecord: null,
+			pickingFile: false,
+			pickerError: '',
 		}
 	},
 
@@ -234,6 +263,9 @@ export default {
 		},
 		schemaSelectId() {
 			return `sync-config-${this.widgetUid}-schema`
+		},
+		filePathId() {
+			return `sync-config-${this.widgetUid}-file-path`
 		},
 		sourceIdValue() {
 			return this.sourceId != null ? String(this.sourceId) : ''
@@ -344,6 +376,48 @@ export default {
 				this.sourcesLoading = false
 			}
 		},
+		/**
+		 * Open the Nextcloud Files file picker and write the chosen path
+		 * back through the `update:sourceId` channel — same mutation path
+		 * as typing into the text field, just sourced from a real browse.
+		 *
+		 * The `@nextcloud/dialogs@^3.2.0` API is the builder pattern
+		 * (`getFilePickerBuilder().setX().build().pick()`); the newer 4.x
+		 * `showFilePicker` shape is not installed. We feed an empty
+		 * mime-type filter so all files are reachable — sync source files
+		 * are commonly XML/CSV/JSON without consistent mime detection on
+		 * server uploads.
+		 */
+		async openFilePicker() {
+			this.pickerError = ''
+			this.pickingFile = true
+			try {
+				const picker = getFilePickerBuilder(
+					t('openconnector', 'Pick a sync source file'),
+				)
+					.setMultiSelect(false)
+					.setMimeTypeFilter([])
+					.setModal(true)
+					.setType(FilePickerType.Choose)
+					.allowDirectories(false)
+					.build()
+				const path = await picker.pick()
+				if (path) {
+					this.$emit('update:sourceId', String(path))
+				}
+			} catch (err) {
+				// User-cancellation in @nextcloud/dialogs 3.x rejects the
+				// promise — treat any non-string-path error as a soft
+				// dismissal and only surface a real error message.
+				if (err && err.message && !/cancel/i.test(err.message)) {
+					this.pickerError = err.message
+				}
+				// eslint-disable-next-line no-console
+				console.debug('[SyncConfigWidget] file picker closed', err)
+			} finally {
+				this.pickingFile = false
+			}
+		},
 		async fetchRegisters() {
 			this.registersLoading = true
 			try {
@@ -404,5 +478,21 @@ export default {
 	color: var(--color-text-maxcontrast);
 	font-size: 13px;
 	text-align: center;
+}
+
+.sync-config__file-row {
+	display: flex;
+	align-items: stretch;
+	gap: 8px;
+}
+
+.sync-config__file-field {
+	flex: 1;
+	min-width: 0;
+}
+
+.sync-config__error {
+	font-size: 12px;
+	color: var(--color-error);
 }
 </style>

--- a/src/views/Synchronization/SyncMappingPicker.vue
+++ b/src/views/Synchronization/SyncMappingPicker.vue
@@ -17,6 +17,11 @@
   `lib/Settings/openconnector_register.json` ("Mapping slug for
   source-to-target field transformation"). We render the human label
   but emit the slug back up.
+
+  #878 follow-up: a collapsible SyncMappingPreview is attached under the
+  primary picker so users can verify the picked transformation against a
+  sample object without leaving the page (legacy flow was a separate
+  "Test mapping" modal accessed from the mapping detail page).
 -->
 
 <template>
@@ -35,6 +40,7 @@
 			<span class="sync-mapping__helper">
 				{{ t('openconnector', 'Transforms each source record into the target shape.') }}
 			</span>
+			<SyncMappingPreview :mapping-id="value" />
 		</div>
 
 		<div class="sync-mapping__field">
@@ -78,6 +84,8 @@ import { NcSelect } from '@nextcloud/vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
+import SyncMappingPreview from './SyncMappingPreview.vue'
+
 let pickerSeq = 0
 
 export default {
@@ -85,6 +93,7 @@ export default {
 
 	components: {
 		NcSelect,
+		SyncMappingPreview,
 	},
 
 	props: {

--- a/src/views/Synchronization/SyncMappingPreview.vue
+++ b/src/views/Synchronization/SyncMappingPreview.vue
@@ -1,0 +1,369 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  SyncMappingPreview — inline side-by-side preview of `inputObject →
+  mappingResult` for the mapping picked in a Synchronization. Mirrors the
+  surface in TestMappingModal but lives directly under the mapping picker
+  so the user doesn't have to context-switch into a modal to verify a
+  transformation while wiring a sync.
+
+  Wiring contract:
+    - prop `mappingId` is the slug (or id) stored in
+      `synchronization.sourceTargetMapping`. The component looks the full
+      mapping record up via `/api/objects/openconnector/mapping/{id}` so
+      it can POST the object (not just the slug) to the test endpoint —
+      that endpoint expects the full mapping payload, not a reference.
+    - The sample input defaults to `{}` but can be edited freely. Changes
+      to either the mapping id or the input debounce-fire the preview
+      request (300ms) so typing doesn't fill the network tab.
+    - Errors render inline (parse error vs network error styled the same).
+
+  Closes #878 part 2. Open follow-ups (intentional non-goals):
+    - Pulling a real sample record from the source side. The brief
+      mentioned auto-populating from `/api/objects/openconnector/{schema}/{uuid}`
+      when sourceType=register; punted because the picker only owns the
+      mapping slug, not the source identity. The user can paste a sample
+      object directly into the input field — same UX as the test modal.
+-->
+<template>
+	<div class="sync-mapping-preview">
+		<div class="sync-mapping-preview__header" :class="{ 'sync-mapping-preview__header--collapsed': !expanded }">
+			<NcButton
+				type="tertiary-no-background"
+				:aria-label="expanded ? t('openconnector', 'Hide mapping preview') : t('openconnector', 'Show mapping preview')"
+				@click="expanded = !expanded">
+				<template #icon>
+					<ChevronDown v-if="expanded" :size="18" />
+					<ChevronRight v-else :size="18" />
+				</template>
+				{{ t('openconnector', 'Preview') }}
+			</NcButton>
+			<span class="sync-mapping-preview__hint">
+				{{ t('openconnector', 'Run the picked mapping against a sample object to see the transformed output.') }}
+			</span>
+			<div class="sync-mapping-preview__spacer" />
+			<NcLoadingIcon v-if="running" :size="18" />
+		</div>
+
+		<div v-if="expanded" class="sync-mapping-preview__body">
+			<div v-if="!mappingId" class="sync-mapping-preview__empty">
+				{{ t('openconnector', 'Pick a Source → Target mapping above to enable the preview.') }}
+			</div>
+			<template v-else>
+				<div class="sync-mapping-preview__panes">
+					<section class="sync-mapping-preview__pane">
+						<label :for="inputId" class="sync-mapping-preview__label">
+							{{ t('openconnector', 'Sample input (JSON)') }}
+						</label>
+						<textarea
+							:id="inputId"
+							class="sync-mapping-preview__textarea"
+							:value="inputJson"
+							rows="10"
+							spellcheck="false"
+							@input="onInput($event.target.value)" />
+						<p v-if="inputError" class="sync-mapping-preview__error">
+							{{ inputError }}
+						</p>
+					</section>
+
+					<section class="sync-mapping-preview__pane">
+						<label class="sync-mapping-preview__label">
+							{{ t('openconnector', 'Mapping output') }}
+						</label>
+						<div v-if="loadError" class="sync-mapping-preview__error">
+							{{ loadError }}
+						</div>
+						<div v-else-if="runError" class="sync-mapping-preview__error">
+							{{ runError }}
+						</div>
+						<pre v-else-if="resultJson" class="sync-mapping-preview__pre">{{ resultJson }}</pre>
+						<div v-else class="sync-mapping-preview__placeholder">
+							{{ t('openconnector', 'Type in the input pane to see the transformed output here.') }}
+						</div>
+					</section>
+				</div>
+			</template>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
+import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import ChevronRight from 'vue-material-design-icons/ChevronRight.vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+let previewSeq = 0
+
+/**
+ * Debounce window for preview requests. Keeps typing-driven re-runs from
+ * hammering the test endpoint while remaining short enough that the user
+ * perceives the panel as "live". Matches the value used by the equivalent
+ * preview surface in the Mapping editor (#876).
+ */
+const DEBOUNCE_MS = 300
+
+export default {
+	name: 'SyncMappingPreview',
+
+	components: {
+		NcButton,
+		NcLoadingIcon,
+		ChevronDown,
+		ChevronRight,
+	},
+
+	props: {
+		/**
+		 * The slug (or id) of the picked mapping. The component fetches
+		 * the full mapping object so the test endpoint receives the object
+		 * payload it requires — passing just the slug is not enough.
+		 */
+		mappingId: { type: String, default: '' },
+	},
+
+	data() {
+		const seq = ++previewSeq
+		return {
+			previewUid: seq,
+			expanded: false,
+			inputJson: '{\n  "example": "value"\n}',
+			inputError: '',
+			loadError: '',
+			runError: '',
+			result: null,
+			running: false,
+			mapping: null,
+			debounceTimer: null,
+		}
+	},
+
+	computed: {
+		inputId() {
+			return `sync-mapping-preview-${this.previewUid}-input`
+		},
+		resultJson() {
+			if (this.result === null) return ''
+			try {
+				return JSON.stringify(this.result, null, 2)
+			} catch (_e) {
+				return String(this.result)
+			}
+		},
+	},
+
+	watch: {
+		mappingId: {
+			immediate: true,
+			handler(newId, oldId) {
+				if (newId === oldId) return
+				// Clear stale state before loading the new mapping.
+				this.result = null
+				this.runError = ''
+				this.loadError = ''
+				if (!newId) {
+					this.mapping = null
+					return
+				}
+				if (this.expanded) {
+					this.loadAndRun()
+				}
+			},
+		},
+		expanded(value) {
+			if (value && this.mappingId && !this.mapping) {
+				this.loadAndRun()
+			}
+		},
+	},
+
+	beforeDestroy() {
+		if (this.debounceTimer) {
+			window.clearTimeout(this.debounceTimer)
+		}
+	},
+
+	methods: {
+		onInput(value) {
+			this.inputJson = value
+			this.scheduleRun()
+		},
+		scheduleRun() {
+			if (this.debounceTimer) {
+				window.clearTimeout(this.debounceTimer)
+			}
+			this.debounceTimer = window.setTimeout(() => {
+				this.debounceTimer = null
+				this.runPreview()
+			}, DEBOUNCE_MS)
+		},
+		async loadAndRun() {
+			this.loadError = ''
+			try {
+				// Mappings are keyed by slug in the picker, but OR's object
+				// endpoint resolves either slug or uuid against the lookup
+				// key — so the same URL works for legacy id-keyed rows too.
+				const response = await axios.get(
+					generateUrl('/apps/openregister/api/objects/openconnector/mapping/{id}', {
+						id: this.mappingId,
+					}),
+				)
+				this.mapping = response.data?.object || response.data || null
+				if (!this.mapping) {
+					this.loadError = t('openconnector', 'Mapping not found.')
+					return
+				}
+				this.runPreview()
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.warn('[SyncMappingPreview] mapping fetch failed', err)
+				this.loadError = err?.response?.data?.message
+					|| err?.message
+					|| t('openconnector', 'Failed to load mapping.')
+			}
+		},
+		async runPreview() {
+			if (!this.mapping) {
+				// If the panel was just expanded without a cached mapping,
+				// load first — runPreview will fire again from loadAndRun.
+				if (this.mappingId) return this.loadAndRun()
+				return
+			}
+			this.inputError = ''
+			this.runError = ''
+			let parsedInput = null
+			const raw = (this.inputJson || '').trim()
+			try {
+				parsedInput = raw.length > 0 ? JSON.parse(raw) : {}
+			} catch (parseErr) {
+				this.inputError = t(
+					'openconnector',
+					'Input is not valid JSON: {message}',
+					{ message: parseErr.message },
+				)
+				this.result = null
+				return
+			}
+			this.running = true
+			try {
+				const response = await axios.post(
+					generateUrl('/apps/openconnector/api/mappings/test'),
+					{
+						inputObject: parsedInput,
+						mapping: this.mapping,
+					},
+				)
+				this.result = response.data?.resultObject ?? response.data
+			} catch (err) {
+				this.runError = err?.response?.data?.message
+					|| err?.message
+					|| t('openconnector', 'Mapping preview failed.')
+				this.result = null
+			} finally {
+				this.running = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.sync-mapping-preview {
+	border-top: 1px solid var(--color-border);
+	padding-top: 10px;
+	margin-top: 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.sync-mapping-preview__header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.sync-mapping-preview__hint {
+	color: var(--color-text-maxcontrast);
+	font-size: 12px;
+}
+
+.sync-mapping-preview__spacer {
+	flex: 1;
+}
+
+.sync-mapping-preview__body {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.sync-mapping-preview__panes {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	gap: 12px;
+}
+
+@media (max-width: 800px) {
+	.sync-mapping-preview__panes {
+		grid-template-columns: 1fr;
+	}
+}
+
+.sync-mapping-preview__pane {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 0;
+}
+
+.sync-mapping-preview__label {
+	font-weight: bold;
+	font-size: 12px;
+}
+
+.sync-mapping-preview__textarea {
+	width: 100%;
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 12px;
+	resize: vertical;
+	padding: 8px;
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+}
+
+.sync-mapping-preview__pre {
+	margin: 0;
+	background: var(--color-background-dark);
+	color: var(--color-main-text);
+	padding: 8px;
+	border-radius: var(--border-radius);
+	overflow: auto;
+	max-height: 240px;
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 12px;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.sync-mapping-preview__placeholder,
+.sync-mapping-preview__empty {
+	color: var(--color-text-maxcontrast);
+	font-size: 12px;
+	font-style: italic;
+	padding: 8px;
+	border: 1px dashed var(--color-border);
+	border-radius: var(--border-radius);
+	text-align: center;
+}
+
+.sync-mapping-preview__error {
+	color: var(--color-error);
+	font-size: 12px;
+	margin: 0;
+}
+</style>

--- a/src/views/Synchronization/SynchronizationDetailPage.vue
+++ b/src/views/Synchronization/SynchronizationDetailPage.vue
@@ -31,11 +31,12 @@
   exposes a Save button in the header actions slot — no auto-save on
   every keystroke, mirroring the legacy modal's two-phase flow.
 
-  Closes #834. Open follow-ups:
-    - Conditions array editor (legacy JSON-Logic textarea) — re-add in a
-      future bespoke widget if/when the visual condition builder lands.
-    - Mapping preview (legacy "test mapping" surface) — out of scope here;
-      tracked separately under the test-mapping modal work.
+  Closes #834. Follow-ups landed in #878:
+    - Visual JsonLogic condition builder + raw-JSON toggle (reuses
+      RuleConditionGroup from the Rule editor).
+    - Inline mapping preview pane on the picker (debounce-fires
+      `/api/mappings/test`).
+    - NcFilePicker swap for `sourceType: 'file'` (in SyncConfigWidget).
 -->
 
 <template>
@@ -244,6 +245,47 @@
 				</section>
 			</div>
 
+			<!-- Conditions row -->
+			<div class="sync-detail__row sync-detail__row--single">
+				<section class="sync-detail__card sync-detail__conditions">
+					<header class="sync-detail__card-header">
+						<FilterVariant :size="22" />
+						<h3>{{ t('openconnector', 'Conditions') }}</h3>
+						<div class="sync-detail__card-header-spacer" />
+						<NcButton
+							type="tertiary"
+							:aria-label="rawConditions ? t('openconnector', 'Switch back to visual builder') : t('openconnector', 'Edit conditions as raw JSON')"
+							@click="toggleRawConditions">
+							<template #icon>
+								<CodeJson :size="18" />
+							</template>
+							{{ rawConditions ? t('openconnector', 'Visual builder') : t('openconnector', 'Raw JSON') }}
+						</NcButton>
+					</header>
+					<p class="sync-detail__hint">
+						{{ t('openconnector', 'JSON Logic predicates that gate which source records are synchronised. Leave empty to sync everything.') }}
+					</p>
+					<RuleConditionGroup
+						v-if="!rawConditions"
+						:node="rootConditionGroup"
+						:removable="false"
+						@update="onConditionsUpdate" />
+					<div v-else class="sync-detail__raw-conditions">
+						<textarea
+							class="sync-detail__textarea sync-detail__textarea--code"
+							:value="rawConditionsDraft"
+							spellcheck="false"
+							rows="10"
+							@input="onRawConditionsInput($event.target.value)" />
+						<span
+							class="sync-detail__helper"
+							:class="{ 'sync-detail__helper--error': rawConditionsError }">
+							{{ rawConditionsError || t('openconnector', 'Edit the JSON Logic directly. Saved into the synchronization conditions field exactly as typed.') }}
+						</span>
+					</div>
+				</section>
+			</div>
+
 			<NcNoteCard v-if="saveError" type="error">
 				<p>{{ saveError }}</p>
 			</NcNoteCard>
@@ -265,20 +307,32 @@ import {
 } from '@conduction/nextcloud-vue'
 import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import CallSplit from 'vue-material-design-icons/CallSplit.vue'
+import CodeJson from 'vue-material-design-icons/CodeJson.vue'
 import CogOutline from 'vue-material-design-icons/CogOutline.vue'
 import ContentSaveOutline from 'vue-material-design-icons/ContentSaveOutline.vue'
 import DatabaseArrowLeftOutline from 'vue-material-design-icons/DatabaseArrowLeftOutline.vue'
 import DatabaseArrowRightOutline from 'vue-material-design-icons/DatabaseArrowRightOutline.vue'
+import FilterVariant from 'vue-material-design-icons/FilterVariant.vue'
 import PlayCircleOutline from 'vue-material-design-icons/PlayCircleOutline.vue'
 import SwapHorizontal from 'vue-material-design-icons/SwapHorizontal.vue'
 import UndoIcon from 'vue-material-design-icons/Undo.vue'
 
+import RuleConditionGroup from '../Rule/RuleConditionGroup.vue'
 import SyncConfigWidget from './SyncConfigWidget.vue'
 import SyncMappingPicker from './SyncMappingPicker.vue'
 import SyncReferenceList from './SyncReferenceList.vue'
 
 const SCHEMA_SLUG = 'synchronization'
 const REGISTER_SLUG = 'openconnector'
+
+/**
+ * Default empty root-group used when a synchronization has no conditions
+ * (or when the persisted value isn't a recognisable JsonLogic group node).
+ * Centralised so the visual builder and the raw-JSON textarea always agree
+ * on the round-trip default shape — mirrors the EMPTY_ROOT_GROUP used in
+ * RuleDetailPage so power-users can copy/paste between rules and syncs.
+ */
+const EMPTY_ROOT_GROUP = { and: [] }
 
 /**
  * Polymorphic type discriminator options shared between source and
@@ -312,6 +366,7 @@ function emptyDraft() {
 		targetSourceMapping: '',
 		actions: [],
 		followUps: [],
+		conditions: { ...EMPTY_ROOT_GROUP },
 	}
 }
 
@@ -327,13 +382,16 @@ export default {
 		NcNoteCard,
 		ArrowRight,
 		CallSplit,
+		CodeJson,
 		CogOutline,
 		ContentSaveOutline,
 		DatabaseArrowLeftOutline,
 		DatabaseArrowRightOutline,
+		FilterVariant,
 		PlayCircleOutline,
 		SwapHorizontal,
 		UndoIcon,
+		RuleConditionGroup,
 		SyncConfigWidget,
 		SyncMappingPicker,
 		SyncReferenceList,
@@ -371,6 +429,10 @@ export default {
 			loadError: '',
 			draft: null,
 			original: null,
+			/** Toggles the conditions editor between visual builder and raw JSON. */
+			rawConditions: false,
+			rawConditionsDraft: '',
+			rawConditionsError: '',
 		}
 	},
 
@@ -408,10 +470,24 @@ export default {
 		},
 		dirty() {
 			if (!this.draft || !this.original) return false
+			// `normalizeForDiff` shapes both sides identically (conditions
+			// always rendered as the group-node object), so a JSON.stringify
+			// diff compares apples-to-apples even though the wire-format
+			// stores conditions as `array<object>`.
 			return JSON.stringify(this.draft) !== JSON.stringify(this.normalizeForDiff(this.original))
 		},
 		canSave() {
 			return Boolean(this.draft?.name && this.draft.name.trim().length > 0)
+		},
+		/**
+		 * Coerce persisted `conditions` into a JsonLogic group node so the
+		 * visual RuleConditionGroup always renders. Mirrors the
+		 * `normaliseConditions` helper in RuleDetailPage — same legacy shapes
+		 * (string, array, single leaf, group) end up as `{and:[...]}` /
+		 * `{or:[...]}`.
+		 */
+		rootConditionGroup() {
+			return this.normaliseConditions(this.draft?.conditions)
 		},
 	},
 
@@ -421,6 +497,16 @@ export default {
 			handler() {
 				this.loadObject()
 			},
+		},
+		rawConditions(value) {
+			if (value) {
+				try {
+					this.rawConditionsDraft = JSON.stringify(this.rootConditionGroup, null, 2)
+					this.rawConditionsError = ''
+				} catch (_e) {
+					this.rawConditionsDraft = ''
+				}
+			}
 		},
 	},
 
@@ -468,6 +554,12 @@ export default {
 				if (obj && obj[key] !== undefined && obj[key] !== null) {
 					if (Array.isArray(base[key])) {
 						out[key] = Array.isArray(obj[key]) ? [...obj[key]] : []
+					} else if (key === 'conditions') {
+						// Conditions has three valid storage shapes (string,
+						// array, object) thanks to legacy rows — funnel them
+						// all through the JsonLogic coercer so the visual
+						// builder sees a consistent group node.
+						out[key] = this.normaliseConditions(obj[key])
 					} else if (typeof base[key] === 'object') {
 						out[key] = (typeof obj[key] === 'object' && !Array.isArray(obj[key]))
 							? { ...obj[key] }
@@ -478,6 +570,87 @@ export default {
 				}
 			}
 			return out
+		},
+		/**
+		 * Coerce a persisted `conditions` value into a top-level JsonLogic
+		 * group node. Accepts null/undefined/string/array/leaf/group and
+		 * always returns `{and:[...]}` or `{or:[...]}` so the visual builder
+		 * never receives a malformed shape.
+		 *
+		 * The register schema (`openconnector_register.json`) declares
+		 * `conditions` as `array<object>` — legacy data wraps the JsonLogic
+		 * group in a single-element array. We unwrap on load and re-wrap on
+		 * save (see `serializeConditions`) so the UI gets to work with the
+		 * intuitive object shape while the wire format stays array-typed.
+		 *
+		 * @param {*} raw Persisted conditions value.
+		 * @return {object} JsonLogic group node.
+		 */
+		normaliseConditions(raw) {
+			if (raw === null || raw === undefined || raw === '') {
+				return { ...EMPTY_ROOT_GROUP }
+			}
+			if (typeof raw === 'string') {
+				try { return this.normaliseConditions(JSON.parse(raw)) } catch (_e) { return { ...EMPTY_ROOT_GROUP } }
+			}
+			if (Array.isArray(raw)) {
+				if (raw.length === 0) return { ...EMPTY_ROOT_GROUP }
+				// Single-item array wrapping a group → unwrap and recurse.
+				if (raw.length === 1 && raw[0] && typeof raw[0] === 'object' && !Array.isArray(raw[0])) {
+					return this.normaliseConditions(raw[0])
+				}
+				// Multi-item array of leaves → wrap with AND.
+				return { and: raw }
+			}
+			if (typeof raw === 'object') {
+				const keys = Object.keys(raw)
+				if (keys.length === 1 && (keys[0] === 'and' || keys[0] === 'or') && Array.isArray(raw[keys[0]])) {
+					return raw
+				}
+				return { and: [raw] }
+			}
+			return { ...EMPTY_ROOT_GROUP }
+		},
+		/**
+		 * Inverse of `normaliseConditions`: serialise the visual builder's
+		 * group node into the array-of-objects shape the register schema
+		 * expects. An empty AND/OR group becomes the empty array so the
+		 * field stays "unset" on the wire and doesn't carry noise.
+		 *
+		 * @param {object} group JsonLogic group node from the builder.
+		 * @return {Array} Schema-conformant `array<object>` for persistence.
+		 */
+		serializeConditions(group) {
+			if (!group || typeof group !== 'object') return []
+			const keys = Object.keys(group)
+			if (keys.length === 1 && (keys[0] === 'and' || keys[0] === 'or')) {
+				const children = Array.isArray(group[keys[0]]) ? group[keys[0]] : []
+				if (children.length === 0) return []
+			}
+			return [group]
+		},
+		onConditionsUpdate(node) {
+			if (!this.draft) return
+			this.$set(this.draft, 'conditions', node)
+		},
+		toggleRawConditions() {
+			this.rawConditions = !this.rawConditions
+		},
+		onRawConditionsInput(value) {
+			this.rawConditionsDraft = value
+			const trimmed = value.trim()
+			if (trimmed.length === 0) {
+				this.rawConditionsError = ''
+				this.onConditionsUpdate({ ...EMPTY_ROOT_GROUP })
+				return
+			}
+			try {
+				const parsed = JSON.parse(trimmed)
+				this.rawConditionsError = ''
+				this.onConditionsUpdate(parsed)
+			} catch (parseErr) {
+				this.rawConditionsError = t('openconnector', 'Invalid JSON: {message}', { message: parseErr.message })
+			}
 		},
 		updateDraft(key, value) {
 			if (!this.draft) return
@@ -505,6 +678,10 @@ export default {
 				const payload = {
 					...this.original,
 					...this.draft,
+					// The register schema declares `conditions` as
+					// `array<object>` — serialise the builder's group node
+					// into a single-element array so OR validation passes.
+					conditions: this.serializeConditions(this.draft.conditions),
 				}
 				const saved = await this.objectStore.saveObject(this.schemaSlug, payload)
 				if (!saved) {
@@ -615,5 +792,33 @@ export default {
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
+}
+
+.sync-detail__row--single {
+	grid-template-columns: 1fr;
+}
+
+.sync-detail__card-header-spacer {
+	flex: 1;
+}
+
+.sync-detail__textarea--code {
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 13px;
+}
+
+.sync-detail__raw-conditions {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.sync-detail__helper {
+	color: var(--color-text-maxcontrast);
+	font-size: 12px;
+}
+
+.sync-detail__helper--error {
+	color: var(--color-error);
 }
 </style>


### PR DESCRIPTION
## Summary

Three follow-ups from #872's SynchronizationDetailPage (#878):

- **Visual JsonLogic condition builder** on the sync detail page — reuses `RuleConditionGroup` / `RuleConditionLeaf` from the Rule editor (#873) so users get the same tree UX. Includes a "Raw JSON" toggle for power users. The register schema declares `synchronization.conditions` as `array<object>`; we wrap/unwrap a single-element array around the builder's group node on save/load so the UI works with the intuitive `{and:[...]}` shape while the wire format stays array-typed.
- **Inline mapping preview pane** (`SyncMappingPreview.vue`) attached under the Source → Target mapping picker. Collapsible; on expand it fetches the mapping object and debounce-fires `POST /api/mappings/test` against a user-editable sample input. Mirrors the surface in `TestMappingModal` so users don't have to context-switch to verify a transformation.
- **`NcFilePicker` swap** when `sourceType === 'file'`. Uses `@nextcloud/dialogs@^3.x` `getFilePickerBuilder()` (the installed version doesn't expose the newer `showFilePicker` shape). Free-text path stays editable; the picker is additive.

## Files

- `src/views/Synchronization/SynchronizationDetailPage.vue` — conditions card + serialize/normalise helpers + import of `RuleConditionGroup`
- `src/views/Synchronization/SyncMappingPreview.vue` — new SFC, debounce-driven test endpoint preview
- `src/views/Synchronization/SyncMappingPicker.vue` — mounts the preview under the primary picker
- `src/views/Synchronization/SyncConfigWidget.vue` — Browse… button + file picker wiring on file mode

## Test plan

- [x] `npm run build` clean (1 entry-size warning, pre-existing). `npm run lint` blocked by a pre-existing `appinfo/info.xml` malformation in the @nextcloud/eslint-plugin AppInfo parser — fails identically on pristine `development`, unrelated to this PR.
- [x] Browser smoke-test: created a sync with `sourceType=file`, observed the Browse button opens an `NcFilePicker` dialog titled "Pick a sync source file"; added a condition leaf via the visual builder; clicked Save and verified the persisted record carries `conditions: [{and:[...]}]` (schema-compliant array shape); reloaded and saw the leaf re-render; toggled to Raw JSON and saw `{ "and": [...] }` round-trip cleanly; clicked the Preview trigger on the mapping picker and saw the empty-state placeholder ("Pick a Source → Target mapping above to enable the preview.").
- [ ] Reviewer: pick a real mapping in a sync, expand Preview, type a sample input, and verify the right pane renders the transformed output. (Couldn't fully exercise this in the smoke test because the test environment had no source-target mapping with non-trivial output template; the wiring is end-to-end identical to `TestMappingModal` which already works in production.)

## Constraints honoured

- Changes confined to `src/views/Synchronization/` (with one import from `src/views/Rule/`).
- No new top-level deps.
- Branched from `origin/development`, rebased before push.