### PR TITLE
style(phpcs): clean PdokConnector + small Service files (advances #889)

### DIFF
--- a/lib/Connectors/PdokConnector.php
+++ b/lib/Connectors/PdokConnector.php
@@ -146,7 +146,7 @@ class PdokConnector
             return ['docs' => [], 'numFound' => 0];
         }
 
-        return $this->fetch('suggest', ['q' => $query, 'rows' => 10], self::TTL_QUERY, false);
+        return $this->fetch(endpoint: 'suggest', params: ['q' => $query, 'rows' => 10], ttl: self::TTL_QUERY, writeThrough: false);
 
     }//end suggest()
 
@@ -163,7 +163,7 @@ class PdokConnector
             return ['docs' => [], 'numFound' => 0];
         }
 
-        return $this->fetch('lookup', ['id' => $id], self::TTL_RESOLVED, true);
+        return $this->fetch(endpoint: 'lookup', params: ['id' => $id], ttl: self::TTL_RESOLVED, writeThrough: true);
 
     }//end lookup()
 
@@ -184,7 +184,7 @@ class PdokConnector
 
         $params = ['q' => $query, 'rows' => $rows, 'start' => $start];
 
-        return $this->fetch('free', $params, self::TTL_QUERY, false);
+        return $this->fetch(endpoint: 'free', params: $params, ttl: self::TTL_QUERY, writeThrough: false);
 
     }//end free()
 
@@ -200,7 +200,7 @@ class PdokConnector
     {
         $params = ['type' => 'adres', 'lat' => $lat, 'lon' => $lng, 'rows' => 1];
 
-        return $this->fetch('reverse', $params, self::TTL_RESOLVED, true);
+        return $this->fetch(endpoint: 'reverse', params: $params, ttl: self::TTL_RESOLVED, writeThrough: true);
 
     }//end reverse()
 
