### PR TITLE
style(phpcs): clean lib/Migration/ debt (advances #889)

### DIFF
--- a/lib/Migration/Version0Date20240826193657.php
+++ b/lib/Migration/Version0Date20240826193657.php
@@ -1,11 +1,24 @@
 <?php
+/**
+ * Initial schema migration creating the OpenConnector tables.
+ *
+ * Creates the endpoints, jobs, mappings, sources, synchronizations,
+ * synchronization contracts, consumers, call logs, job logs, and
+ * synchronization contract logs tables used by the app.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -17,7 +30,7 @@ use OCP\Migration\SimpleMigrationStep;
 
 
 /**
- * FIXME Auto-generated migration step: Please modify to your needs!
+ * Creates the initial OpenConnector table set on first install.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -27,28 +40,36 @@ use OCP\Migration\SimpleMigrationStep;
 class Version0Date20240826193657 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Creates the OpenConnector tables when they do not yet exist.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
-        if (!$schema->hasTable('openconnector_endpoints')) {
+        if ($schema->hasTable('openconnector_endpoints') === false) {
             $table = $schema->createTable('openconnector_endpoints');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -70,7 +91,7 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addIndex(['endpoint_regex'], 'openconnector_endpoints_endpoint_regex_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_jobs')) {
+        if ($schema->hasTable('openconnector_jobs') === false) {
             $table = $schema->createTable('openconnector_jobs');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -98,7 +119,7 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addIndex(['uuid'], 'openconnector_jobs_uuid_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_mappings')) {
+        if ($schema->hasTable('openconnector_mappings') === false) {
             $table = $schema->createTable('openconnector_mappings');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -116,7 +137,7 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addIndex(['uuid'], 'openconnector_mappings_uuid_index');
         }
 
-        if (!$schema->hasTable('openconnector_sources')) {
+        if ($schema->hasTable('openconnector_sources') === false) {
             $table = $schema->createTable('openconnector_sources');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -160,14 +181,14 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addIndex(['uuid'], 'openconnector_sources_uuid_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_synchronizations')) {
+        if ($schema->hasTable('openconnector_synchronizations') === false) {
             $table = $schema->createTable('openconnector_synchronizations');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
             $table->addColumn('version', Types::STRING, ['notnull' => true, 'length' => 255, 'default' => '0.0.1']);
             $table->addColumn('name', Types::STRING, ['notnull' => true, 'length' => 255]);
             $table->addColumn('description', Types::TEXT, ['notnull' => false]);
-            // Source
+            // Source.
             $table->addColumn('source_id', Types::STRING, ['notnull' => true, 'length' => 255]);
             $table->addColumn('source_type', Types::STRING, ['notnull' => true, 'length' => 255]);
             $table->addColumn('source_hash', Types::STRING, ['notnull' => false, 'length' => 255]);
@@ -176,7 +197,7 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addColumn('source_last_changed', Types::DATETIME, ['notnull' => false]);
             $table->addColumn('source_last_checked', Types::DATETIME, ['notnull' => false]);
             $table->addColumn('source_last_synced', Types::DATETIME, ['notnull' => false]);
-            // Target
+            // Target.
             $table->addColumn('target_id', Types::STRING, ['notnull' => true, 'length' => 255]);
             $table->addColumn('target_type', Types::STRING, ['notnull' => true, 'length' => 255]);
             $table->addColumn('target_hash', Types::STRING, ['notnull' => false, 'length' => 255]);
@@ -185,7 +206,7 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addColumn('target_last_changed', Types::DATETIME, ['notnull' => false]);
             $table->addColumn('target_last_checked', Types::DATETIME, ['notnull' => false]);
             $table->addColumn('target_last_synced', Types::DATETIME, ['notnull' => false]);
-            // General
+            // General.
             $table->addColumn('created', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);
             $table->addColumn('updated', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);
             $table->setPrimaryKey(['id']);
@@ -194,25 +215,25 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addIndex(['target_id'], 'openconnector_synchronizations_target_id_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_synchronization_contracts')) {
+        if ($schema->hasTable('openconnector_synchronization_contracts') === false) {
             $table = $schema->createTable('openconnector_synchronization_contracts');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
             $table->addColumn('version', Types::STRING, ['notnull' => true, 'length' => 255, 'default' => '0.0.1']);
             $table->addColumn('synchronization_id', Types::STRING, ['notnull' => true, 'length' => 255]);
-            // Source
+            // Source.
             $table->addColumn('source_id', Types::STRING, ['notnull' => false, 'length' => 255]);
             $table->addColumn('source_hash', Types::STRING, ['notnull' => false, 'length' => 255]);
             $table->addColumn('source_last_changed', Types::DATETIME, ['notnull' => false]);
             $table->addColumn('source_last_checked', Types::DATETIME, ['notnull' => false]);
             $table->addColumn('source_last_synced', Types::DATETIME, ['notnull' => false]);
-            // Target
+            // Target.
             $table->addColumn('target_id', Types::STRING, ['notnull' => false, 'length' => 255]);
             $table->addColumn('target_hash', Types::STRING, ['notnull' => false, 'length' => 255]);
             $table->addColumn('target_last_changed', Types::DATETIME, ['notnull' => false]);
             $table->addColumn('target_last_checked', Types::DATETIME, ['notnull' => false]);
             $table->addColumn('target_last_synced', Types::DATETIME, ['notnull' => false]);
-            // General
+            // General.
             $table->addColumn('created', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);
             $table->addColumn('updated', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);
 
@@ -225,33 +246,35 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addIndex(['synchronization_id', 'target_id'], 'openconnector_sync_contracts_sync_target_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_consumers')) {
+        if ($schema->hasTable('openconnector_consumers') === false) {
             $table = $schema->createTable('openconnector_consumers');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
-            // The id of the consumer
+            // The id of the consumer.
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
-            // The uuid of the consumer
+            // The uuid of the consumer.
             $table->addColumn('name', Types::STRING, ['notnull' => true, 'length' => 255]);
-            // The name of the consumer
+            // The name of the consumer.
             $table->addColumn('description', Types::TEXT, ['notnull' => false]);
-            // The description of the consumer
+            // The description of the consumer.
             $table->addColumn('domains', Types::JSON, ['notnull' => false]);
-            // The domains the consumer is allowed to run from
+            // The domains the consumer is allowed to run from.
             $table->addColumn('ips', Types::JSON, ['notnull' => false]);
-            // The ips the consumer is allowed to run from
+            // The ips the consumer is allowed to run from.
             $table->addColumn('authorization_type', Types::STRING, ['notnull' => false, 'length' => 255]);
-            // The authorization type of the consumer, should be one of the following: 'none', 'basic', 'bearer', 'apiKey', 'oauth2', 'jwt'. Keep in mind that the consumer needs to be able to handle the authorization type.
+            // The authorization type of the consumer, should be one of the following:
+            // 'none', 'basic', 'bearer', 'apiKey', 'oauth2', 'jwt'.
+            // Keep in mind that the consumer needs to be able to handle the authorization type.
             $table->addColumn('authorization_configuration', Types::TEXT, ['notnull' => false]);
-            // The authorization configuration of the consumer
+            // The authorization configuration of the consumer.
             $table->addColumn('created', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);
-            // the date and time the consumer was created
+            // The date and time the consumer was created.
             $table->addColumn('updated', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);
-            // the date and time the consumer was updated
+            // The date and time the consumer was updated.
             $table->setPrimaryKey(['id']);
             $table->addIndex(['uuid'], 'openconnector_consumers_uuid_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_call_logs')) {
+        if ($schema->hasTable('openconnector_call_logs') === false) {
             $table = $schema->createTable('openconnector_call_logs');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -275,7 +298,7 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addIndex(['status_code'], 'openconnector_call_logs_status_code_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_job_logs')) {
+        if ($schema->hasTable('openconnector_job_logs') === false) {
             $table = $schema->createTable('openconnector_job_logs');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -300,7 +323,7 @@ class Version0Date20240826193657 extends SimpleMigrationStep
             $table->addIndex(['user_id'], 'openconnector_job_logs_user_id_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_synchronization_contract_logs')) {
+        if ($schema->hasTable('openconnector_synchronization_contract_logs') === false) {
             $table = $schema->createTable('openconnector_synchronization_contract_logs');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -319,12 +342,17 @@ class Version0Date20240826193657 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241111144800.php
+++ b/lib/Migration/Version1Date20241111144800.php
@@ -1,11 +1,26 @@
 <?php
+/**
+ * Rename SynchronizationContract source fields to origin.
+ *
+ * This migration changes the following:
+ * - Renaming of SynchronizationContract sourceId & sourceHash to originId and originHash,
+ *   creating the new columns and transferring old data to the new fields.
+ * - Removal of old indexes related to sourceId and sourceHash.
+ * - Addition of new indexes for originId and synchronization_id fields.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -17,71 +32,86 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\IDBConnection;
 
 /**
- * This migration changes the following:
- * - Renaming of SynchronizationContract sourceId & sourceHash to originId and originHash,
- * creating the new columns and transferring old data to the new fields.
- * - Removal of old indexes related to sourceId and sourceHash
- * - Addition of new indexes for originId and synchronization_id fields
+ * Renames SynchronizationContract source fields to origin and migrates the data.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241111144800 extends SimpleMigrationStep
 {
 
+    /**
+     * Database connection used to copy data between the legacy and renamed columns.
+     *
+     * @var IDBConnection
+     */
     private IDBConnection $connection;
 
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $connection Database connection injected by the Nextcloud DI container.
+     */
     public function __construct(IDBConnection $connection)
     {
         $this->connection = $connection;
+
     }//end __construct()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Add the renamed columns and adjust related indexes.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
         $table  = $schema->getTable('openconnector_synchronization_contracts');
 
-        // Step 1: Add new columns for 'origin_id' and 'origin_hash'
+        // Step 1: Add new columns for 'origin_id' and 'origin_hash'.
         if ($table->hasColumn('origin_id') === false) {
             $table->addColumn(
-            'origin_id',
-            Types::STRING,
-            [
-                'length'  => 255,
-                'notnull' => true,
-            ]
+                'origin_id',
+                Types::STRING,
+                [
+                    'length'  => 255,
+                    'notnull' => true,
+                ]
             );
         }
 
         if ($table->hasColumn('origin_hash') === false) {
             $table->addColumn(
-            'origin_hash',
-            Types::STRING,
-            [
-                'length'  => 255,
-                'notnull' => false,
-            ]
+                'origin_hash',
+                Types::STRING,
+                [
+                    'length'  => 255,
+                    'notnull' => false,
+                ]
             );
         }
 
-        // Step 4: Adjust indexes in preparation for data migration
+        // Step 4: Adjust indexes in preparation for data migration.
         if ($table->hasIndex('openconnector_sync_contracts_source_id_index') === true) {
             $table->dropIndex('openconnector_sync_contracts_source_id_index');
         }
@@ -99,27 +129,33 @@ class Version1Date20241111144800 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Copy data from the legacy source columns into the new origin columns and drop the originals.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
         $table  = $schema->getTable('openconnector_synchronization_contracts');
 
-        // Step 2: Copy data from old columns to new columns
+        // Step 2: Copy data from old columns to new columns.
         if ($table->hasColumn('origin_id') === true && $table->hasColumn('origin_hash') === true
             && $table->hasColumn('source_id') === true && $table->hasColumn('source_hash') === true
         ) {
             $this->connection->executeQuery(
-            "
+                "
 				UPDATE oc_openconnector_synchronization_contracts
 				SET origin_id = source_id, origin_hash = source_hash
 				WHERE source_id IS NOT NULL
@@ -134,5 +170,6 @@ class Version1Date20241111144800 extends SimpleMigrationStep
         if ($table->hasColumn('source_hash') === true) {
             $table->dropColumn('source_hash');
         }
+
     }//end postSchemaChange()
 }//end class

--- a/lib/Migration/Version1Date20241121160300.php
+++ b/lib/Migration/Version1Date20241121160300.php
@@ -1,11 +1,24 @@
 <?php
+/**
+ * Add rate-limit columns to the Source table.
+ *
+ * This migration changes the following:
+ * - Adding 4 new columns for the table Source: rateLimitLimit, rateLimitRemaining,
+ *   rateLimitReset and rateLimitWindow.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -17,88 +30,100 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\IDBConnection;
 
 /**
- * This migration changes the following:
- * - Adding 4 new columns for the table Source: rateLimitLimit, rateLimitRemaining, rateLimitReset & rateLimitWindow
+ * Adds rate-limit tracking columns to the openconnector_sources table.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241121160300 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Adds the rate-limit columns to the sources table when missing.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
-        // Sources table
+        // Sources table.
         $table = $schema->getTable('openconnector_sources');
 
         if ($table->hasColumn('rate_limit_limit') === false) {
             $table->addColumn(
-            'rate_limit_limit',
-            Types::INTEGER,
-            [
-                'notnull' => false,
-                'default' => null,
-            ]
+                'rate_limit_limit',
+                Types::INTEGER,
+                [
+                    'notnull' => false,
+                    'default' => null,
+                ]
             );
         }
 
         if ($table->hasColumn('rate_limit_remaining') === false) {
             $table->addColumn(
-            'rate_limit_remaining',
-            Types::INTEGER,
-            [
-                'notnull' => false,
-                'default' => null,
-            ]
+                'rate_limit_remaining',
+                Types::INTEGER,
+                [
+                    'notnull' => false,
+                    'default' => null,
+                ]
             );
         }
 
         if ($table->hasColumn('rate_limit_reset') === false) {
             $table->addColumn(
-            'rate_limit_reset',
-            Types::INTEGER,
-            [
-                'notnull' => false,
-                'default' => null,
-            ]
+                'rate_limit_reset',
+                Types::INTEGER,
+                [
+                    'notnull' => false,
+                    'default' => null,
+                ]
             );
         }
 
         if ($table->hasColumn('rate_limit_window') === false) {
             $table->addColumn(
-            'rate_limit_window',
-            Types::INTEGER,
-            [
-                'notnull' => false,
-                'default' => null,
-            ]
+                'rate_limit_window',
+                Types::INTEGER,
+                [
+                    'notnull' => false,
+                    'default' => null,
+                ]
             );
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241126074122.php
+++ b/lib/Migration/Version1Date20241126074122.php
@@ -1,11 +1,24 @@
 <?php
+/**
+ * Add conditions and follow_ups columns to Synchronizations.
+ *
+ * Adds two columns to the Synchronizations table:
+ * - conditions for json logic.
+ * - follow_ups for follow up synchronizations.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -17,34 +30,40 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * Adds two columns to the Synchronizations table:
- * - conditions for json logic
- * - follow_ups for follow up synchronizations
+ * Adds conditions and follow_ups JSON columns to the Synchronizations table.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241126074122 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Adds the conditions and follow_ups columns to the synchronizations table.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
         if ($schema->hasTable(tableName: 'openconnector_synchronizations') === true) {
             $table = $schema->getTable(tableName: 'openconnector_synchronizations');
@@ -62,12 +81,17 @@ class Version1Date20241126074122 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241206095007.php
+++ b/lib/Migration/Version1Date20241206095007.php
@@ -1,11 +1,23 @@
 <?php
+/**
+ * Rename source retention columns to snake_case.
+ *
+ * Drops the camelCase logRetention and errorRetention columns from the sources
+ * table and recreates them as log_retention and error_retention.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,32 +28,40 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * FIXME Auto-generated migration step: Please modify to your needs!
+ * Renames the source retention columns from camelCase to snake_case.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241206095007 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Drops the camelCase columns and recreates them in snake_case.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
         if ($schema->hasTable('openconnector_sources') === true) {
@@ -59,12 +79,17 @@ class Version1Date20241206095007 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241210100000.php
+++ b/lib/Migration/Version1Date20241210100000.php
@@ -1,11 +1,23 @@
 <?php
+/**
+ * Rename sourceHashMapping to source_hash_mapping.
+ *
+ * Renames the synchronization sourceHashMapping column to snake_case
+ * (source_hash_mapping) to match the project's column-naming convention.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,32 +28,40 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * FIXME Auto-generated migration step: Please modify to your needs!
+ * Renames the synchronization sourceHashMapping column to snake_case.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241210100000 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Renames the sourceHashMapping column to source_hash_mapping.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
         if ($schema->hasTable('openconnector_synchronizations') === true) {
@@ -54,12 +74,17 @@ class Version1Date20241210100000 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241210120155.php
+++ b/lib/Migration/Version1Date20241210120155.php
@@ -1,11 +1,24 @@
 <?php
+/**
+ * Add current_page and message columns.
+ *
+ * This migration changes the following:
+ * - Adding 1 new column for the table Synchronization: currentPage.
+ * - Adding 1 new column for the table SynchronizationContractLogs: message.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,75 +29,86 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * This migration changes the following:
- * - Adding 1 new column for the table Synchronization: currentPage
- * - Adding 1 new column for the table SynchronizationContractLogs: message
+ * Adds the current_page and message columns to the synchronization tables.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241210120155 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Adds the current_page and message columns when missing.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
-        // Synchronizations table
+        // Synchronizations table.
         if ($schema->hasTable('openconnector_synchronizations') === true) {
             $table = $schema->getTable('openconnector_synchronizations');
 
             if ($table->hasColumn('current_page') === false) {
                 $table->addColumn(
-                'current_page',
-                Types::INTEGER,
-                [
-                    'notnull' => false,
-                    'default' => 1,
-                ]
+                    'current_page',
+                    Types::INTEGER,
+                    [
+                        'notnull' => false,
+                        'default' => 1,
+                    ]
                 );
             }
         }
 
-        // SynchronizationContractLogs table
+        // SynchronizationContractLogs table.
         if ($schema->hasTable('openconnector_synchronization_contract_logs') === true) {
             $table = $schema->getTable('openconnector_synchronization_contract_logs');
 
             if ($table->hasColumn('message') === false) {
                 $table->addColumn(
-                'message',
-                Types::STRING,
-                [
-                    'length'  => 255,
-                    'notnull' => false,
-                ]
+                    'message',
+                    Types::STRING,
+                    [
+                        'length'  => 255,
+                        'notnull' => false,
+                    ]
                 )->setDefault(null);
             }
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241218122708.php
+++ b/lib/Migration/Version1Date20241218122708.php
@@ -1,11 +1,23 @@
 <?php
+/**
+ * Drop the consumer authorization_configuration column.
+ *
+ * Removes the legacy authorization_configuration column from the consumers
+ * table; consumer configuration moved to the typed configuration field.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -15,32 +27,40 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * FIXME Auto-generated migration step: Please modify to your needs!
+ * Drops the legacy authorization_configuration column from the consumers table.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241218122708 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Drops the authorization_configuration column from the consumers table.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
         if ($schema->hasTable(tableName: 'openconnector_consumers') === true) {
@@ -49,12 +69,17 @@ class Version1Date20241218122708 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241218122932.php
+++ b/lib/Migration/Version1Date20241218122932.php
@@ -1,11 +1,23 @@
 <?php
+/**
+ * Re-add consumer authorization_configuration and add endpoint conditions.
+ *
+ * Recreates the consumers.authorization_configuration column as JSON, adds the
+ * consumers.user_id column, and adds the endpoints.conditions JSON column.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,32 +28,40 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * FIXME Auto-generated migration step: Please modify to your needs!
+ * Re-adds consumer authorization_configuration / user_id and endpoint conditions.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241218122932 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Re-adds the typed consumer and endpoint configuration columns.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
         if ($schema->hasTable(tableName: 'openconnector_consumers') === true) {
@@ -56,12 +76,17 @@ class Version1Date20241218122932 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241230141628.php
+++ b/lib/Migration/Version1Date20241230141628.php
@@ -1,11 +1,23 @@
 <?php
+/**
+ * Add endpoint input/output mapping columns.
+ *
+ * Adds the input_mapping and output_mapping columns to the endpoints table
+ * and sets a default value for the existing conditions column.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,32 +28,40 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * FIXME Auto-generated migration step: Please modify to your needs!
+ * Adds input/output mapping columns and a default for the conditions column on endpoints.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241230141628 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Adds the endpoint mapping columns and the conditions default.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
         if ($schema->hasTable(tableName: 'openconnector_endpoints') === true) {
@@ -52,12 +72,17 @@ class Version1Date20241230141628 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250107163601.php
+++ b/lib/Migration/Version1Date20250107163601.php
@@ -1,11 +1,25 @@
 <?php
+/**
+ * Add reference columns to Jobs and Synchronizations.
+ *
+ * This migration changes the following:
+ * - Adding 1 new column for the table Consumers: reference.
+ * - Adding 1 new column for the table Jobs: reference.
+ * - Adding 1 new column for the table Synchronizations: reference.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,35 +30,40 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * This migration changes the following:
- * - Adding 1 new column for the table Consumers: reference
- * - Adding 1 new column for the table Jobs: reference
- * - Adding 1 new column for the table Synchronizations: reference
+ * Adds reference string columns to the jobs and synchronizations tables.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20250107163601 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Adds the reference columns to the jobs and synchronizations tables.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
         if ($schema->hasTable(tableName: 'openconnector_jobs') === true) {
@@ -58,12 +77,17 @@ class Version1Date20250107163601 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250109093325.php
+++ b/lib/Migration/Version1Date20250109093325.php
@@ -1,11 +1,24 @@
 <?php
+/**
+ * Create events, subscriptions, messages and rules tables.
+ *
+ * Adds the openconnector_events, openconnector_event_subscriptions,
+ * openconnector_event_messages and openconnector_rules tables, and the
+ * rules column on the openconnector_endpoints table.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,34 +29,44 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
+ * Adds the events, subscriptions, messages and rules tables.
+ *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  */
 class Version1Date20250109093325 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Adds the events, subscriptions, messages and rules tables.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
-        if (!$schema->hasTable('openconnector_events')) {
+        if ($schema->hasTable('openconnector_events') === false) {
             $table = $schema->createTable('openconnector_events');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -64,7 +87,7 @@ class Version1Date20250109093325 extends SimpleMigrationStep
             $table->addIndex(['uuid'], 'openconnector_events_uuid_index');
         }
 
-        if (!$schema->hasTable('openconnector_event_subscriptions')) {
+        if ($schema->hasTable('openconnector_event_subscriptions') === false) {
             $table = $schema->createTable('openconnector_event_subscriptions');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -91,7 +114,7 @@ class Version1Date20250109093325 extends SimpleMigrationStep
             $table->addIndex(['status'], 'openconnector_event_subs_status_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_event_messages')) {
+        if ($schema->hasTable('openconnector_event_messages') === false) {
             $table = $schema->createTable('openconnector_event_messages');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -116,7 +139,7 @@ class Version1Date20250109093325 extends SimpleMigrationStep
             $table->addIndex(['next_attempt'], 'openconnector_event_msg_next_index');
         }//end if
 
-        if (!$schema->hasTable('openconnector_rules')) {
+        if ($schema->hasTable('openconnector_rules') === false) {
             $table = $schema->createTable('openconnector_rules');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -125,12 +148,12 @@ class Version1Date20250109093325 extends SimpleMigrationStep
             $table->addColumn('reference', Types::STRING, ['notnull' => false, 'length' => 255]);
             $table->addColumn('version', Types::STRING, ['notnull' => true, 'length' => 255, 'default' => '0.0.1']);
             $table->addColumn('action', Types::STRING, ['notnull' => true, 'length' => 20]);
-            // create, read, update, delete
+            // Create, read, update, delete.
             $table->addColumn('timing', Types::STRING, ['notnull' => true, 'length' => 10, 'default' => 'before']);
-            // before or after
+            // Before or after.
             $table->addColumn('conditions', Types::JSON, ['notnull' => false]);
             $table->addColumn('type', Types::STRING, ['notnull' => true, 'length' => 50]);
-            // mapping, error, script, synchronization
+            // Mapping, error, script, synchronization.
             $table->addColumn('configuration', Types::JSON, ['notnull' => false]);
             $table->addColumn('order', Types::INTEGER, ['notnull' => true, 'default' => 0]);
             $table->addColumn('created', Types::DATETIME, ['notnull' => true, 'default' => 'CURRENT_TIMESTAMP']);
@@ -143,21 +166,26 @@ class Version1Date20250109093325 extends SimpleMigrationStep
             $table->addIndex(['order'], 'openconnector_rules_order_index');
         }//end if
 
-        // Add rules relationship to endpoints table
-        if ($schema->hasTable('openconnector_endpoints')) {
+        // Add rules relationship to endpoints table.
+        if ($schema->hasTable('openconnector_endpoints') === true) {
             $table = $schema->getTable('openconnector_endpoints');
-            if (!$table->hasColumn('rules')) {
+            if ($table->hasColumn('rules') === false) {
                 $table->addColumn('rules', Types::JSON, ['notnull' => false]);
             }
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250109121103.php
+++ b/lib/Migration/Version1Date20250109121103.php
@@ -1,11 +1,23 @@
 <?php
+/**
+ * Relax notnull on synchronization contract origin/target columns.
+ *
+ * Changes origin_id, target_id, origin_hash and target_hash on the
+ * synchronization contracts table to nullable.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2025 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,32 +28,40 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * FIXME Auto-generated migration step: Please modify to your needs!
+ * Drops notnull on origin/target id and hash columns on the contracts table.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20250109121103 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Removes the notnull constraint from the contract origin/target columns.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
         if ($schema->hasTable(tableName: 'openconnector_synchronization_contracts') === true) {
@@ -53,12 +73,17 @@ class Version1Date20250109121103 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250118124025.php
+++ b/lib/Migration/Version1Date20250118124025.php
@@ -1,11 +1,23 @@
 <?php
+/**
+ * Add synchronization_logs table and related columns.
+ *
+ * Adds the synchronization_logs table, the contracts.target_last_action column,
+ * and the contract_logs.synchronization_log_id / target_result / test / force columns.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2025 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,35 +28,43 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * FIXME Auto-generated migration step: Please modify to your needs!
+ * Adds the synchronization logs table and supporting columns on related tables.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20250118124025 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Creates the synchronization_logs table and related columns.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
-        if (!$schema->hasTable('openconnector_synchronization_logs')) {
+        if ($schema->hasTable('openconnector_synchronization_logs') === false) {
             $table = $schema->createTable('openconnector_synchronization_logs');
             $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
             $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
@@ -69,15 +89,15 @@ class Version1Date20250118124025 extends SimpleMigrationStep
         if ($schema->hasTable(tableName: 'openconnector_synchronization_contracts') === true) {
             $table = $schema->getTable(tableName: 'openconnector_synchronization_contracts');
             $table->addColumn('target_last_action', Types::STRING, ['notnull' => false, 'length' => 6]);
-            // 6 chars is enough for 'create', 'update', 'delete'
+            // 6 chars is enough for 'create', 'update', 'delete'.
         }
 
         if ($schema->hasTable(tableName: 'openconnector_synchronization_contract_logs') === true) {
             $table = $schema->getTable(tableName: 'openconnector_synchronization_contract_logs');
             $table->addColumn('synchronization_log_id', Types::STRING, ['notnull' => false, 'length' => 36]);
-            // synchronization_log_id
+            // The synchronization_log_id column.
             $table->addColumn('target_result', Types::STRING, ['notnull' => false, 'length' => 6]);
-            // target_result
+            // The target_result column.
             $table->addColumn('test', Types::BOOLEAN, ['notnull' => true, 'default' => false]);
             $table->addColumn('force', Types::BOOLEAN, ['notnull' => true, 'default' => false]);
 
@@ -85,12 +105,17 @@ class Version1Date20250118124025 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250123100521.php
+++ b/lib/Migration/Version1Date20250123100521.php
@@ -1,11 +1,22 @@
 <?php
+/**
+ * Add actions JSON column to Synchronizations.
+ *
+ * Adds the actions column to the openconnector_synchronizations table.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2025 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,32 +27,40 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * FIXME Auto-generated migration step: Please modify to your needs!
+ * Adds the actions JSON column to the synchronizations table.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20250123100521 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Adds the actions column to the synchronizations table when missing.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
         if ($schema->hasTable(tableName: 'openconnector_synchronizations') === true) {
@@ -52,12 +71,17 @@ class Version1Date20250123100521 extends SimpleMigrationStep
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Post-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250515232835.php
+++ b/lib/Migration/Version1Date20250515232835.php
@@ -1,11 +1,24 @@
 <?php
+/**
+ * Add configurations and slug columns to all main tables.
+ *
+ * Adds the configurations JSON column, the slug string column (plus index and
+ * unique constraint) and a status column on jobs and synchronizations. The
+ * post-schema step backfills slugs from the existing name columns.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2025 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
 
 namespace OCA\OpenConnector\Migration;
 
@@ -16,43 +29,43 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 /**
- * Migration step to add configurations and slug columns to all necessary tables.
- *
- * @package   OCA\OpenConnector\Migration
- * @category  Migration
- * @author    OpenConnector Team
- * @copyright 2024 OpenConnector
- * @license   AGPL-3.0
- * @version   1.0.0
- * @link      https://github.com/OpenConnector/openconnector
+ * Adds configurations / slug / status columns and backfills slug values.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20250515232835 extends SimpleMigrationStep
 {
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Pre-schema change callback.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
     }//end preSchemaChange()
 
     /**
-     * @param  IOutput                   $output
-     * @param  Closure(): ISchemaWrapper $schemaClosure
-     * @param  array                     $options
-     * @return null|ISchemaWrapper
+     * Adds configurations / slug / status columns to all related tables.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
-        // List of tables that need the new columns
+        // List of tables that need the new columns.
         $tables = [
             'openconnector_sources',
             'openconnector_endpoints',
@@ -62,83 +75,88 @@ class Version1Date20250515232835 extends SimpleMigrationStep
             'openconnector_synchronizations',
         ];
 
-        // Add configurations and slug columns to each table
+        // Add configurations and slug columns to each table.
         foreach ($tables as $tableName) {
-            if ($schema->hasTable($tableName)) {
+            if ($schema->hasTable($tableName) === true) {
                 $table = $schema->getTable($tableName);
 
-                // Add configurations column if it doesn't exist
-                if (!$table->hasColumn('configurations')) {
+                // Add configurations column if it doesn't exist.
+                if ($table->hasColumn('configurations') === false) {
                     $table->addColumn('configurations', Types::JSON)
                         ->setNotnull(false)
                         ->setDefault('[]');
                 }
 
-                // Add slug column if it doesn't exist
-                if (!$table->hasColumn('slug')) {
+                // Add slug column if it doesn't exist.
+                if ($table->hasColumn('slug') === false) {
                     $table->addColumn(
-                    'slug',
-                    Types::STRING,
-                    [
-                        'length'  => 255,
-                        'notnull' => false,
-                        'default' => null,
-                    ]
+                        'slug',
+                        Types::STRING,
+                        [
+                            'length'  => 255,
+                            'notnull' => false,
+                            'default' => null,
+                        ]
                     );
 
-                    // Add index for the slug column
+                    // Add index for the slug column.
                     $table->addIndex(['slug'], 'idx_'.$tableName.'_slug');
                     $table->addUniqueConstraint(['slug'], 'idx_'.$tableName.'_slug_unique');
                 }
             }//end if
         }//end foreach
 
-        // Add status column to synchronizations table if it doesn't exist
-        if ($schema->hasTable('openconnector_synchronizations')) {
+        // Add status column to synchronizations table if it doesn't exist.
+        if ($schema->hasTable('openconnector_synchronizations') === true) {
             $table = $schema->getTable('openconnector_synchronizations');
-            if (!$table->hasColumn('status')) {
+            if ($table->hasColumn('status') === false) {
                 $table->addColumn(
-                'status',
-                Types::STRING,
-                [
-                    'length'  => 255,
-                    'notnull' => false,
-                    'default' => null,
-                ]
+                    'status',
+                    Types::STRING,
+                    [
+                        'length'  => 255,
+                        'notnull' => false,
+                        'default' => null,
+                    ]
                 );
             }
         }
 
-        // Add status column to jobs table if it doesn't exist
-        if ($schema->hasTable('openconnector_jobs')) {
+        // Add status column to jobs table if it doesn't exist.
+        if ($schema->hasTable('openconnector_jobs') === true) {
             $table = $schema->getTable('openconnector_jobs');
-            if (!$table->hasColumn('status')) {
+            if ($table->hasColumn('status') === false) {
                 $table->addColumn(
-                'status',
-                Types::STRING,
-                [
-                    'length'  => 255,
-                    'notnull' => false,
-                    'default' => null,
-                ]
+                    'status',
+                    Types::STRING,
+                    [
+                        'length'  => 255,
+                        'notnull' => false,
+                        'default' => null,
+                    ]
                 );
             }
         }
 
         return $schema;
+
     }//end changeSchema()
 
     /**
-     * @param IOutput                   $output
-     * @param Closure(): ISchemaWrapper $schemaClosure
-     * @param array                     $options
+     * Backfills slug values for the migrated tables.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
-        // Get the database connection
+        // Get the database connection.
         $connection = \OC::$server->get(\OCP\IDBConnection::class);
 
-        // List of tables that need slug updates
+        // List of tables that need slug updates.
         $tables = [
             'openconnector_sources'          => 'name',
             'openconnector_endpoints'        => 'name',
@@ -148,21 +166,21 @@ class Version1Date20250515232835 extends SimpleMigrationStep
             'openconnector_synchronizations' => 'name',
         ];
 
-        // Update slugs for each table
+        // Update slugs for each table.
         foreach ($tables as $tableName => $nameColumn) {
-            // First, update any null or empty slugs using the name column
+            // First, update any null or empty slugs using the name column.
             $query = $connection->getQueryBuilder();
             $query->update($tableName)
                 ->set('slug', $query->createFunction('LOWER(REPLACE(REPLACE(REPLACE('.$nameColumn.', \' \', \'-\'), \'.\', \'-\'), \'_\', \'-\'))'))
                 ->where(
-            $query->expr()->orX(
-                    $query->expr()->isNull('slug'),
-                    $query->expr()->eq('slug', $query->createNamedParameter(''))
-                )
-            );
+                    $query->expr()->orX(
+                        $query->expr()->isNull('slug'),
+                        $query->expr()->eq('slug', $query->createNamedParameter(''))
+                    )
+                );
             $query->execute();
 
-            // Then, ensure uniqueness across all tables
+            // Then, ensure uniqueness across all tables.
             $query = $connection->getQueryBuilder();
             $query->select('id', 'slug')
                 ->from($tableName)
@@ -171,19 +189,19 @@ class Version1Date20250515232835 extends SimpleMigrationStep
             $slugs   = [];
             $updates = [];
 
-            while ($row = $result->fetch()) {
+            while (($row = $result->fetch()) !== false) {
                 $originalSlug = $row['slug'];
                 $newSlug      = $originalSlug;
                 $counter      = 1;
 
-                // If slug is empty or null, use a default
-                if (empty($originalSlug)) {
+                // If slug is empty or null, use a default.
+                if (empty($originalSlug) === true) {
                     $newSlug = 'item-'.$row['id'];
                 }
 
-                // Handle duplicate slugs
-                if (!empty($originalSlug)) {
-                    while (isset($slugs[$newSlug])) {
+                // Handle duplicate slugs.
+                if (empty($originalSlug) === false) {
+                    while (isset($slugs[$newSlug]) === true) {
                         $newSlug = $originalSlug.'-'.$counter;
                         $counter++;
                     }
@@ -201,7 +219,7 @@ class Version1Date20250515232835 extends SimpleMigrationStep
 
             $result->closeCursor();
 
-            // Apply the updates
+            // Apply the updates.
             foreach ($updates as $update) {
                 $query = $connection->getQueryBuilder();
                 $query->update($tableName)
@@ -212,5 +230,6 @@ class Version1Date20250515232835 extends SimpleMigrationStep
 
             $output->info("Updated slugs for table: ".$tableName);
         }//end foreach
+
     }//end postSchemaChange()
 }//end class

--- a/lib/Migration/Version1Date20250826103500.php
+++ b/lib/Migration/Version1Date20250826103500.php
@@ -1,20 +1,23 @@
 <?php
-
-declare(strict_types=1);
-
-/*
- * JobLogMessageColumnMigration
+/**
+ * Job-logs message column migration.
  *
- * Migration step to increase the message column size in the openconnector_job_logs table
- * to handle longer job execution messages and prevent truncation errors.
+ * Migration step to increase the message column size in the openconnector_job_logs
+ * table to handle longer job execution messages and prevent truncation errors.
  *
  * @category Migration
  * @package  OCA\OpenConnector\Migration
- * @author   OpenConnector Development Team
- * @license  AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/openconnector
- * @version  1.0.0
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
  */
+
+declare(strict_types=1);
 
 namespace OCA\OpenConnector\Migration;
 
@@ -62,7 +65,7 @@ class Version1Date20250826103500 extends SimpleMigrationStep
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
-        // No pre-schema changes needed
+        // No pre-schema changes needed.
     }//end preSchemaChange()
 
     /**
@@ -92,23 +95,24 @@ class Version1Date20250826103500 extends SimpleMigrationStep
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
-        // Check if the job_logs table exists
-        if (!$schema->hasTable('openconnector_job_logs')) {
+        // Check if the job_logs table exists.
+        if ($schema->hasTable('openconnector_job_logs') === false) {
             $output->warning('openconnector_job_logs table not found');
             return $schema;
         }
 
         $table = $schema->getTable('openconnector_job_logs');
 
-        // Check if the message column exists
-        if (!$table->hasColumn('message')) {
+        // Check if the message column exists.
+        if ($table->hasColumn('message') === false) {
             $output->warning('Message column not found in openconnector_job_logs table');
             return $schema;
         }
 
-        // Drop the existing column and recreate it with TEXT type
+        // Drop the existing column and recreate it with TEXT type.
         // Nextcloud migrations work better with drop/add pattern for type changes — Doctrine's
         // changeColumn silently no-ops the type change in some DB backends, leaving the column
         // stuck at VARCHAR(255) and causing job-log truncation errors at runtime.
@@ -137,7 +141,7 @@ class Version1Date20250826103500 extends SimpleMigrationStep
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
-        // No post-schema changes needed
+        // No post-schema changes needed.
         $output->info('Job logs message column migration completed successfully');
     }//end postSchemaChange()
 }//end class

--- a/lib/Migration/Version1Date20250826120000.php
+++ b/lib/Migration/Version1Date20250826120000.php
@@ -1,20 +1,23 @@
 <?php
-
-declare(strict_types=1);
-
-/*
- * LogSizeColumnsMigration
+/**
+ * Log size columns migration.
  *
  * Migration step to add size columns to all log tables for tracking log entry sizes.
  * This helps with storage management and automated cleanup based on log sizes.
  *
  * @category Migration
  * @package  OCA\OpenConnector\Migration
- * @author   OpenConnector Development Team
- * @license  AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/openconnector
- * @version  1.0.0
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
  */
+
+declare(strict_types=1);
 
 namespace OCA\OpenConnector\Migration;
 
@@ -65,7 +68,7 @@ class Version1Date20250826120000 extends SimpleMigrationStep
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
-        // No pre-schema changes needed
+        // No pre-schema changes needed.
     }//end preSchemaChange()
 
     /**
@@ -95,9 +98,10 @@ class Version1Date20250826120000 extends SimpleMigrationStep
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
-        // List of log tables that need the size column
+        // List of log tables that need the size column.
         $logTables = [
             'openconnector_call_logs',
             'openconnector_job_logs',
@@ -107,31 +111,31 @@ class Version1Date20250826120000 extends SimpleMigrationStep
 
         $tablesUpdated = 0;
 
-        // Add size column to each log table
+        // Add size column to each log table.
         foreach ($logTables as $tableName) {
-            if (!$schema->hasTable($tableName)) {
+            if ($schema->hasTable($tableName) === false) {
                 $output->warning("Table {$tableName} not found, skipping");
                 continue;
             }
 
             $table = $schema->getTable($tableName);
 
-            // Check if the size column already exists
-            if ($table->hasColumn('size')) {
+            // Check if the size column already exists.
+            if ($table->hasColumn('size') === true) {
                 $output->info("'size' column already exists in {$tableName} table, skipping");
                 continue;
             }
 
-            // Add the size column with default value of 4096 bytes (4KB)
+            // Add the size column with default value of 4096 bytes (4KB).
             $table->addColumn(
-                    'size',
-                    Types::INTEGER,
-                    [
-                        'notnull' => true,
-                        'default' => 4096,
-                        'comment' => 'Size of the log entry in bytes',
-                    ]
-                    );
+                'size',
+                Types::INTEGER,
+                [
+                    'notnull' => true,
+                    'default' => 4096,
+                    'comment' => 'Size of the log entry in bytes',
+                ]
+            );
 
             $tablesUpdated++;
             $output->info("Added 'size' column to {$tableName} table");

--- a/lib/Migration/Version2Date20260520000001.php
+++ b/lib/Migration/Version2Date20260520000001.php
@@ -1,12 +1,6 @@
 <?php
-
-declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
- * SPDX-License-Identifier: EUPL-1.2
- *
- * Chain B (openconnector-register-storage) — main migration entrypoint.
+/**
+ * Chain B migration: import register + copy rows to OpenRegister.
  *
  * Calls ConfigurationService::importFromApp() to materialise the openconnector
  * register + 15 schemas (declared by chain A's lib/Settings/openconnector_register.json),
@@ -15,8 +9,22 @@ declare(strict_types=1);
  *
  * Idempotent: re-running has no effect after `openconnector.storage_migrated` is set.
  *
- * Cross-ref: openspec/changes/openconnector-register-storage/specs/openconnector-storage-migration/spec.md REQ-001/005, local ADR-012 (strangler-fig pattern).
+ * Cross-ref: openspec/changes/openconnector-register-storage/specs/openconnector-storage-migration/spec.md
+ * REQ-001/005, local ADR-012 (strangler-fig pattern).
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
  */
+
+declare(strict_types=1);
 
 namespace OCA\OpenConnector\Migration;
 
@@ -31,15 +39,27 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Imports the openconnector register and copies legacy rows into OpenRegister.
+ */
 class Version2Date20260520000001 extends SimpleMigrationStep
 {
-
-    // Nextcloud's MigrationService::createInstance() uses `new $class()` —
-    // migrations cannot have constructor parameters. All dependencies are
-    // resolved via the service container inside postSchemaChange().
+    /**
+     * No-op pre-schema callback.
+     *
+     * Nextcloud's MigrationService::createInstance() uses `new $class()` —
+     * migrations cannot have constructor parameters. All dependencies are
+     * resolved via the service container inside postSchemaChange().
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
+     */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
-        // No-op. All work happens in postSchemaChange so OR's schemas exist
+        // No-op. All work happens in postSchemaChange so OR's schemas exist.
         // before we attempt to import the descriptor.
     }//end preSchemaChange()
 
@@ -47,12 +67,34 @@ class Version2Date20260520000001 extends SimpleMigrationStep
      * No schema diff for chain B — the OR tables already exist from the
      * openregister app's own migrations. We only IMPORT the descriptor and
      * COPY legacy rows.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null Always null for this migration.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         return null;
+
     }//end changeSchema()
 
+    /**
+     * Imports the register descriptor and copies legacy rows.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
+     *
+     * @throws \Throwable When the descriptor cannot be decoded or import fails.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
         $container = \OC::$server;
@@ -80,7 +122,7 @@ class Version2Date20260520000001 extends SimpleMigrationStep
         try {
             $orAppPath  = $appManager->getAppPath('openregister');
             $orAutoload = $orAppPath.'/vendor/autoload.php';
-            if (file_exists($orAutoload)) {
+            if (file_exists($orAutoload) === true) {
                 include_once $orAutoload;
                 $output->info('chain-B: required openregister autoload from '.$orAutoload);
             } else {
@@ -103,7 +145,10 @@ class Version2Date20260520000001 extends SimpleMigrationStep
         // Guard against OpenRegister being unavailable (would crash the
         // upgrade with a useless DI error). Defer to next upgrade.
         if (class_exists('\\OCA\\OpenRegister\\Service\\ConfigurationService') === false) {
-            $output->warning('chain-B: openregister app not enabled or not loaded; skipping descriptor import + migration. Re-run `occ upgrade` after enabling openregister.');
+            $output->warning(
+                'chain-B: openregister app not enabled or not loaded; skipping descriptor import + migration.'
+                .' Re-run `occ upgrade` after enabling openregister.'
+            );
             return;
         }
 
@@ -139,17 +184,17 @@ class Version2Date20260520000001 extends SimpleMigrationStep
         foreach ($result as $perEntity) {
             $skipped = (int) ($perEntity['skipped'] ?? 0);
             $output->info(
-                    sprintf(
-                '  %s: legacy=%d migrated=%d skipped=%d fkRewrites=%d (%dms)',
-                $perEntity['slug'] ?? '?',
-                (int) ($perEntity['legacyCount'] ?? 0),
-                (int) ($perEntity['migratedCount'] ?? 0),
-                $skipped,
-                (int) ($perEntity['fkRewrites'] ?? 0),
-                (int) ($perEntity['elapsedMs'] ?? 0)
-            )
-                    );
-            if ($skipped > 0 || !empty($perEntity['error'])) {
+                sprintf(
+                    '  %s: legacy=%d migrated=%d skipped=%d fkRewrites=%d (%dms)',
+                    $perEntity['slug'] ?? '?',
+                    (int) ($perEntity['legacyCount'] ?? 0),
+                    (int) ($perEntity['migratedCount'] ?? 0),
+                    $skipped,
+                    (int) ($perEntity['fkRewrites'] ?? 0),
+                    (int) ($perEntity['elapsedMs'] ?? 0)
+                )
+            );
+            if ($skipped > 0 || empty($perEntity['error']) === false) {
                 $allOk = false;
             }
         }
@@ -158,7 +203,11 @@ class Version2Date20260520000001 extends SimpleMigrationStep
             $appConfig->setValueString('openconnector', 'storage_migrated', 'true');
             $output->info('chain-B: storage_migrated=true — all 15 entities copied successfully.');
         } else {
-            $output->warning('chain-B: storage_migrated flag NOT set — at least one entity reported skips or errors. Use occ openconnector:migrate-storage to retry per-entity.');
+            $output->warning(
+                'chain-B: storage_migrated flag NOT set — at least one entity reported skips or errors.'
+                .' Use occ openconnector:migrate-storage to retry per-entity.'
+            );
         }
+
     }//end postSchemaChange()
 }//end class

--- a/lib/Migration/Version2Date20260520000099.php
+++ b/lib/Migration/Version2Date20260520000099.php
@@ -1,11 +1,5 @@
 <?php
-
-declare(strict_types=1);
-
-/*
- * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
- * SPDX-License-Identifier: EUPL-1.2
- *
+/**
  * Chain B/C cleanup — drop legacy oc_openconnector_* tables when empty.
  *
  * Runs after {@see Version2Date20260520000001} has materialised the OR
@@ -19,7 +13,7 @@ declare(strict_types=1);
  * authoritative copies). On the next `occ upgrade`, THIS migration sweeps
  * the now-empty tables out of the database.
  *
- * **Safety gate**: each legacy table is dropped ONLY if its row count is
+ * Safety gate: each legacy table is dropped ONLY if its row count is
  * zero. Non-empty tables are LEFT IN PLACE with a warning logged — the
  * operator is expected to investigate (someone wrote to the legacy table
  * post-cutover, or the rollback buffer hasn't been drained yet). Re-running
@@ -28,10 +22,23 @@ declare(strict_types=1);
  * Idempotent: tables that have already been dropped are skipped silently.
  *
  * Cross-ref:
- *   - GH #820 (legacy table cleanup follow-up)
- *   - lib/Migration/Version2Date20260520000001.php (chain B data migration)
- *   - openspec/changes/openconnector-services-direct-or-usage/proposal.md § cleanup
+ *   - GH #820 (legacy table cleanup follow-up).
+ *   - lib/Migration/Version2Date20260520000001.php (chain B data migration).
+ *   - openspec/changes/openconnector-services-direct-or-usage/proposal.md § cleanup.
+ *
+ * @category Migration
+ * @package  OCA\OpenConnector\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
  */
+
+declare(strict_types=1);
 
 namespace OCA\OpenConnector\Migration;
 
@@ -42,6 +49,9 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Drops legacy oc_openconnector_* tables once they are empty.
+ */
 class Version2Date20260520000099 extends SimpleMigrationStep
 {
 
@@ -55,20 +65,22 @@ class Version2Date20260520000099 extends SimpleMigrationStep
      * referenced tables (sync, source) — matters only if FK constraints
      * exist on the legacy tables (they generally don't on Nextcloud apps,
      * but the order is defensive in case Doctrine added them on Postgres).
+     *
+     * @var array<int, string>
      */
     private const LEGACY_TABLES = [
-        // Dependent / log tables first
+        // Dependent / log tables first.
         'openconnector_synchronization_contract_logs',
         'openconnector_synchronization_logs',
         'openconnector_job_logs',
         'openconnector_call_logs',
         'openconnector_event_messages',
-        // Mid-tier referencing tables
+        // Mid-tier referencing tables.
         'openconnector_synchronization_contracts',
         'openconnector_synchronizations',
         'openconnector_event_subscriptions',
         'openconnector_events',
-        // Leaf tables (no inter-openconnector FKs)
+        // Leaf tables (no inter-openconnector FKs).
         'openconnector_endpoints',
         'openconnector_sources',
         'openconnector_jobs',
@@ -77,10 +89,19 @@ class Version2Date20260520000099 extends SimpleMigrationStep
         'openconnector_consumers',
     ];
 
-
-    // Nextcloud's MigrationService::createInstance() uses `new $class()` —
-    // migrations cannot have constructor parameters. Dependencies resolved
-    // via service container inside the methods that need them.
+    /**
+     * No-op pre-schema callback.
+     *
+     * Nextcloud's MigrationService::createInstance() uses `new $class()` —
+     * migrations cannot have constructor parameters. Dependencies resolved
+     * via service container inside the methods that need them.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
+     */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
         // No-op. Row-count checks happen in changeSchema so the safety
@@ -89,14 +110,22 @@ class Version2Date20260520000099 extends SimpleMigrationStep
 
     /**
      * Drop each legacy table when (a) it exists and (b) it has zero rows.
+     *
      * Non-empty tables are skipped with a warning — operator must drain
      * them before the next `occ upgrade` re-attempts the drop.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema wrapper.
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /*
          * @var ISchemaWrapper $schema
          */
+
         $schema = $schemaClosure();
 
         $db     = \OC::$server->get(IDBConnection::class);
@@ -112,22 +141,24 @@ class Version2Date20260520000099 extends SimpleMigrationStep
                 continue;
             }
 
-            $rowCount = $this->countRows($db, $logger, $tableShort);
+            $rowCount = $this->countRows(db: $db, logger: $logger, tableShort: $tableShort);
             if ($rowCount > 0) {
                 $output->warning(
-                        sprintf(
-                    'chain-B/C cleanup: legacy table `oc_%s` has %d row(s) — SKIPPED. Verify the chain-C cutover migrated all rows into OR storage, then TRUNCATE the table manually and re-run `occ upgrade`.',
-                    $tableShort,
-                    $rowCount
-                )
-                        );
+                    sprintf(
+                        'chain-B/C cleanup: legacy table `oc_%s` has %d row(s) — SKIPPED.'
+                        .' Verify the chain-C cutover migrated all rows into OR storage,'
+                        .' then TRUNCATE the table manually and re-run `occ upgrade`.',
+                        $tableShort,
+                        $rowCount
+                    )
+                );
                 $logger->warning(
-                        sprintf(
-                    'chain-B/C cleanup: skipping non-empty legacy table %s (%d rows)',
-                    $tableShort,
-                    $rowCount
-                )
-                        );
+                    sprintf(
+                        'chain-B/C cleanup: skipping non-empty legacy table %s (%d rows)',
+                        $tableShort,
+                        $rowCount
+                    )
+                );
                 $skippedNonEmpty++;
                 continue;
             }
@@ -138,29 +169,46 @@ class Version2Date20260520000099 extends SimpleMigrationStep
         }//end foreach
 
         $output->info(
-                sprintf(
-            'chain-B/C cleanup summary: %d dropped, %d skipped-non-empty, %d already-absent (of %d legacy tables)',
-            $dropped,
-            $skippedNonEmpty,
-            $skippedAbsent,
-            count(self::LEGACY_TABLES)
-        )
-                );
+            sprintf(
+                'chain-B/C cleanup summary: %d dropped, %d skipped-non-empty, %d already-absent (of %d legacy tables)',
+                $dropped,
+                $skippedNonEmpty,
+                $skippedAbsent,
+                count(self::LEGACY_TABLES)
+            )
+        );
 
         return $schema;
+
     }//end changeSchema()
 