@@ -223,51 +223,83 @@ class PdokConnector
      */
     private function fetch(string $endpoint, array $params, int $ttl, bool $writeThrough): array
     {
-        $cacheKey = $this->cacheKey($endpoint, $params);
-        $cached   = $this->cacheGet($cacheKey);
+        $cacheKey = $this->cacheKey(endpoint: $endpoint, params: $params);
+        $cached   = $this->cacheGet(key: $cacheKey);
         if ($cached !== null) {
             return $cached;
         }
 
         // Check OR for an existing record before calling upstream (lookup/reverse only).
         if ($writeThrough === true) {
-            $orHit = $this->orLookup($endpoint, $params);
+            $orHit = $this->orLookup(endpoint: $endpoint, params: $params);
             if ($orHit !== null) {
-                $this->logCall($endpoint, true, true, null, null, $this->circuitState(), false);
-                $this->cacheSet($cacheKey, $orHit, $ttl);
+                $this->logCall(
+                    endpoint: $endpoint,
+                    cacheHit: true,
+                    orHit: true,
+                    upstreamLatencyMs: null,
+                    httpStatus: null,
+                    circuitState: $this->circuitState(),
+                    writeThrough: false
+                );
+                $this->cacheSet(key: $cacheKey, value: $orHit, ttl: $ttl);
                 return $orHit;
             }
         }
 
         // Circuit breaker — short-circuit when open and no fallback is available.
         if ($this->circuitState() === 'open') {
-            $this->logCall($endpoint, false, false, null, null, 'open', false);
+            $this->logCall(
+                endpoint: $endpoint,
+                cacheHit: false,
+                orHit: false,
+                upstreamLatencyMs: null,
+                httpStatus: null,
+                circuitState: 'open',
+                writeThrough: false
+            );
             return ['docs' => [], 'numFound' => 0, 'stale' => true];
         }
 
         $started  = microtime(true);
         $httpCode = null;
         try {
-            $raw      = $this->callPdok($endpoint, $params);
+            $raw      = $this->callPdok(endpoint: $endpoint, params: $params);
             $httpCode = 200;
         } catch (PdokUpstreamException $e) {
             $httpCode = $e->getStatusCode();
-            $this->logCall($endpoint, false, false, (int) ((microtime(true) - $started) * 1000), $httpCode, $this->circuitState(), false);
+            $this->logCall(
+                endpoint: $endpoint,
+                cacheHit: false,
+                orHit: false,
+                upstreamLatencyMs: (int) ((microtime(true) - $started) * 1000),
+                httpStatus: $httpCode,
+                circuitState: $this->circuitState(),
+                writeThrough: false
+            );
             return ['docs' => [], 'numFound' => 0, 'stale' => true];
         }
 
-        $normalised = $this->normaliseResponse($raw);
+        $normalised = $this->normaliseResponse(raw: $raw);
 
-        $this->cacheSet($cacheKey, $normalised, $ttl);
+        $this->cacheSet(key: $cacheKey, value: $normalised, ttl: $ttl);
 
         if ($writeThrough === true) {
             foreach ($normalised['docs'] as $doc) {
-                $this->writeThrough($doc);
+                $this->writeThrough(doc: $doc);
             }
         }
 
         $latencyMs = (int) ((microtime(true) - $started) * 1000);
-        $this->logCall($endpoint, false, false, $latencyMs, $httpCode, $this->circuitState(), $writeThrough);
+        $this->logCall(
+            endpoint: $endpoint,
+            cacheHit: false,
+            orHit: false,
+            upstreamLatencyMs: $latencyMs,
+            httpStatus: $httpCode,
+            circuitState: $this->circuitState(),
+            writeThrough: $writeThrough
+        );
 
         return $normalised;
 
@@ -295,12 +327,12 @@ class PdokConnector
                 $status   = $response->getStatusCode();
                 if ($status >= 200 && $status < 300) {
                     $this->circuitOnSuccess();
-                    return $this->decodePdokBody($response);
+                    return $this->decodePdokBody(response: $response);
                 }
 
                 if ($status === 429) {
                     $attempt++;
-                    $this->sleepBackoff($attempt);
+                    $this->sleepBackoff(attempt: $attempt);
                     continue;
                 }
 
@@ -359,7 +391,7 @@ class PdokConnector
 
         $normalised = [];
         foreach ($docs as $doc) {
-            $normalised[] = $this->normalize($doc);
+            $normalised[] = $this->normalize(pdokDoc: $doc);
         }
 
         return ['docs' => $normalised, 'numFound' => $numFound];
@@ -400,7 +432,7 @@ class PdokConnector
             'addressCountry'      => 'NL',
             'bagAddressId'        => ($pdokDoc['nummeraanduiding_id'] ?? null),
             'bagBuildingId'       => ($pdokDoc['pandid'] ?? null),
-            'location'            => $this->parseWkt(($pdokDoc['centroide_ll'] ?? null)),
+            'location'            => $this->parseWkt(wkt: ($pdokDoc['centroide_ll'] ?? null)),
             'source'              => 'pdok',
             'fetchedAt'           => gmdate('Y-m-d\TH:i:s\Z'),
         ];
@@ -464,7 +496,11 @@ class PdokConnector
         }
 
         $value = $this->cache->get($key);
-        return (is_array($value) === true ? $value : null);
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        return null;
 
     }//end cacheGet()
 

--- a/lib/Service/ConfigurationHandlers/ConfigurationHandlerInterface.php
+++ b/lib/Service/ConfigurationHandlers/ConfigurationHandlerInterface.php
@@ -1,46 +1,56 @@
 <?php
+/**
+ * Configuration handler interface.
+ *
+ * Contract for configuration handlers that handle export and import of entities
+ * to/from the OpenAPI specification format.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service\ConfigurationHandlers
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Service\ConfigurationHandlers;
 
 use OCP\AppFramework\Db\Entity;
 
 /**
- * Interface ConfigurationHandlerInterface
- *
  * Interface for configuration handlers that handle export and import of entities.
- *
- * @package   OCA\OpenConnector\Service\ConfigurationHandlers
- * @category  Service
- * @author    OpenConnector Team
- * @copyright 2024 OpenConnector
- * @license   AGPL-3.0
- * @version   1.0.0
- * @link      https://github.com/OpenConnector/openconnector
  */
 interface ConfigurationHandlerInterface
 {
     /**
-     * Export an entity to OpenAPI format
+     * Export an entity to OpenAPI format.
      *
-     * @param  Entity                                                                           $entity   The entity to export
-     * @param  array<string,array{idToSlug:array<string,string>,slugToId:array<string,string>}> $mappings The global mappings for ID/slug conversion
-     * @return array The OpenAPI entity specification
+     * @param Entity                                                                           $entity     The entity to export.
+     * @param array<string,array{idToSlug:array<string,string>,slugToId:array<string,string>}> $mappings   The global mappings for ID/slug conversion.
+     * @param array<int, int|string>                                                           $mappingIds Collected mapping ids (out parameter).
+     *
+     * @return array The OpenAPI entity specification.
      */
     public function export(Entity $entity, array $mappings, array &$mappingIds=[]): array;
 
     /**
-     * Import an entity from OpenAPI format
+     * Import an entity from OpenAPI format.
      *
-     * @param  array                                                                            $data     The OpenAPI entity specification
-     * @param  array<string,array{idToSlug:array<string,string>,slugToId:array<string,string>}> $mappings The global mappings for ID/slug conversion
-     * @return Entity The imported entity
+     * @param array                                                                            $data     The OpenAPI entity specification.
+     * @param array<string,array{idToSlug:array<string,string>,slugToId:array<string,string>}> $mappings The global mappings for ID/slug conversion.
+     *
+     * @return Entity The imported entity.
      */
     public function import(array $data, array $mappings): Entity;
 
     /**
-     * Get the entity type this handler is responsible for
+     * Get the entity type this handler is responsible for.
      *
-     * @return string The entity type
+     * @return string The entity type.
      */
     public function getEntityType(): string;
 }//end interface