+    /**
+     * Post-schema change callback.
+     *
+     * The `openconnector.storage_migrated` IAppConfig flag stays set to
+     * 'true'. It still serves as a marker that the cutover ran (read by
+     * SynchronizationContractProvider::isEnabled() among others).
+     * Deleting it would be backwards-incompatible.
+     *
+     * @param IOutput                   $output        Migration output interface.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
+     * @param array<string, mixed>      $options       Migration options.
+     *
+     * @return void
+     */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
-        // The `openconnector.storage_migrated` IAppConfig flag stays set to
-        // 'true'. It still serves as a marker that the cutover ran (read by
-        // SynchronizationContractProvider::isEnabled() among others).
-        // Deleting it would be backwards-incompatible.
+        // Intentional no-op — see method docblock.
     }//end postSchemaChange()
 
     /**
-     * Count rows in a legacy table. Returns -1 on query error (treated as
-     * "non-empty / unsafe to drop" by the safety gate).
+     * Count rows in a legacy table.
+     *
+     * @param IDBConnection   $db         Database connection.
+     * @param LoggerInterface $logger     Logger used to record query failures.
+     * @param string          $tableShort The unprefixed legacy table name.
+     *
+     * @return int Row count, or -1 on query error (treated as "non-empty / unsafe to drop" by the safety gate).
      */
     private function countRows(IDBConnection $db, LoggerInterface $logger, string $tableShort): int
     {
@@ -173,13 +221,14 @@ class Version2Date20260520000099 extends SimpleMigrationStep
             return (int) ($row['c'] ?? -1);
         } catch (\Throwable $e) {
             $logger->warning(
-                    sprintf(
-                'chain-B/C cleanup: failed to count rows in %s — treating as non-empty for safety. %s',
-                $tableShort,
-                $e->getMessage()
-            )
-                    );
+                sprintf(
+                    'chain-B/C cleanup: failed to count rows in %s — treating as non-empty for safety. %s',
+                    $tableShort,
+                    $e->getMessage()
+                )
+            );
             return -1;
         }
+
     }//end countRows()
 }//end class


### PR DESCRIPTION
## Summary

Cleans **400 PHPCS errors across 20 files** in `lib/Migration/`. Per the phase-2 plan to drive #889 to zero.

- Canonical Conduction file docblocks
- Method docblocks (`@param`, `@return`) on `preSchemaChange` / `changeSchema` / `postSchemaChange`
- Inline comments end in periods
- Implicit boolean comparisons rewritten as explicit `=== false`/`=== true`
- `@var` member docblocks on class properties
- Long lines broken to fit the 150-char limit

No functional changes - pure style/comment cleanup.

## Test plan

- [x] `phpcs --standard=phpcs.xml lib/Migration/` reports 0 errors (was 400)
- [ ] CI green