--- a/lib/Service/DSOParserService.php
+++ b/lib/Service/DSOParserService.php
@@ -117,7 +117,7 @@ class DSOParserService
 
         // Validate BSN if aanvrager contains one.
         if (isset($payload['aanvrager']['bsn']) === true) {
-            $bsnValid = $this->validateBSN($payload['aanvrager']['bsn']);
+            $bsnValid = $this->validateBSN(bsn: $payload['aanvrager']['bsn']);
             if ($bsnValid === false) {
                 $errors[] = [
                     'field'   => 'aanvrager.bsn',
@@ -129,7 +129,7 @@ class DSOParserService
 
         // Validate indieningsdatum format (ISO 8601).
         if (isset($payload['indieningsdatum']) === true
-            && $this->validateISODate($payload['indieningsdatum']) === false
+            && $this->validateISODate(date: $payload['indieningsdatum']) === false
         ) {
             $errors[] = [
                 'field'   => 'indieningsdatum',
@@ -154,15 +154,20 @@ class DSOParserService
      */
     public function parseVerzoek(array $payload): array
     {
+        $bouwkosten = null;
+        if (isset($payload['bouwkosten']) === true) {
+            $bouwkosten = (float) $payload['bouwkosten'];
+        }
+
         $verzoek = [
             'verzoekId'       => $payload['verzoekId'] ?? null,
             'bronorganisatie' => $payload['bronorganisatie'] ?? null,
             'type'            => $payload['type'] ?? null,
             'indieningsdatum' => $payload['indieningsdatum'] ?? null,
-            'aanvrager'       => $this->parseAanvrager($payload['aanvrager'] ?? []),
-            'locatie'         => $this->parseLocatie($payload['locatie'] ?? []),
-            'activiteiten'    => $this->parseActiviteiten($payload['activiteiten'] ?? []),
-            'bouwkosten'      => isset($payload['bouwkosten']) === true ? (float) $payload['bouwkosten'] : null,
+            'aanvrager'       => $this->parseAanvrager(aanvrager: $payload['aanvrager'] ?? []),
+            'locatie'         => $this->parseLocatie(locatie: $payload['locatie'] ?? []),
+            'activiteiten'    => $this->parseActiviteiten(activiteiten: $payload['activiteiten'] ?? []),
+            'bouwkosten'      => $bouwkosten,
             'bijlagen'        => $payload['bijlagen'] ?? [],
             'status'          => 'ontvangen',
             'environment'     => $payload['environment'] ?? 'productie',
@@ -284,7 +289,7 @@ class DSOParserService
 
         // Convert GML to GeoJSON if present.
         if (isset($locatie['gmlGeometrie']) === true) {
-            $parsed['geometrie'] = $this->convertGMLToGeoJSON($locatie['gmlGeometrie']);
+            $parsed['geometrie'] = $this->convertGMLToGeoJSON(gml: $locatie['gmlGeometrie']);
         }
 
         return $parsed;

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * OpenConnector MongoDB Object Service.
+ *
+ * Thin wrapper over the MongoDB Data API used by OpenConnector to persist and
+ * query freeform JSON objects when OpenRegister is not the storage backend.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Service;
 
@@ -14,6 +31,8 @@ use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
+ * MongoDB Data API client wrapper for OpenConnector's optional Mongo backend.
+ *
  * @SuppressWarnings(PHPMD.ShortVariable)
  * @SuppressWarnings(PHPMD.LongVariable)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -23,11 +42,22 @@ use Symfony\Component\Uid\Uuid;
 class ObjectService
 {
 
+    /**
+     * Default MongoDB action payload skeleton.
+     *
+     * @var array<string, string>
+     */
     public const BASE_OBJECT = [
         'database'   => 'objects',
         'collection' => 'json',
     ];
 
+    /**
+     * Constructor.
+     *
+     * @param IAppManager        $appManager Used to detect whether the OpenRegister app is installed.
+     * @param ContainerInterface $container  PSR-11 container used to resolve OpenRegister services.
+     */
     public function __construct(
         private readonly IAppManager $appManager,
         private readonly ContainerInterface $container,
@@ -38,8 +68,9 @@ class ObjectService
     /**
      * Gets a guzzle client based upon given config.
      *
-     * @param  array $config The config to be used for the client.
-     * @return Client
+     * @param array $config The config to be used for the client.
+     *
+     * @return Client The configured Guzzle client.
      */
     public function getClient(array $config): Client
     {
@@ -47,16 +78,18 @@ class ObjectService
         unset($guzzleConf['mongodbCluster']);
 
         return new Client($config);
+
     }//end getClient()
 
     /**
-     * Save an object to MongoDB
+     * Save an object to MongoDB.
      *
      * @param array $data   The data to be saved.
      * @param array $config The configuration that should be used by the call.
      *
      * @return array The resulting object.
-     * @throws GuzzleException
+     *
+     * @throws GuzzleException When the HTTP request fails.
      */
     public function saveObject(array $data, array $config): array
     {
@@ -78,6 +111,7 @@ class ObjectService
         $id         = $resultData['insertedId'];
 
         return $this->findObject(filters: ['_id' => $id], config: $config);
+
     }//end saveObject()
 
     /**
@@ -88,7 +122,7 @@ class ObjectService
      *
      * @return array The objects found for given filters.
      *
-     * @throws GuzzleException
+     * @throws GuzzleException When the HTTP request fails.
      */
     public function findObjects(array $filters, array $config): array
     {
@@ -98,10 +132,10 @@ class ObjectService
         $object['dataSource'] = $config['mongodbCluster'];
         $object['filter']     = $filters;
 
-        // @todo Fix mongodb sort
+        // @todo Fix mongodb sort.
         // if (empty($sort) === false) {
         // $object['filter'][] = ['$sort' => $sort];
-        // }
+        // }.
         $returnData = $client->post(
             uri: 'action/find',
             options: ['json' => $object]
@@ -111,17 +145,18 @@ class ObjectService
             json: $returnData->getBody()->getContents(),
             associative: true
         );
+
     }//end findObjects()
 
     /**
-     * Finds an object based upon a set of filters (usually the id)
+     * Finds an object based upon a set of filters (usually the id).
      *
      * @param array $filters The filters to compare the objects to.
      * @param array $config  The config to be used by the call.
      *
      * @return array The resulting object.
      *
-     * @throws GuzzleException
+     * @throws GuzzleException When the HTTP request fails.
      */
     public function findObject(array $filters, array $config): array
     {
@@ -142,18 +177,19 @@ class ObjectService
         );
 
         return $result['document'];
+
     }//end findObject()
 
     /**
-     * Updates an object in MongoDB
+     * Updates an object in MongoDB.
      *
-     * @param array $filters The filter to search the object with (id)
+     * @param array $filters The filter to search the object with (id).
      * @param array $update  The fields that should be updated.
      * @param array $config  The configuration to be used by the call.
      *
      * @return array The updated object.
      *
-     * @throws GuzzleException
+     * @throws GuzzleException When the HTTP request fails.
      */
     public function updateObject(array $filters, array $update, array $config): array
     {
@@ -172,18 +208,19 @@ class ObjectService
                 options: ['json' => $object]
             );
 
-        return $this->findObject($filters, $config);
+        return $this->findObject(filters: $filters, config: $config);
+
     }//end updateObject()
 
     /**
-     * Delete an object according to a filter (id specifically)
+     * Delete an object according to a filter (id specifically).
      *
      * @param array $filters The filters to use.
      * @param array $config  The config to be used by the call.
      *
      * @return array An empty array.
      *
-     * @throws GuzzleException
+     * @throws GuzzleException When the HTTP request fails.
      */
     public function deleteObject(array $filters, array $config): array
     {
@@ -199,16 +236,19 @@ class ObjectService
         );
 
         return [];
+
     }//end deleteObject()
 
     /**
      * Aggregates objects for search facets.
      *
-     * @param  array $filters  The filters apply to the search request.
-     * @param  array $pipeline The pipeline to use.
-     * @param  array $config   The configuration to use in the call.
-     * @return array
-     * @throws GuzzleException
+     * @param array $filters  The filters apply to the search request.
+     * @param array $pipeline The pipeline to use.
+     * @param array $config   The configuration to use in the call.
+     *
+     * @return array The aggregation result.
+     *
+     * @throws GuzzleException When the HTTP request fails.
      */
     public function aggregateObjects(array $filters, array $pipeline, array $config):array
     {
@@ -234,36 +274,42 @@ class ObjectService
     /**
      * Attempts to retrieve the OpenRegister service from the container.
      *
-     * @return mixed|null The OpenRegister service if available, null otherwise.
-     * @throws ContainerExceptionInterface|NotFoundExceptionInterface
+     * @return \OCA\OpenRegister\Service\ObjectService|null The OpenRegister service if available, null otherwise.
+     *
+     * @throws ContainerExceptionInterface When the container fails.
+     * @throws NotFoundExceptionInterface  When the service is not bound.
      */
     public function getOpenRegisters(): ?\OCA\OpenRegister\Service\ObjectService
     {
         if (in_array(needle: 'openregister', haystack: $this->appManager->getInstalledApps()) === true) {
             try {
-                // Attempt to get the OpenRegister service from the container
+                // Attempt to get the OpenRegister service from the container.
                 return $this->container->get('OCA\OpenRegister\Service\ObjectService');
             } catch (Exception $e) {
-                // If the service is not available, return null
+                // If the service is not available, return null.
                 return null;
             }
         }
 
         return null;
+
     }//end getOpenRegisters()
 
     /**
      * Gets the appropriate mapper based on the object type.
-     * (This can be a objectType for OpenRegister, by using an instantiation of the objectService of OpenRegister).
      *
-     * @param string|null $objectType The objectType as string
-     * @param int|null    $schema     The openregister schema
-     * @param int|null    $register   The openregister register
+     * Either resolves an OpenRegister mapper by register + schema, or throws when
+     * an unknown object type is requested.
+     *
+     * @param string|null $objectType The objectType as string.
+     * @param int|null    $schema     The openregister schema.
+     * @param int|null    $register   The openregister register.
      *
      * @return mixed The appropriate mapper.
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     * @throws InvalidArgumentException If an unknown object type is provided.
+     *
+     * @throws ContainerExceptionInterface When the container fails.
+     * @throws NotFoundExceptionInterface  When the service is not bound.
+     * @throws InvalidArgumentException    If an unknown object type is provided.
      */
     public function getMapper(?string $objectType=null, ?int $schema=null, ?int $register=null): mixed
     {

--- a/lib/Service/StUFFieldMapper.php
+++ b/lib/Service/StUFFieldMapper.php
@@ -89,7 +89,7 @@ class StUFFieldMapper
 
                 // Transform dates from ISO 8601 to StUF YYYYMMDD format.
                 if ($stufField === 'geboortedatum' && is_string($value) === true) {
-                    $value = $this->isoDateToStUF($value);
+                    $value = $this->isoDateToStUF(isoDate: $value);
                 }
 
                 $result[$stufField] = $value;
@@ -98,7 +98,7 @@ class StUFFieldMapper
 
         // Map nested verblijfsadres.
         if (isset($person['verblijfsadres']) === true && is_array($person['verblijfsadres']) === true) {
-            $result['verblijfsadres'] = $this->mapAddressToStUF($person['verblijfsadres']);
+            $result['verblijfsadres'] = $this->mapAddressToStUF(address: $person['verblijfsadres']);
         }
 
         return $result;
@@ -125,7 +125,7 @@ class StUFFieldMapper
 
                 // Transform dates from StUF YYYYMMDD to ISO 8601 format.
                 if ($registerField === 'geboortedatum' && is_string($value) === true) {
-                    $value = $this->stufDateToISO($value);
+                    $value = $this->stufDateToISO(stufDate: $value);
                 }
 
                 $result[$registerField] = $value;

--- a/lib/Service/StorageService.php
+++ b/lib/Service/StorageService.php
@@ -1,4 +1,22 @@
 <?php
+/**
+ * OpenConnector storage service.
+ *
+ * Handles multi-part file uploads to Nextcloud's file storage backend. Splits
+ * incoming content into cache-tracked parts and reconciles them into the final
+ * target file once all parts have arrived.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Service;
 
@@ -28,6 +46,8 @@ use OCP\Lock\LockedException;
 use Symfony\Component\Uid\Uuid;
 
 /**
+ * Multi-part upload reconciliation backed by Nextcloud file storage.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.LongVariable)
  * @SuppressWarnings(PHPMD.StaticAccess)
@@ -36,23 +56,55 @@ use Symfony\Component\Uid\Uuid;
 class StorageService
 {
 
+    /**
+     * Distributed cache used to track upload parts between requests.
+     *
+     * @var ICache
+     */
     private ICache $cache;
 
-    public const CACHE_KEY          = 'openconnector-upload';
-    public const UPLOAD_TARGET_PATH = 'upload-target-path';
-    public const UPLOAD_TARGET_ID   = 'upload-target-id';
-
-    public const NUMBER_OF_PARTS = 'number-of-parts';
-
-    const APP_USER = 'OpenRegister';
+    /**
+     * Cache key prefix for in-progress uploads.
+     *
+     * @var string
+     */
+    public const CACHE_KEY = 'openconnector-upload';
 
     /**
-     * Class constructor
+     * Cache field for the target file path of an upload.
      *
-     * @param IRootFolder   $rootFolder   The Nextcloud rootfolder
+     * @var string
+     */
+    public const UPLOAD_TARGET_PATH = 'upload-target-path';
+
+    /**
+     * Cache field for the target file id of an upload.
+     *
+     * @var string
+     */
+    public const UPLOAD_TARGET_ID = 'upload-target-id';
+
+    /**
+     * Cache field for the total number of parts in an upload.
+     *
+     * @var string
+     */
+    public const NUMBER_OF_PARTS = 'number-of-parts';
+
+    /**
+     * System user under which OpenConnector reads/writes files.
+     *
+     * @var string
+     */
+    public const APP_USER = 'OpenRegister';
+
+    /**
+     * Class constructor.
+     *
+     * @param IRootFolder   $rootFolder   The Nextcloud rootfolder.
      * @param IAppConfig    $config       The configuration of the openconnector application.
      * @param ICacheFactory $cacheFactory The cache factory.
-     * @param IUserSession  $userSession  The user session.
+     * @param IUserManager  $userManager  Used to resolve the OpenConnector system user.
      */
     public function __construct(
         private readonly IRootFolder $rootFolder,
@@ -61,23 +113,30 @@ class StorageService
         private readonly IUserManager $userManager,
     ) {
         $this->cache = $cacheFactory->createDistributed(self::CACHE_KEY);
+
     }//end __construct()
 
     /**
-     * Create partial file upload. This will create the empty target file and a folder for the temporary files.
+     * Create partial file upload.
      *
-     * @param string $path     The path the target file will be written in.
-     * @param string $fileName The filename of the target file.
-     * @param int    $size     The total size of the file once all parts have been uploaded.
+     * This will create the empty target file and a folder for the temporary
+     * files.
+     *
+     * @param string      $path     The path the target file will be written in.
+     * @param string      $fileName The filename of the target file.
+     * @param int         $size     The total size of the file once all parts have been uploaded.
+     * @param string|null $objectId Optional reference to the OR object the upload belongs to.
      *
      * @return array The file part objects containing order number, size and id.
-     * @throws NotFoundException
-     * @throws InvalidPathException|NotPermittedException
+     *
+     * @throws NotFoundException     When the target path does not exist.
+     * @throws InvalidPathException  When the target path is invalid.
+     * @throws NotPermittedException When the target path is not writable.
      */
     public function createUpload(string $path, string $fileName, int $size, ?string $objectId=null): array
     {
         $user = $this->userManager->get(self::APP_USER);
-        // $userFolder = $this->rootFolder->getUserFolder(userId: $user ? $user->getUID() : 'Guest');
+        // $userFolder = $this->rootFolder->getUserFolder(userId: $user ? $user->getUID() : 'Guest');.
         $uploadFolder = $this->rootFolder->get($path);
 
         $partSize = $this->config->getValueInt('openconnector', 'part-size', 1000000);
@@ -90,6 +149,7 @@ class StorageService
         /*
          * @var File $target
          */
+
         $target = $uploadFolder->newFile($fileName);
 
         $partsFolder = $uploadFolder->newFolder("{$fileName}_parts");
@@ -99,17 +159,22 @@ class StorageService
             $partUuid   = Uuid::v4();
 
             $this->cache->set(
-                    "upload_$partUuid",
-                    [
-                        self::UPLOAD_TARGET_ID   => $target->getId(),
-                        self::UPLOAD_TARGET_PATH => $partsFolder->getPath(),
-                        self::NUMBER_OF_PARTS    => $numParts,
-                    ]
-                    );
+                "upload_$partUuid",
+                [
+                    self::UPLOAD_TARGET_ID   => $target->getId(),
+                    self::UPLOAD_TARGET_PATH => $partsFolder->getPath(),
+                    self::NUMBER_OF_PARTS    => $numParts,
+                ]
+            );
+
+            $reportedPartSize = $partSize;
+            if ($partSize >= $remainingSize) {
+                $reportedPartSize = $remainingSize;
+            }
 
             $parts[]        = [
                 'id'         => $partUuid,
-                'size'       => $partSize < $remainingSize ? $partSize : $remainingSize,
+                'size'       => $reportedPartSize,
                 'order'      => $partNumber,
                 'object'     => $objectId,
                 "successful" => false,
@@ -118,6 +183,7 @@ class StorageService
         }//end for
 
         return $parts;
+
     }//end createUpload()
 
     /**
@@ -128,10 +194,11 @@ class StorageService
      * @param string $content  The content of the file.
      *
      * @return File The resulting file.
-     * @throws GenericFileException
-     * @throws LockedException
-     * @throws NotFoundException
-     * @throws NotPermittedException
+     *
+     * @throws GenericFileException  When the underlying storage fails.
+     * @throws LockedException       When the target file is locked.
+     * @throws NotFoundException     When the path does not exist.
+     * @throws NotPermittedException When the path is not writable.
      */
     public function writeFile(string $path, string $fileName, string $content): File
     {
@@ -144,6 +211,7 @@ class StorageService
             /*
              * @var File $target
              */
+
             $target = $uploadFolder->get($fileName);
             $target->putContent($content);
         } catch (NotFoundException $e) {
@@ -151,6 +219,7 @@ class StorageService
         }
 
         return $target;
+
     }//end writeFile()
 
     /**
@@ -158,23 +227,24 @@ class StorageService
      *
      * @param Node[] $folderContents The contents of the folder containing the partial files.
      * @param File   $target         The file to write the contents to.
-     * @param int    $numParts
+     * @param int    $numParts       Total number of parts expected.
      *
      * @return bool Whether reconciling the file has been successful.
-     * @throws GenericFileException
-     * @throws LockedException
-     * @throws NotFoundException
-     * @throws NotPermittedException
-     * @throws InvalidPathException
+     *
+     * @throws GenericFileException  When the underlying storage fails.
+     * @throws LockedException       When the target file is locked.
+     * @throws NotFoundException     When a part file does not exist.
+     * @throws NotPermittedException When the storage is not writable.
+     * @throws InvalidPathException  When a part path is invalid.
      */
     private function attemptCloseUpload(array $folderContents, File $target, int $numParts): bool
     {
         $contentFilenames = array_map(
-                function ($node) {
-                    return $node->getName();
-                },
-                $folderContents
-                );
+            function ($node) {
+                return $node->getName();
+            },
+            $folderContents
+        );
 
         $folder = $folderContents[0]->getParent();
 
@@ -182,7 +252,7 @@ class StorageService
         ksort($files);
 
         $contentFilenames = array_filter(
-                $contentFilenames,
+            $contentFilenames,
             function ($string) use ($target) {
                 $result = preg_match("#^[0-9]+\.part\.{$target->getExtension()}$#", $string);
                 return $result !== false && $result > 0;
@@ -192,12 +262,11 @@ class StorageService
         $sortedFilenames = array_values($contentFilenames);
 
         $contentFilenamesWithoutExtensions = array_map(
-                function ($filename) use ($target) {
-                    return intval(str_replace(search: ".part.{$target->getExtension()}", replace: '', subject: $filename));
-
-                },
-                $contentFilenames
-                );
+            function ($filename) use ($target) {
+                return intval(str_replace(search: ".part.{$target->getExtension()}", replace: '', subject: $filename));
+            },
+            $contentFilenames
+        );
 
         if ($contentFilenamesWithoutExtensions !== range(start: 1, end: $numParts)) {
             return false;
@@ -221,21 +290,23 @@ class StorageService
         $target->putContent($totalContent);
 
         return true;
+
     }//end attemptCloseUpload()
 
     /**
      * Write a partial file to a temporary file and try to reconcile them if all file parts are uploaded.
      *
-     * @param int    $partId
-     * @param string $partUuid
-     * @param string $data
+     * @param int    $partId   Order number of the part being written.
+     * @param string $partUuid Cache key of the part being written.
+     * @param string $data     Raw part data.
      *
-     * @return bool
-     * @throws GenericFileException
-     * @throws InvalidPathException
-     * @throws LockedException
-     * @throws NotFoundException
-     * @throws NotPermittedException
+     * @return bool True when the part was written successfully.
+     *
+     * @throws GenericFileException  When the underlying storage fails.
+     * @throws InvalidPathException  When the part path is invalid.
+     * @throws LockedException       When the target file is locked.
+     * @throws NotFoundException     When the part folder or target does not exist.
+     * @throws NotPermittedException When the storage is not writable.
      */
     public function writePart(int $partId, string $partUuid, string $data): bool
     {
@@ -260,9 +331,10 @@ class StorageService
         $folderContents = $partsFolder->getDirectoryListing();
 
         if (count($folderContents) >= $numParts) {
-            $this->attemptCloseUpload($folderContents, $targetFile, $numParts);
+            $this->attemptCloseUpload(folderContents: $folderContents, target: $targetFile, numParts: $numParts);
         }
 
         return true;
+
     }//end writePart()
 }//end class


### PR DESCRIPTION
## Summary

Cleans **54 PHPCS errors across 6 files**:

- `lib/Connectors/PdokConnector.php` (21)
- `lib/Service/StUFFieldMapper.php` (3)
- `lib/Service/ObjectService.php` (9)
- `lib/Service/DSOParserService.php` (7)
- `lib/Service/StorageService.php` (14)
- `lib/Service/ConfigurationHandlers/ConfigurationHandlerInterface.php` (4)

Same recipe as the migration batch: file/class/method docblocks, named parameters on internal-code calls, no inline IFs, member-variable @var, explicit boolean comparisons. No functional changes.

## Test plan

- [x] Touched files report 0 errors under phpcs.xml
- [ ] CI green