### PR TITLE
style(phpcs): clean 7 services - drives #889 to 0 errors

### DIFF
--- a/lib/Service/AuthorizationService.php
+++ b/lib/Service/AuthorizationService.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * OpenConnector AuthorizationService.
+ *
+ * Service class for handling authorization on incoming calls — JWT, basic auth,
+ * OAuth bearer tokens and API keys.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Service;
 
@@ -51,9 +68,13 @@ class AuthorizationService
     const PSS_ALGORITHMS   = ['PS256', 'PS384', 'PS512'];
 
     /**
-     * @param IUserManager                            $userManager
-     * @param IUserSession                            $userSession
-     * @param \OCA\OpenRegister\Service\ObjectService $orObjectService
+     * Constructor.
+     *
+     * @param IUserManager                            $userManager     The user manager.
+     * @param IUserSession                            $userSession     The user session.
+     * @param \OCA\OpenRegister\Service\ObjectService $orObjectService OR ObjectService used to resolve consumers.
+     * @param IGroupManager                           $groupManager    The group manager.
+     * @param IProvider                               $tokenProvider   OAuth token provider.
      */
     public function __construct(
         private readonly IUserManager $userManager,
@@ -62,19 +83,30 @@ class AuthorizationService
         private readonly IGroupManager $groupManager,
         private readonly IProvider $tokenProvider,
     ) {
+
     }//end __construct()
 
     /**
      * Find the issuer (consumer) for the request.
      *
-     * @param  string $issuer The issuer from the JWT token.
+     * @param string $issuer The issuer from the JWT token.
+     *
      * @return ObjectEntity The consumer for the JWT token.
+     *
      * @throws AuthenticationException Thrown if no issuer was found.
      */
     private function findIssuer(string $issuer): ObjectEntity
     {
-        $matches   = $this->orObjectService->findAll(config: ['filters' => ['register' => 'openconnector', 'schema' => 'consumer', 'name' => $issuer]]);
-        $consumers = $matches['results'] ?? $matches;
+        $matches   = $this->orObjectService->findAll(
+            config: [
+                'filters' => [
+                    'register' => 'openconnector',
+                    'schema'   => 'consumer',
+                    'name'     => $issuer,
+                ],
+            ]
+        );
+        $consumers = ($matches['results'] ?? $matches);
 
         if (count($consumers) === 0) {
             throw new AuthenticationException(message: 'The issuer was not found', details: ['iss' => $issuer]);
@@ -86,7 +118,8 @@ class AuthorizationService
     /**
      * Check if the headers of a JWT token are valid.
      *
-     * @param  JWS $token The unserialized token.
+     * @param JWS $token The unserialized token.
+     *
      * @return void
      */
     private function checkHeaders(JWS $token): void
@@ -105,10 +138,12 @@ class AuthorizationService
     /**
      * Get the Json Web Key for a public key combined with an algorithm.
      *
-     * @param  string $publicKey The public key to create a JWK for
-     * @param  string $algorithm The algorithm deciding how the key should be defined.
+     * @param string $publicKey The public key to create a JWK for.
+     * @param string $algorithm The algorithm deciding how the key should be defined.
+     *
      * @return JWKSet The resulting JWK-set.
-     * @throws AuthenticationException
+     *
+     * @throws AuthenticationException If the algorithm is not supported.
      */
     private function getJWK(string $publicKey, string $algorithm): JWKSet
     {
@@ -141,9 +176,11 @@ class AuthorizationService
     /**
      * Validate data in the payload.
      *
-     * @param  array $payload The payload of the JWT token.
+     * @param array $payload The payload of the JWT token.
+     *
      * @return void
-     * @throws AuthenticationException
+     *
+     * @throws AuthenticationException If the token is missing/expired.
      */
     public function validatePayload(array $payload): void
     {
@@ -162,16 +199,26 @@ class AuthorizationService
         }
 
         if ($exp->diff($now)->format('%R') === '+') {
-            throw new AuthenticationException(message: 'The token has expired', details: ['iat' => $iat->getTimestamp(), 'exp' => $exp->getTimestamp(), 'time checked' => $now->getTimestamp()]);
+            throw new AuthenticationException(
+                message: 'The token has expired',
+                details: [
+                    'iat'          => $iat->getTimestamp(),
+                    'exp'          => $exp->getTimestamp(),
+                    'time checked' => $now->getTimestamp(),
+                ]
+            );
         }
+
     }//end validatePayload()
 
     /**
      * Checks if authorization header contains a valid JWT token.
      *
-     * @param  string $authorization The authorization header.
+     * @param string $authorization The authorization header.
+     *
      * @return void
-     * @throws AuthenticationException
+     *
+     * @throws AuthenticationException On any validation failure.
      */
     public function authorizeJwt(string $authorization): void
     {
@@ -200,7 +247,7 @@ class AuthorizationService
         $jws = $serializerManager->unserialize(input: $token);
 
         try {
-            $this->checkHeaders($jws);
+            $this->checkHeaders(token: $jws);
         } catch (InvalidHeaderException $exception) {
             throw new AuthenticationException(message: 'The token could not be validated', details: ['reason' => $exception->getMessage()]);
         }
@@ -220,23 +267,27 @@ class AuthorizationService
         $jwkSet = $this->getJWK(publicKey: $publicKey, algorithm: $algorithm);
 
         if ($verifier->verifyWithKeySet(jws: $jws, jwkset: $jwkSet, signatureIndex: 0) === false) {
-            throw new AuthenticationException(message: 'The token could not be validated', details: ['reason' => 'The token does not match the public key']);
+            throw new AuthenticationException(
+                message: 'The token could not be validated',
+                details: ['reason' => 'The token does not match the public key']
+            );
         }
 
-        $this->validatePayload($payload);
+        $this->validatePayload(payload: $payload);
 
         $this->userSession->setUser($this->userManager->get($issuerData['userId'] ?? ''));
     }//end authorizeJwt()
 
     /**
-     * Authorize user based on basic
+     * Authorize user based on basic auth.
      *
-     * @param string $header The authorization header given in the request
-     * @param array  $users  The users allowed to be authenticated according to the rule
-     * @param array  $groups The groups allowed to be authenticated according to the rule
+     * @param string $header The authorization header given in the request.
+     * @param array  $users  The users allowed to be authenticated according to the rule.
+     * @param array  $groups The groups allowed to be authenticated according to the rule.
      *
      * @return void
-     * @throws AuthenticationException
+     *
+     * @throws AuthenticationException On invalid credentials.
      */
     public function authorizeBasic(string $header, array $users, array $groups): void
     {
@@ -260,19 +311,40 @@ class AuthorizationService
         // $userInAllowedGroups = array_intersect($groups, $userGroups) !== [];
         //
         // if($userInAllowedUsers === false && $userInAllowedGroups === false) {
-        // throw new AuthenticationException(message: 'Not authorized', details: ['reason' => 'The selected user is not allowed to login on this endpoint']);
+        // throw new AuthenticationException(
+        // message: 'Not authorized',
+        // details: ['reason' => 'The selected user is not allowed to login on this endpoint']
+        // );
         // }
         $this->userSession->setUser($user);
+
     }//end authorizeBasic()
 
+    /**
+     * Authorize user based on OAuth bearer tokens.
+     *
+     * @param string $header The authorization header given in the request.
+     * @param array  $users  The users allowed to be authenticated according to the rule.
+     * @param array  $groups The groups allowed to be authenticated according to the rule.
+     *
+     * @return void
+     *
+     * @throws AuthenticationException On invalid tokens.
+     */
     public function authorizeOAuth(string $header, array $users, array $groups): void
     {
         if (str_starts_with($header, 'Bearer') === false) {
-            throw new AuthenticationException(message: 'Invalid method', details: ['reason' => 'The authentication method you are using is not allowed on this resource.']);
+            throw new AuthenticationException(
+                message: 'Invalid method',
+                details: ['reason' => 'The authentication method you are using is not allowed on this resource.']
+            );
         }
 
         if ($this->userSession->isLoggedIn() === false) {
-            throw new AuthenticationException(message: 'Not authorized', details: ['reason' => 'The token you used has either expired or was not recognized as a valid token']);
+            throw new AuthenticationException(
+                message: 'Not authorized',
+                details: ['reason' => 'The token you used has either expired or was not recognized as a valid token']
+            );
         }
 
         $user = $this->userSession->getUser();
@@ -296,19 +368,20 @@ class AuthorizationService
     }//end authorizeOAuth()
 
     /**
-     * Add CORS headers to controller result
+     * Add CORS headers to controller result.
      *
-     * @param  IRequest $request  The incoming request.
-     * @param  Response $response The outgoing response.
+     * @param IRequest $request  The incoming request.
+     * @param Response $response The outgoing response.
+     *
      * @return Response The updated response.
-     * @throws SecurityException
+     *
+     * @throws SecurityException If Allow-Credentials is true.
      */
     public function corsAfterController(IRequest $request, Response $response)
     {
-        // only react if it's a CORS request and if the request sends origin and
-        if (isset($request->server['HTTP_ORIGIN'])) {
-            // allow credentials headers must not be true or CSRF is possible
-            // otherwise
+        // Only react if it's a CORS request and if the request sends origin and.
+        if (isset($request->server['HTTP_ORIGIN']) === true) {
+            // Allow credentials headers must not be true or CSRF is possible otherwise.
             foreach ($response->getHeaders() as $header => $value) {
                 if (strtolower($header) === 'access-control-allow-credentials'
                     && strtolower(trim($value)) === 'true'
@@ -326,12 +399,14 @@ class AuthorizationService
     }//end corsAfterController()
 
     /**
-     * Authorize user based on APIkey
+     * Authorize user based on API key.
      *
-     * @param  string $header The authorization header used.
-     * @param  array  $keys   The array of keys configured on the rule.
+     * @param string $header The authorization header used.
+     * @param array  $keys   The array of keys configured on the rule.
+     *
      * @return void
-     * @throws AuthenticationException
+     *
+     * @throws AuthenticationException On invalid API keys.
      */
     public function authorizeApiKey(string $header, array $keys): void
     {

--- a/lib/Service/EndpointCacheService.php
+++ b/lib/Service/EndpointCacheService.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * OpenConnector EndpointCacheService.
+ *
+ * Service for caching endpoint data to improve matching performance.
+ *
+ * This service caches endpoint data in memory to avoid database queries
+ * on every request when matching paths to endpoints.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Service;
 
@@ -8,17 +27,7 @@ use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 
 /**
- * Service for caching endpoint data to improve matching performance
- *
- * This service caches endpoint data in memory to avoid database queries
- * on every request when matching paths to endpoints.
- *
- * @category Service
- * @package  OCA\OpenConnector\Service
- * @author   Ruben van der Linde <ruben@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- * @version  1.0.0
- * @link     https://github.com/ConductionNL/openconnector
+ * Service for caching endpoint data to improve matching performance.
  *
  * @SuppressWarnings(PHPMD.ShortVariable)
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -29,18 +38,19 @@ use Psr\Log\LoggerInterface;
  */
 class EndpointCacheService
 {
+
     /**
-     * Cache key for endpoint data
+     * Cache key for endpoint data.
      */
     private const CACHE_KEY = 'openconnector_endpoints_cache';
 
     /**
-     * Cache TTL in seconds (1 hour)
+     * Cache TTL in seconds (1 hour).
      */
     private const CACHE_TTL = 3600;
 
     /**
-     * In-memory cache for request lifetime
+     * In-memory cache for request lifetime.
      *
      * @var array|null
      */
@@ -54,27 +64,30 @@ class EndpointCacheService
     private bool $cacheDirty = false;
 
     /**
-     * Constructor for EndpointCacheService
+     * Constructor for EndpointCacheService.
      *
-     * @param ICacheFactory                           $cacheFactory    Factory for creating cache instances
-     * @param \OCA\OpenRegister\Service\ObjectService $orObjectService OR object service for endpoint lookups
-     * @param LoggerInterface                         $logger          Logger for error handling
+     * @param ICacheFactory                           $cacheFactory    Factory for creating cache instances.
+     * @param \OCA\OpenRegister\Service\ObjectService $orObjectService OR object service for endpoint lookups.
+     * @param LoggerInterface                         $logger          Logger for error handling.
      */
     public function __construct(
         private readonly ICacheFactory $cacheFactory,
         private readonly \OCA\OpenRegister\Service\ObjectService $orObjectService,
         private readonly LoggerInterface $logger
     ) {
+
     }//end __construct()
 
     /**
-     * Find the best matching endpoint for a path and method using cached data with smart fallback
+     * Find the best matching endpoint for a path and method using cached data with smart fallback.
      *
-     * @param  string $path    The path to match against endpoint regex patterns
-     * @param  string $method  The HTTP method to filter by (GET, POST, etc)
-     * @param  bool   $isRetry Internal flag to prevent infinite recursion
-     * @return ObjectEntity|null Returns the best matching endpoint or null if none found
-     * @throws \Exception When multiple endpoints match (ambiguous routing)
+     * @param string  $path    The path to match against endpoint regex patterns.
+     * @param string  $method  The HTTP method to filter by (GET, POST, etc).
+     * @param boolean $isRetry Internal flag to prevent infinite recursion.
+     *
+     * @return ObjectEntity|null Returns the best matching endpoint or null if none found.
+     *
+     * @throws \Exception When multiple endpoints match (ambiguous routing).
      */
     public function findByPathRegex(string $path, string $method, bool $isRetry=false): ?ObjectEntity
     {
@@ -83,38 +96,52 @@ class EndpointCacheService
         $matches = array_filter(
                 $endpoints,
                 function ($endpoint) use ($path, $method) {
-                    // Work with arrays directly - much faster than object reconstruction
-                    $endpointData   = ($endpoint instanceof ObjectEntity) ? $endpoint->getObject() : (is_array($endpoint) ? $endpoint : []);
-                    $pattern        = $endpointData['endpointRegex'] ?? null;
-                    $endpointMethod = $endpointData['method'] ?? null;
+                    // Work with arrays directly - much faster than object reconstruction.
+                    if ($endpoint instanceof ObjectEntity) {
+                        $endpointData = $endpoint->getObject();
+                    } else if (is_array($endpoint) === true) {
+                        $endpointData = $endpoint;
+                    } else {
+                        $endpointData = [];
+                    }
 
-                    // Skip if no regex pattern is set
+                    $pattern        = ($endpointData['endpointRegex'] ?? null);
+                    $endpointMethod = ($endpointData['method'] ?? null);
+
+                    // Skip if no regex pattern is set.
                     if (empty($pattern) === true) {
                         return false;
                     }
 
-                    // Check if both path matches the regex pattern and method matches
-                    return preg_match($pattern, $path) === 1 && $endpointMethod === $method;
+                    // Check if both path matches the regex pattern and method matches.
+                    return (preg_match($pattern, $path) === 1 && $endpointMethod === $method);
                 }
                 );
 
-        // Smart fallback: if no matches found and we haven't retried yet, refresh cache once and try again
-        if (empty($matches) && !$isRetry) {
+        // Smart fallback: if no matches found and we haven't retried yet, refresh cache once and try again.
+        if (empty($matches) === true && $isRetry === false) {
             $this->logger->info("No endpoint matches found for {$method} {$path}, refreshing cache and retrying");
 
-            // Force refresh the cache
+            // Force refresh the cache.
             $this->refreshCache();
 
-            // Try once more with fresh data
-            return $this->findByPathRegex($path, $method, true);
+            // Try once more with fresh data.
+            return $this->findByPathRegex(path: $path, method: $method, isRetry: true);
         }
 
-        // Handle multiple matches - this is an ambiguous routing situation
+        // Handle multiple matches - this is an ambiguous routing situation.
         if (count($matches) > 1) {
             $endpointNames = array_map(
                     function ($ep) {
-                        $data = ($ep instanceof ObjectEntity) ? $ep->getObject() : (is_array($ep) ? $ep : []);
-                        return $data['name'] ?? 'unnamed';
+                        if ($ep instanceof ObjectEntity) {
+                            $data = $ep->getObject();
+                        } else if (is_array($ep) === true) {
+                            $data = $ep;
+                        } else {
+                            $data = [];
+                        }
+
+                        return ($data['name'] ?? 'unnamed');
                     },
                     $matches
                     );
@@ -123,89 +150,106 @@ class EndpointCacheService
             );
         }
 
-        // Return null if no matches
-        if (empty($matches)) {
+        // Return null if no matches.
+        if (empty($matches) === true) {
             return null;
         }
 
-        // Return the matched ObjectEntity endpoint
+        // Return the matched ObjectEntity endpoint.
         $matchedEndpoint = reset($matches);
-        return ($matchedEndpoint instanceof ObjectEntity) ? $matchedEndpoint : null;
+        if ($matchedEndpoint instanceof ObjectEntity) {
+            return $matchedEndpoint;
+        }
+
+        return null;
+
     }//end findByPathRegex()
 
     /**
-     * Get all endpoints from cache or database as ObjectEntity arrays (for performance)
+     * Get all endpoints from cache or database as ObjectEntity arrays (for performance).
      *
-     * @return array Array of ObjectEntity instances (for faster filtering)
+     * @return array Array of ObjectEntity instances (for faster filtering).
      */
     public function getAllEndpoints(): array
     {
-        // Return from memory cache if available and cache is not dirty (request lifetime)
-        if ($this->memoryCache !== null && !$this->cacheDirty) {
+        // Return from memory cache if available and cache is not dirty (request lifetime).
+        if ($this->memoryCache !== null && $this->cacheDirty === false) {
             return $this->memoryCache;
         }
 
         try {
             $cache = $this->cacheFactory->createDistributed('openconnector');
 
-            // Check if cache is dirty (endpoints were modified)
-            if ($this->cacheDirty) {
+            // Check if cache is dirty (endpoints were modified).
+            if ($this->cacheDirty === true) {
                 $this->logger->info('Endpoint cache is dirty, forcing refresh');
                 $this->refreshCache();
-                return $this->memoryCache ?? [];
+                return ($this->memoryCache ?? []);
             }
 
-            // Try to get from persistent cache
+            // Try to get from persistent cache.
             $cachedData = $cache->get(self::CACHE_KEY);
 
-            if ($cachedData !== null && is_array($cachedData)) {
+            if ($cachedData !== null && is_array($cachedData) === true) {
                 $this->memoryCache = $cachedData;
                 return $cachedData;
             }
 
-            // Cache miss - load from database
+            // Cache miss - load from database.
             $this->refreshCache();
 
-            return $this->memoryCache ?? [];
+            return ($this->memoryCache ?? []);
         } catch (\Exception $e) {
             $this->logger->warning('Endpoint cache error, falling back to database: '.$e->getMessage());
 
-            // Fallback to direct OR query
+            // Fallback to direct OR query.
             return $this->fetchEndpointsFromOr();
         }//end try
+
     }//end getAllEndpoints()
 
     /**
      * Fetch all endpoints from OpenRegister ObjectService.
      *
-     * @return array Array of ObjectEntity instances
+     * @return array Array of ObjectEntity instances.
      */
     private function fetchEndpointsFromOr(): array
     {
         $matches   = $this->orObjectService->findAll(config: ['filters' => ['register' => 'openconnector', 'schema' => 'endpoint']]);
-        $endpoints = $matches['results'] ?? $matches;
-        return is_array($endpoints) ? $endpoints : [];
+        $endpoints = ($matches['results'] ?? $matches);
+        if (is_array($endpoints) === true) {
+            return $endpoints;
+        }
+
+        return [];
+
     }//end fetchEndpointsFromOr()
 
     /**
-     * Refresh the endpoint cache from OpenRegister
+     * Refresh the endpoint cache from OpenRegister.
      *
      * @return void
      */
     public function refreshCache(): void
     {
         try {
-            // Load fresh data from OR
+            // Load fresh data from OR.
             $endpoints = $this->fetchEndpointsFromOr();
 
-            // Store in memory cache (request lifetime)
+            // Store in memory cache (request lifetime).
             $this->memoryCache = $endpoints;
             $this->cacheDirty  = false;
 
-            // Persist serialisable data (arrays) in distributed cache
+            // Persist serialisable data (arrays) in distributed cache.
             $serialisable = array_map(
                 static function ($ep) {
-                    return ($ep instanceof ObjectEntity) ? $ep->getObject() : (is_array($ep) ? $ep : []);
+                    if ($ep instanceof ObjectEntity) {
+                        return $ep->getObject();
+                    } else if (is_array($ep) === true) {
+                        return $ep;
+                    }
+
+                    return [];
                 },
                 $endpoints
             );
@@ -218,10 +262,11 @@ class EndpointCacheService
             $this->logger->error('Failed to refresh endpoint cache: '.$e->getMessage());
             throw $e;
         }//end try
+
     }//end refreshCache()
 
     /**
-     * Clear the endpoint cache
+     * Clear the endpoint cache.
      *
      * This should be called when endpoints are created, updated, or deleted.
      *
@@ -230,10 +275,10 @@ class EndpointCacheService
     public function clearCache(): void
     {
         try {
-            // Clear memory cache
+            // Clear memory cache.
             $this->memoryCache = null;
 
-            // Clear persistent cache
+            // Clear persistent cache.
             $cache = $this->cacheFactory->createDistributed('openconnector');
             $cache->remove(self::CACHE_KEY);
 
@@ -241,16 +286,18 @@ class EndpointCacheService
         } catch (\Exception $e) {
             $this->logger->warning('Failed to clear endpoint cache: '.$e->getMessage());
         }
+
     }//end clearCache()
 
     /**
-     * Create endpoint regex pattern from endpoint path
+     * Create endpoint regex pattern from endpoint path.
      *
      * This mirrors the logic from EndpointMapper::createEndpointRegex()
      * but is kept here to maintain cache service independence.
      *
-     * @param  string $endpoint The endpoint path pattern
-     * @return string The regex pattern for matching
+     * @param string $endpoint The endpoint path pattern.
+     *
+     * @return string The regex pattern for matching.
      */
     private function createEndpointRegex(string $endpoint): string
     {
@@ -260,28 +307,29 @@ class EndpointCacheService
             $endpoint
         ).'#';
 
-        // Replace only the LAST occurrence of "(/([^/]+))?#" with "(?:/([^/]+))?$#"
+        // Replace only the LAST occurrence of "(/([^/]+))?#" with "(?:/([^/]+))?$#".
         $regex = preg_replace_callback(
             '/\(\/\(\[\^\/\]\+\)\)\?#/',
             function ($matches) {
                 return '(?:/([^/]+))?$#';
             },
             $regex,
+            // Limit to only one replacement.
             1
-        // Limit to only one replacement
         );
 
         if (str_ends_with($regex, '?#') === false && str_ends_with($regex, '$#') === false) {
-            $regex = substr($regex, 0, -1).'$#';
+            $regex = (substr($regex, 0, -1).'$#');
         }
 
         return $regex;
+
     }//end createEndpointRegex()
 
     /**
-     * Get cache statistics for monitoring
+     * Get cache statistics for monitoring.
      *
-     * @return array Cache statistics
+     * @return array Cache statistics.
      */
     public function getCacheStats(): array
     {
@@ -289,10 +337,16 @@ class EndpointCacheService
             $cache      = $this->cacheFactory->createDistributed('openconnector');
             $cachedData = $cache->get(self::CACHE_KEY);
 
+            if ($cachedData !== null && is_array($cachedData) === true) {
+                $endpointCount = count($cachedData);
+            } else {
+                $endpointCount = 0;
+            }
+
             return [
-                'cached'         => $cachedData !== null,
-                'memory_cached'  => $this->memoryCache !== null,
-                'endpoint_count' => $cachedData && is_array($cachedData) ? count($cachedData) : 0,
+                'cached'         => ($cachedData !== null),
+                'memory_cached'  => ($this->memoryCache !== null),
+                'endpoint_count' => $endpointCount,
                 'cache_key'      => self::CACHE_KEY,
                 'cache_ttl'      => self::CACHE_TTL,
                 'cache_dirty'    => $this->cacheDirty,
@@ -301,9 +355,10 @@ class EndpointCacheService
             return [
                 'error'         => $e->getMessage(),
                 'cached'        => false,
-                'memory_cached' => $this->memoryCache !== null,
+                'memory_cached' => ($this->memoryCache !== null),
                 'cache_dirty'   => $this->cacheDirty,
             ];
         }//end try
+
     }//end getCacheStats()
 }//end class

--- a/lib/Service/EventService.php
+++ b/lib/Service/EventService.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * OpenConnector EventService.
+ *
+ * Service class for managing events and their delivery.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Service;
 
@@ -11,37 +27,40 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 /**
- * Service class for managing events and their delivery
- *
- * @package OCA\OpenConnector\Service
+ * Service class for managing events and their delivery.
  *
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  */
 class EventService
 {
     /**
-     * @param ORObjectService $objectService The OR ObjectService for data access
-     * @param IClientService  $clientService
-     * @param LoggerInterface $logger
+     * Constructor.
+     *
+     * @param ORObjectService $objectService The OR ObjectService for data access.
+     * @param IClientService  $clientService HTTP client service used to deliver push messages.
+     * @param LoggerInterface $logger        Logger for delivery successes and failures.
      */
     public function __construct(
         private readonly ORObjectService $objectService,
         private readonly IClientService $clientService,
         private readonly LoggerInterface $logger
     ) {
+
     }//end __construct()
 
     /**
-     * Process a new event and create messages for all matching subscriptions
+     * Process a new event and create messages for all matching subscriptions.
      *
-     * @param  ObjectEntity $event The event ObjectEntity to process
-     * @return array<ObjectEntity> Array of created message ObjectEntities
-     * @throws Exception
+     * @param ObjectEntity $event The event ObjectEntity to process.
+     *
+     * @return array<ObjectEntity> Array of created message ObjectEntities.
+     *
+     * @throws Exception On failure to process the event.
      */
     public function processEvent(ObjectEntity $event): array
     {
         try {
-            // Find all active subscriptions
+            // Find all active subscriptions.
             $matches       = $this->objectService->findAll(
                     config: [
                         'filters' => [
@@ -51,18 +70,18 @@ class EventService
                         ],
                     ]
                     );
-            $subscriptions = $matches['results'] ?? $matches;
+            $subscriptions = ($matches['results'] ?? $matches);
             $messages      = [];
 
             foreach ($subscriptions as $subscription) {
-                if ($this->doesEventMatchSubscription($event, $subscription)) {
-                    $message    = $this->createEventMessage($event, $subscription);
+                if ($this->doesEventMatchSubscription(event: $event, subscription: $subscription) === true) {
+                    $message    = $this->createEventMessage(event: $event, subscription: $subscription);
                     $messages[] = $message;
 
                     $subscriptionData = $subscription->getObject();
-                    // If it's a push subscription, attempt immediate delivery
+                    // If it's a push subscription, attempt immediate delivery.
                     if (($subscriptionData['style'] ?? '') === 'push') {
-                        $this->deliverMessage($message);
+                        $this->deliverMessage(message: $message);
                     }
                 }
             }
@@ -78,51 +97,55 @@ class EventService
                     );
             throw $e;
         }//end try
+
     }//end processEvent()
 
     /**
-     * Check if an event matches a subscription's criteria
+     * Check if an event matches a subscription's criteria.
      *
-     * @param  ObjectEntity $event
-     * @param  ObjectEntity $subscription
-     * @return bool
+     * @param ObjectEntity $event        The event to evaluate.
+     * @param ObjectEntity $subscription The subscription whose filters/types are checked.
+     *
+     * @return boolean
      */
     private function doesEventMatchSubscription(ObjectEntity $event, ObjectEntity $subscription): bool
     {
         $eventData        = $event->getObject();
         $subscriptionData = $subscription->getObject();
 
-        // Check event type matches
-        $types = $subscriptionData['types'] ?? [];
+        // Check event type matches.
+        $types = ($subscriptionData['types'] ?? []);
         if (empty($types) === false
-            && in_array($eventData['type'] ?? '', $types) === false
+            && in_array(($eventData['type'] ?? ''), $types) === false
         ) {
             return false;
         }
 
-        // Check source matches
-        $subscriptionSource = $subscriptionData['source'] ?? null;
+        // Check source matches.
+        $subscriptionSource = ($subscriptionData['source'] ?? null);
         if ($subscriptionSource !== null
             && ($eventData['source'] ?? null) !== $subscriptionSource
         ) {
             return false;
         }
 
-        // Process filters if any exist
-        $filters = $subscriptionData['filters'] ?? [];
+        // Process filters if any exist.
+        $filters = ($subscriptionData['filters'] ?? []);
         if (empty($filters) === false) {
-            return $this->evaluateFilters($eventData, $filters);
+            return $this->evaluateFilters(eventData: $eventData, filters: $filters);
         }
 
         return true;
+
     }//end doesEventMatchSubscription()
 
     /**
-     * Evaluate filter conditions against an event data array
+     * Evaluate filter conditions against an event data array.
      *
-     * @param  array $eventData The event data as plain array
-     * @param  array $filters
-     * @return bool
+     * @param array $eventData The event data as plain array.
+     * @param array $filters   Subscription filters.
+     *
+     * @return boolean
      */
     private function evaluateFilters(array $eventData, array $filters): bool
     {
@@ -141,7 +164,7 @@ class EventService
 
                     case 'prefix':
                         foreach ($condition as $field => $value) {
-                            if (str_starts_with($eventData[$field] ?? '', $value) === false) {
+                            if (str_starts_with(($eventData[$field] ?? ''), $value) === false) {
                                 return false;
                             }
                         }
@@ -149,7 +172,7 @@ class EventService
 
                     case 'suffix':
                         foreach ($condition as $field => $value) {
-                            if (str_ends_with($eventData[$field] ?? '', $value) === false) {
+                            if (str_ends_with(($eventData[$field] ?? ''), $value) === false) {
                                 return false;
                             }
                         }
@@ -165,15 +188,18 @@ class EventService
         }//end foreach
 
         return true;
+
     }//end evaluateFilters()
 
     /**
-     * Create a new event message
+     * Create a new event message.
      *
-     * @param  ObjectEntity $event
-     * @param  ObjectEntity $subscription
+     * @param ObjectEntity $event        The event to materialise.
+     * @param ObjectEntity $subscription The subscription owning the message.
+     *
      * @return ObjectEntity
-     * @throws \OCP\DB\Exception
+     *
+     * @throws \OCP\DB\Exception On persistence failure.
      */
     private function createEventMessage(ObjectEntity $event, ObjectEntity $subscription): ObjectEntity
     {
@@ -183,7 +209,7 @@ class EventService
         return $this->objectService->saveObject(
             object: [
                 'eventId'        => $event->getUuid(),
-                'consumerId'     => $subscriptionData['consumerId'] ?? null,
+                'consumerId'     => ($subscriptionData['consumerId'] ?? null),
                 'subscriptionId' => $subscription->getUuid(),
                 'status'         => 'pending',
                 'payload'        => $event->jsonSerialize(),
@@ -193,19 +219,21 @@ class EventService
             register: 'openconnector',
             schema: 'event_message'
         );
+
     }//end createEventMessage()
 
     /**
-     * Attempt to deliver a message
+     * Attempt to deliver a message.
      *
-     * @param  ObjectEntity $message
-     * @return bool
+     * @param ObjectEntity $message The pending message to deliver.
+     *
+     * @return boolean True when delivered successfully.
      */
     public function deliverMessage(ObjectEntity $message): bool
     {
         try {
             $messageData    = $message->getObject();
-            $subscriptionId = $messageData['subscriptionId'] ?? null;
+            $subscriptionId = ($messageData['subscriptionId'] ?? null);
 
             if ($subscriptionId === null) {
                 return false;
@@ -278,13 +306,15 @@ class EventService
 
             return false;
         }//end try
+
     }//end deliverMessage()
 
     /**
-     * Process pending message retries
+     * Process pending message retries.
      *
-     * @param  int $maxRetries Maximum number of retry attempts
-     * @return int Number of successfully delivered messages
+     * @param integer $maxRetries Maximum number of retry attempts.
+     *
+     * @return integer Number of successfully delivered messages.
      */
     public function processRetries(int $maxRetries=5): int
     {
@@ -297,26 +327,28 @@ class EventService
                     ],
                 ]
                 );
-        $messages     = $matches['results'] ?? $matches;
+        $messages     = ($matches['results'] ?? $matches);
         $successCount = 0;
 
         foreach ($messages as $message) {
             $messageData = $message->getObject();
             $retryCount  = (int) ($messageData['retryCount'] ?? 0);
-            if ($retryCount < $maxRetries && $this->deliverMessage($message)) {
+            if ($retryCount < $maxRetries && $this->deliverMessage(message: $message) === true) {
                 $successCount++;
             }
         }
 
         return $successCount;
+
     }//end processRetries()
 
     /**
-     * Get events for a pull-based subscription
+     * Get events for a pull-based subscription.
      *
-     * @param  ObjectEntity $subscription
-     * @param  int|null     $limit
-     * @param  string|null  $cursor
+     * @param ObjectEntity $subscription The owning subscription.
+     * @param integer|null $limit        Maximum number of messages to return.
+     * @param string|null  $cursor       Pagination cursor from the previous call.
+     *
      * @return array{messages: ObjectEntity[], cursor: string|null}
      */
     public function pullEvents(ObjectEntity $subscription, ?int $limit=100, ?string $cursor=null): array
@@ -332,60 +364,70 @@ class EventService
             $filters['id'] = ['>' => $cursor];
         }
 
-        $matches    = $this->objectService->findAll(
+        $matches  = $this->objectService->findAll(
                 config: [
                     'filters' => $filters,
-                    'limit'   => $limit ?? 100,
+                    'limit'   => ($limit ?? 100),
                 ]
                 );
-        $messages   = $matches['results'] ?? $matches;
-        $lastCursor = count($messages) > 0 ? end($messages)->getUuid() : null;
+        $messages = ($matches['results'] ?? $matches);
+        if (count($messages) > 0) {
+            $lastCursor = end($messages)->getUuid();
+        } else {
+            $lastCursor = null;
+        }
 
         return [
             'messages' => $messages,
             'cursor'   => $lastCursor,
         ];
+
     }//end pullEvents()
 
     /**
-     * Handle object creation by creating and processing a CloudEvent
+     * Handle object creation by creating and processing a CloudEvent.
      *
-     * @param  ObjectEntity $object The created object
-     * @return ObjectEntity[] The created CloudEvent messages
-     * @throws Exception
-     * @throws \OCP\DB\Exception
+     * @param ObjectEntity $object The created object.
+     *
+     * @return ObjectEntity[] The created CloudEvent messages.
+     *
+     * @throws Exception        On event processing failure.
+     * @throws \OCP\DB\Exception On persistence failure.
      */
     public function handleObjectCreated(ObjectEntity $object): array
     {
         $objectData = $object->getObject();
         $event      = $this->objectService->saveObject(
             object: [
-                'source'  => '/objects/'.($objectData['type'] ?? ''),
+                'source'  => ('/objects/'.($objectData['type'] ?? '')),
                 'type'    => 'com.nextcloud.openregister.object.created',
                 'time'    => (new DateTime())->format('c'),
                 'subject' => $object->getUuid(),
                 'data'    => [
-                    'type'       => $objectData['type'] ?? null,
+                    'type'       => ($objectData['type'] ?? null),
                     'id'         => $object->getUuid(),
                     'attributes' => $objectData,
                 ],
-                'userId'  => $objectData['userId'] ?? null,
+                'userId'  => ($objectData['userId'] ?? null),
             ],
             register: 'openconnector',
             schema: 'event'
         );
 
-        return $this->processEvent($event);
+        return $this->processEvent(event: $event);
+
     }//end handleObjectCreated()
 
     /**
-     * Handle object update by creating and processing a CloudEvent
+     * Handle object update by creating and processing a CloudEvent.
      *
-     * @param  ObjectEntity $oldObject The previous state of the object
-     * @param  ObjectEntity $newObject The new state of the object
-     * @return ObjectEntity[] The created CloudEvent messages
-     * @throws Exception
-     * @throws \OCP\DB\Exception
+     * @param ObjectEntity $oldObject The previous state of the object.
+     * @param ObjectEntity $newObject The new state of the object.
+     *
+     * @return ObjectEntity[] The created CloudEvent messages.
+     *
+     * @throws Exception        On event processing failure.
+     * @throws \OCP\DB\Exception On persistence failure.
      */
     public function handleObjectUpdated(ObjectEntity $oldObject, ObjectEntity $newObject): array
     {
@@ -394,34 +436,37 @@ class EventService
 
         $event = $this->objectService->saveObject(
             object: [
-                'source'  => '/objects/'.($newData['type'] ?? ''),
+                'source'  => ('/objects/'.($newData['type'] ?? '')),
                 'type'    => 'com.nextcloud.openregister.object.updated',
                 'time'    => (new DateTime())->format('c'),
                 'subject' => $newObject->getUuid(),
                 'data'    => [
-                    'type'       => $newData['type'] ?? null,
+                    'type'       => ($newData['type'] ?? null),
                     'id'         => $newObject->getUuid(),
                     'attributes' => $newData,
                     'previous'   => [
                         'attributes' => $oldData,
                     ],
                 ],
-                'userId'  => $newData['userId'] ?? null,
+                'userId'  => ($newData['userId'] ?? null),
             ],
             register: 'openconnector',
             schema: 'event'
         );
 
-        return $this->processEvent($event);
+        return $this->processEvent(event: $event);
+
     }//end handleObjectUpdated()
 
     /**
-     * Handle object deletion by creating and processing a CloudEvent
+     * Handle object deletion by creating and processing a CloudEvent.
      *
-     * @param  ObjectEntity $object The deleted object
-     * @return ObjectEntity[] The created CloudEvent messages
-     * @throws Exception
-     * @throws \OCP\DB\Exception
+     * @param ObjectEntity $object The deleted object.
+     *
+     * @return ObjectEntity[] The created CloudEvent messages.
+     *
+     * @throws Exception        On event processing failure.
+     * @throws \OCP\DB\Exception On persistence failure.
      */
     public function handleObjectDeleted(ObjectEntity $object): array
     {
@@ -429,20 +474,21 @@ class EventService
 
         $event = $this->objectService->saveObject(
             object: [
-                'source'  => '/objects/'.($objectData['type'] ?? ''),
+                'source'  => ('/objects/'.($objectData['type'] ?? '')),
                 'type'    => 'com.nextcloud.openregister.object.deleted',
                 'time'    => (new DateTime())->format('c'),
                 'subject' => $object->getUuid(),
                 'data'    => [
-                    'type' => $objectData['type'] ?? null,
+                    'type' => ($objectData['type'] ?? null),
                     'id'   => $object->getUuid(),
                 ],
-                'userId'  => $objectData['userId'] ?? null,
+                'userId'  => ($objectData['userId'] ?? null),
             ],
             register: 'openconnector',
             schema: 'event'
         );
 
-        return $this->processEvent($event);
+        return $this->processEvent(event: $event);
+
     }//end handleObjectDeleted()
 }//end class

--- a/lib/Service/Helper/FlowToken.php
+++ b/lib/Service/Helper/FlowToken.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * OpenConnector FlowToken.
+ *
+ * Mutable container that carries the original + amended request / response /
+ * sync-input / sync-output payloads across the rule pipeline.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service\Helper
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Service\Helper;
 
@@ -6,27 +23,78 @@ use OC\AppFramework\Http\Request;
 use OCP\AppFramework\Http\Response;
 
 /**
+ * Container for original + amended payloads passed through the rule pipeline.
+ *
  * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
  */
 class FlowToken
 {
 
+    /**
+     * Original request snapshot.
+     *
+     * @var array
+     */
     private array $requestOriginal;
 
+    /**
+     * Amended request snapshot.
+     *
+     * @var array
+     */
     private array $requestAmended;
 
+    /**
+     * Original response snapshot.
+     *
+     * @var array
+     */
     private array $responseOriginal;
 
+    /**
+     * Amended response snapshot.
+     *
+     * @var array
+     */
     private array $responseAmended;
 
+    /**
+     * Original sync input snapshot.
+     *
+     * @var array
+     */
     private array $syncInputOriginal;
 
+    /**
+     * Amended sync input snapshot.
+     *
+     * @var array
+     */
     private array $syncInputAmended;
 
+    /**
+     * Original sync output snapshot.
+     *
+     * @var array
+     */
     private array $syncOutputOriginal;
 
+    /**
+     * Amended sync output snapshot.
+     *
+     * @var array
+     */
     private array $syncOutputAmended;
 
+    /**
+     * Constructor.
+     *
+     * @param $requestOriginal    Original inbound request or pre-built array payload.
+     * @param $responseOriginal   Original outbound response or pre-built array payload.
+     * @param array       $syncInputOriginal  Original sync input snapshot.
+     * @param array       $syncOutputOriginal Original sync output snapshot.
+     * @param string|null $path               Request path used when serialising a Request.
+     */
     public function __construct(
         Request|array $requestOriginal=[],
         Response|array $responseOriginal=[],
@@ -35,18 +103,27 @@ class FlowToken
         ?string $path=null
     ) {
         $this->setRequestOriginal(requestOriginal: $requestOriginal, path: $path);
-        $this->setRequestAmended($this->getRequestOriginal());
+        $this->setRequestAmended(requestAmended: $this->getRequestOriginal());
 
-        $this->setResponseOriginal($responseOriginal);
-        $this->setResponseAmended($this->getResponseOriginal());
+        $this->setResponseOriginal(responseOriginal: $responseOriginal);
+        $this->setResponseAmended(responseAmended: $this->getResponseOriginal());
 
-        $this->setSyncInputOriginal($syncInputOriginal);
-        $this->setSyncInputAmended($this->getSyncInputOriginal());
+        $this->setSyncInputOriginal(syncInputOriginal: $syncInputOriginal);
+        $this->setSyncInputAmended(syncInputAmended: $this->getSyncInputOriginal());
 
-        $this->setSyncOutputOriginal($syncOutputOriginal);
-        $this->setSyncOutputAmended($this->getSyncOutputOriginal());
+        $this->setSyncOutputOriginal(syncOutputOriginal: $syncOutputOriginal);
+        $this->setSyncOutputAmended(syncOutputAmended: $this->getSyncOutputOriginal());
+
     }//end __construct()
 
+    /**
+     * Filter $_SERVER for HTTP_* headers, optionally including proxy headers.
+     *
+     * @param array   $server       Server array (typically $request->server).
+     * @param boolean $proxyHeaders Whether to include X-Forwarded-* / X-Real-IP / X-Original-URI.
+     *
+     * @return array Map of lowercase header name to value.
+     */
     private function getHeaders(array $server, bool $proxyHeaders=false): array
     {
         $headers = array_filter(
@@ -77,44 +154,48 @@ class FlowToken
                     ),
             $headers
         );
+
     }//end getHeaders()
 
     /**
      * Gets the raw content for a http request from the input stream.
      *
-     * @return string The raw content body for a http request
+     * @return string The raw content body for a http request.
      */
     private function getRawContent(): string
     {
         return file_get_contents(filename: 'php://input');
+
     }//end getRawContent()
 
     /**
-     * Check if content appears to be XML
+     * Check if content appears to be XML.
      *
-     * @param  string $content Content to check
-     * @return bool True if content is valid XML
+     * @param string $content Content to check.
+     *
+     * @return boolean True if content is valid XML.
      */
     private function looksLikeXml(string $content): bool
     {
-        // Suppress XML errors
+        // Suppress XML errors.
         libxml_use_internal_errors(true);
 
-        // Attempt to parse the content as XML
-        $result = simplexml_load_string($content) !== false;
+        // Attempt to parse the content as XML.
+        $result = (simplexml_load_string($content) !== false);
 
-        // Clear any XML errors
+        // Clear any XML errors.
         libxml_clear_errors();
 
         return $result;
+
     }//end looksLikeXml()
 
     /**
-     * Parse raw content into structured data based on content type
+     * Parse raw content into structured data based on content type.
      *
-     * @param  string      $content     The raw content to parse
-     * @param  string|null $contentType Optional content type hint
-     * @return mixed Parsed data (array for JSON/XML) or original string
+     * @param $request The inbound request used to determine content type and fallback parameters.
+     *
+     * @return mixed Parsed data (array for JSON/XML) or original string.
      */
     private function parseContent(Request $request): mixed
     {
@@ -126,7 +207,6 @@ class FlowToken
             $parsedFiles = array_map(
                     function ($file) {
                         return file_get_contents($file['tmp_name']);
-
                     },
                     $files
                     );
@@ -136,15 +216,15 @@ class FlowToken
 
         $content = $this->getRawContent();
 
-        // Try JSON decode first
+        // Try JSON decode first.
         $json = json_decode($content, true);
         if ($json !== null) {
             return $json;
         }
 
-        // Try XML decode if content type suggests XML or content looks like XML
+        // Try XML decode if content type suggests XML or content looks like XML.
         if ($contentType === 'application/xml' || $contentType === 'text/xml'
-            || ($contentType === null && $this->looksLikeXml($content) === true)
+            || ($contentType === null && $this->looksLikeXml(content: $content) === true)
         ) {
             libxml_use_internal_errors(true);
             $xml = simplexml_load_string($content);
@@ -155,18 +235,27 @@ class FlowToken
             }
         }
 
-        // Return original content as fallback
+        // Return original content as fallback.
         return $request->getParams();
+
     }//end parseContent()
 
+    /**
+     * Set the original request, normalising Request objects into an array shape.
+     *
+     * @param $requestOriginal The original request payload.
+     * @param string|null $path            Path used when serialising a Request.
+     *
+     * @return array The stored array shape.
+     */
     public function setRequestOriginal(array|Request $requestOriginal, ?string $path=null): array
     {
         if ($requestOriginal instanceof Request) {
             $request         = $requestOriginal;
             $requestOriginal = [
                 'method'     => $request->getMethod(),
-                'headers'    => $this->getHeaders($request->server, true),
-                'parameters' => array_merge($request->getParams(), $this->parseContent($request)),
+                'headers'    => $this->getHeaders(server: $request->server, proxyHeaders: true),
+                'parameters' => array_merge($request->getParams(), $this->parseContent(request: $request)),
                 'path'       => $path,
             ];
         }
@@ -174,30 +263,64 @@ class FlowToken
         $this->requestOriginal = $requestOriginal;
 
         return $this->requestOriginal;
+
     }//end setRequestOriginal()
 
+    /**
+     * Get the original request snapshot.
+     *
+     * @return array
+     */
     public function getRequestOriginal(): array
     {
         return $this->requestOriginal;
+
     }//end getRequestOriginal()
 
+    /**
+     * Set the amended request snapshot.
+     *
+     * @param array $requestAmended Amended request snapshot.
+     *
+     * @return array
+     */
     public function setRequestAmended(array $requestAmended): array
     {
         $this->requestAmended = $requestAmended;
 
         return $this->requestAmended;
+
     }//end setRequestAmended()
 
+    /**
+     * Get the amended request snapshot.
+     *
+     * @return array
+     */
     public function getRequestAmended(): array
     {
         return $this->requestAmended;
+
     }//end getRequestAmended()
 
+    /**
+     * Set the original response, normalising Response objects into an array shape.
+     *
+     * @param array|Response $responseOriginal Original response or pre-built array payload.
+     *
+     * @return array The stored array shape.
+     */
     public function setResponseOriginal(array|Response $responseOriginal): array
     {
         if ($responseOriginal instanceof Response) {
+            if (method_exists($responseOriginal, 'getData') === true) {
+                $data = $responseOriginal->getData();
+            } else {
+                $data = [];
+            }
+
             $responseOriginal = [
-                'data'    => method_exists($responseOriginal, 'getData') ? $responseOriginal->getData() : [],
+                'data'    => $data,
                 'headers' => $responseOriginal->getHeaders(),
                 'status'  => $responseOriginal->getStatus(),
                 'cookies' => $responseOriginal->getCookies(),
@@ -207,67 +330,152 @@ class FlowToken
         $this->responseOriginal = $responseOriginal;
 
         return $responseOriginal;
+
     }//end setResponseOriginal()
 
+    /**
+     * Get the original response snapshot.
+     *
+     * @return array
+     */
     public function getResponseOriginal(): array
     {
         return $this->responseOriginal;
+
     }//end getResponseOriginal()
 
+    /**
+     * Set the amended response snapshot.
+     *
+     * @param array $responseAmended Amended response snapshot.
+     *
+     * @return array
+     */
     public function setResponseAmended(array $responseAmended): array
     {
         $this->responseAmended = $responseAmended;
 
         return $this->responseAmended;
+
     }//end setResponseAmended()
 
+    /**
+     * Get the amended response snapshot.
+     *
+     * @return array
+     */
     public function getResponseAmended(): array
     {
         return $this->responseAmended;
+
     }//end getResponseAmended()
 
+    /**
+     * Set the original sync input snapshot.
+     *
+     * @param array $syncInputOriginal Original sync input snapshot.
+     *
+     * @return array
+     */
     public function setSyncInputOriginal(array $syncInputOriginal): array
     {
         $this->syncInputOriginal = $syncInputOriginal;
 
         return $this->syncInputOriginal;
+
     }//end setSyncInputOriginal()
 
+    /**
+     * Get the original sync input snapshot.
+     *
+     * @return array
+     */
     public function getSyncInputOriginal(): array
     {
         return $this->syncInputOriginal;
+
     }//end getSyncInputOriginal()
 
+    /**
+     * Set the amended sync input snapshot.
+     *
+     * @param array $syncInputAmended Amended sync input snapshot.
+     *
+     * @return array
+     */
     public function setSyncInputAmended(array $syncInputAmended): array
     {
-        return $this->syncInputAmended = $syncInputAmended;
+        $this->syncInputAmended = $syncInputAmended;
+        return $this->syncInputAmended;
+
     }//end setSyncInputAmended()
 
+    /**
+     * Get the amended sync input snapshot.
+     *
+     * @return array
+     */
     public function getSyncInputAmended(): array
     {
         return $this->syncInputAmended;
+
     }//end getSyncInputAmended()
 
+    /**
+     * Set the original sync output snapshot.
+     *
+     * @param array $syncOutputOriginal Original sync output snapshot.
+     *
+     * @return array
+     */
     public function setSyncOutputOriginal(array $syncOutputOriginal): array
     {
-        return $this->syncOutputOriginal = $syncOutputOriginal;
+        $this->syncOutputOriginal = $syncOutputOriginal;
+        return $this->syncOutputOriginal;
+
     }//end setSyncOutputOriginal()
 
+    /**
+     * Get the original sync output snapshot.
+     *
+     * @return array
+     */
     public function getSyncOutputOriginal(): array
     {
         return $this->syncOutputOriginal;
+
     }//end getSyncOutputOriginal()
 
+    /**
+     * Set the amended sync output snapshot.
+     *
+     * @param array $syncOutputAmended Amended sync output snapshot.
+     *
+     * @return array
+     */
     public function setSyncOutputAmended(array $syncOutputAmended): array
     {
-        return $this->syncOutputAmended = $syncOutputAmended;
+        $this->syncOutputAmended = $syncOutputAmended;
+        return $this->syncOutputAmended;
+
     }//end setSyncOutputAmended()
 
+    /**
+     * Get the amended sync output snapshot.
+     *
+     * @return array
+     */
     public function getSyncOutputAmended(): array
     {
         return $this->syncOutputAmended;
+
     }//end getSyncOutputAmended()
 
+    /**
+     * Serialise the FlowToken into an array suitable for json encoding.
+     *
+     * @return array
+     */
     public function __serialize(): array
     {
         return [
@@ -280,5 +488,6 @@ class FlowToken
             'syncOutputOriginal' => $this->syncOutputOriginal,
             'syncOutputAmended'  => $this->syncOutputAmended,
         ];
+
     }//end __serialize()
 }//end class

--- a/lib/Service/JobService.php
+++ b/lib/Service/JobService.php
@@ -1,17 +1,21 @@
 <?php
 
 /**
- * JobService
+ * OpenConnector JobService.
  *
  * Service class for handling job execution logic in the OpenConnector application.
  * This service manages job retrieval, validation, execution, and logging.
  *
  * @category Service
  * @package  OCA\OpenConnector\Service
- * @author   OpenConnector Development Team
- * @license  AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/openconnector
- * @version  1.0.0
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
  */
 
 namespace OCA\OpenConnector\Service;
@@ -53,24 +57,37 @@ use OCP\BackgroundJob\IJob;
 class JobService
 {
 
-    private int $errorRetention;
-
-    private int $successRetention;
     private const DEFAULT_SUCCESS_LOG_RETENTION = 3600000;
-    private const DEFAULT_ERROR_LOG_RETENTION   = 2592000000;
+
+    private const DEFAULT_ERROR_LOG_RETENTION = 2592000000;
 
     /**
-     * JobService constructor
+     * Retention (ms) applied to error JobLogs.
+     *
+     * @var integer
+     */
+    private int $errorRetention;
+
+    /**
+     * Retention (ms) applied to successful JobLogs.
+     *
+     * @var integer
+     */
+    private int $successRetention;
+
+    /**
+     * JobService constructor.
      *
      * Initializes the job service with required dependencies for job execution
      * and management operations.
      *
-     * @param IJobList           $jobList            The job list manager for background jobs
-     * @param ORObjectService    $objectService      The OR ObjectService for data access
-     * @param IDBConnection      $connection         Database connection for direct queries
-     * @param ContainerInterface $containerInterface Container for dependency injection
-     * @param IUserSession       $userSession        User session manager
-     * @param IUserManager       $userManager        User manager for user operations
+     * @param IJobList           $jobList            The job list manager for background jobs.
+     * @param ORObjectService    $objectService      The OR ObjectService for data access.
+     * @param IDBConnection      $connection         Database connection for direct queries.
+     * @param ContainerInterface $containerInterface Container for dependency injection.
+     * @param IUserSession       $userSession        User session manager.
+     * @param IUserManager       $userManager        User manager for user operations.
+     * @param IAppConfig         $appConfig          App config used to read global retention overrides.
      *
      * @psalm-param IJobList $jobList
      * @psalm-param ORObjectService $objectService
@@ -91,18 +108,27 @@ class JobService
         $this->errorRetention   = self::DEFAULT_ERROR_LOG_RETENTION;
         $this->successRetention = self::DEFAULT_SUCCESS_LOG_RETENTION;
         if ($appConfig->hasKey(app: 'openconnector', key: 'retention') === true) {
-            $this->errorRetention   = json_decode($appConfig->getValueString(app: 'openconnector', key: 'retention'), true)['jobLogRetention'] ?? self::DEFAULT_ERROR_LOG_RETENTION;
-            $this->successRetention = json_decode($appConfig->getValueString(app: 'openconnector', key: 'retention'), true)['successLogRetention'] ?? self::DEFAULT_SUCCESS_LOG_RETENTION;
+            $retentionPayload       = json_decode(
+                $appConfig->getValueString(app: 'openconnector', key: 'retention'),
+                true
+            );
+            $this->errorRetention   = ($retentionPayload['jobLogRetention'] ?? self::DEFAULT_ERROR_LOG_RETENTION);
+            $this->successRetention = ($retentionPayload['successLogRetention'] ?? self::DEFAULT_SUCCESS_LOG_RETENTION);
         }
 
     }//end __construct()
 
     /**
-     * Calculates the used retention for created logs. Consists of the maximum of the retention from the source, and the global retention, unless either of both is 0, in which case retention is indefinite.
+     * Calculates the used retention for created logs.
      *
-     * @param  int[] $retentions The list of retentions in milliseconds to find the maximum duration for.
-     * @return \DateTime|null The calculated expiry
-     * @throws \DateMalformedStringException
+     * Consists of the maximum of the retention from the source and the global
+     * retention, unless either is 0 (indefinite retention).
+     *
+     * @param integer ...$retentions The list of retentions in milliseconds to find the maximum duration for.
+     *
+     * @return \DateTime|null The calculated expiry.
+     *
+     * @throws \DateMalformedStringException On invalid datetime composition.
      *
      * @TODO: At a later point in time this should be changed to using the most specific source for expiration
      */
@@ -113,6 +139,7 @@ class JobService
         }
 
         return new \DateTime('now +'.max($retentions).'milliseconds');
+
     }//end calculateExpires()
 
     /**
@@ -137,16 +164,17 @@ class JobService
      */
     private function truncateMessage(string $message, int $maxLength=10000): string
     {
-        // If message is within limits, return as-is
+        // If message is within limits, return as-is.
         if (strlen($message) <= $maxLength) {
             return $message;
         }
 
-        // Truncate and add indicator
-        $truncated  = substr($message, 0, $maxLength - 50);
+        // Truncate and add indicator.
+        $truncated  = substr($message, 0, ($maxLength - 50));
         $truncated .= '... [Message truncated - original length: '.strlen($message).' characters]';
 
         return $truncated;
+
     }//end truncateMessage()
 
     /**
@@ -168,9 +196,9 @@ class JobService
     {
         $jobData = $job->getObject();
 
-        // Let's first check if the job should be disabled
-        if (($jobData['isEnabled'] ?? true) === false || ($jobData['jobListId'] ?? null)) {
-            // @todo fix this (call to protected method)
+        // Let's first check if the job should be disabled.
+        if (($jobData['isEnabled'] ?? true) === false || ($jobData['jobListId'] ?? null) !== null) {
+            // @todo fix this (call to protected method).
             // $this->jobList->removeById($jobData['jobListId']);
             $jobData['jobListId'] = null;
             return $this->objectService->saveObject(
@@ -181,17 +209,17 @@ class JobService
             );
         }
 
-        // Let's not update the job if it's already scheduled @todo we should
-        if ($jobData['jobListId'] ?? null) {
+        // Let's not update the job if it's already scheduled @todo we should.
+        if (isset($jobData['jobListId']) === true && $jobData['jobListId'] !== null) {
             return $job;
         }
 
-        // Oke this is a new job let's schedule it
-        $arguments          = $jobData['arguments'] ?? [];
+        // Oke this is a new job let's schedule it.
+        $arguments          = ($jobData['arguments'] ?? []);
         $arguments['jobId'] = $job->getUuid();
 
-        // Schedule the job using the new JobTask class
-        $scheduleAfter = $jobData['scheduleAfter'] ?? null;
+        // Schedule the job using the new JobTask class.
+        $scheduleAfter = ($jobData['scheduleAfter'] ?? null);
         if ($scheduleAfter !== null) {
             $runAfter = (new DateTime($scheduleAfter))->getTimestamp();
             $this->jobList->scheduleAfter(\OCA\OpenConnector\Cron\JobTask::class, $runAfter, $arguments);
@@ -201,29 +229,30 @@ class JobService
             $this->jobList->add(\OCA\OpenConnector\Cron\JobTask::class, $arguments);
         }
 
-        // Set the job list id
-        $jobData['jobListId'] = $this->getJobListId(\OCA\OpenConnector\Cron\JobTask::class);
-        // Save the job to the database
+        // Set the job list id.
+        $jobData['jobListId'] = $this->getJobListId(job: \OCA\OpenConnector\Cron\JobTask::class);
+        // Save the job to the database.
         return $this->objectService->saveObject(
             object: $jobData,
             register: 'openconnector',
             schema: 'job',
             uuid: $job->getUuid()
         );
+
     }//end scheduleJob()
 
     /**
-     * Get the job list ID of the last job in the list
+     * Get the job list ID of the last job in the list.
      *
      * This function retrieves the database ID of the most recently added job
      * of a specific class from the background job list. This is needed because
      * the Nextcloud job list doesn't provide a better way to get the last job ID.
      *
+     * @param class-string<IJob>|IJob $job The job class or instance to find the ID for.
+     *
+     * @return integer|null The job list ID if found, null otherwise.
+     *
      * @see https://github.com/nextcloud/server/blob/master/lib/private/BackgroundJob/JobList.php#L134
-     *
-     * @param class-string<IJob>|IJob $job The job class or instance to find the ID for
-     *
-     * @return int|null The job list ID if found, null otherwise
      *
      * @psalm-param    class-string<IJob>|IJob $job
      * @psalm-return   int|null
@@ -232,10 +261,14 @@ class JobService
      */
     public function getJobListId(IJob|string $job): int|null
     {
-        // Extract the class name from either string or object
-        $class = ($job instanceof IJob) ? get_class($job) : $job;
+        // Extract the class name from either string or object.
+        if ($job instanceof IJob) {
+            $class = get_class($job);
+        } else {
+            $class = $job;
+        }
 
-        // Build query to find the most recent job of this class
+        // Build query to find the most recent job of this class.
         $query = $this->connection->getQueryBuilder();
         $query->select('id')
             ->from('jobs')
@@ -243,12 +276,13 @@ class JobService
             ->orderBy('id', 'DESC')
             ->setMaxResults(1);
 
-        // Execute query and fetch result
+        // Execute query and fetch result.
         $result = $query->executeQuery();
         $row    = $result->fetch();
         $result->closeCursor();
 
-        return $row['id'] ?? null;
+        return ($row['id'] ?? null);
+
     }//end getJobListId()
 
     /**
@@ -279,13 +313,13 @@ class JobService
     {
         $jobData = $job->getObject();
 
-        // Initialize stack trace for logging
+        // Initialize stack trace for logging.
         $stackTrace = [];
         if ($forceRun === true) {
             $stackTrace[] = 'Doing a force run for this job, ignoring "enabled" & "nextRun" check...';
         }
 
-        // Check if the job is enabled (unless force run is requested)
+        // Check if the job is enabled (unless force run is requested).
         if ($forceRun === false && ($jobData['isEnabled'] ?? true) === false) {
             return $this->saveJobLog(
                 job: $job,
@@ -297,54 +331,54 @@ class JobService
             );
         }
 
-        // Check if the job is scheduled to run (unless force run is requested)
-        $nextRunStr = $jobData['nextRun'] ?? null;
+        // Check if the job is scheduled to run (unless force run is requested).
+        $nextRunStr = ($jobData['nextRun'] ?? null);
         if ($forceRun === false && $nextRunStr !== null) {
             $nextRun = new DateTime($nextRunStr);
             if ($nextRun > new DateTime()) {
-                // Do not log, just skip execution
+                // Do not log, just skip execution.
                 return null;
             }
         }
 
-        // Set user session if job has a specific user configured
-        $userId = $jobData['userId'] ?? null;
+        // Set user session if job has a specific user configured.
+        $userId = ($jobData['userId'] ?? null);
         if (empty($userId) === false && $this->userSession->getUser() === null) {
             $user = $this->userManager->get($userId);
             $this->userSession->setUser($user);
         }
 
-        // Record execution start time for performance tracking
+        // Record execution start time for performance tracking.
         $timeStart = microtime(true);
 
-        // Get the job action class from the container and execute it
+        // Get the job action class from the container and execute it.
         $action    = $this->containerInterface->get($jobData['jobClass']);
-        $arguments = $jobData['arguments'] ?? [];
+        $arguments = ($jobData['arguments'] ?? []);
         if (is_array($arguments) === false) {
             $arguments = [];
         }
 
         $result = $action->run($arguments);
 
-        // Calculate execution time in milliseconds
+        // Calculate execution time in milliseconds.
         $timeEnd       = microtime(true);
-        $executionTime = ($timeEnd - $timeStart) * 1000;
+        $executionTime = (($timeEnd - $timeStart) * 1000);
 
-        // Handle single run jobs by disabling them after execution
-        $isSingleRun = $jobData['isSingleRun'] ?? false;
+        // Handle single run jobs by disabling them after execution.
+        $isSingleRun = ($jobData['isSingleRun'] ?? false);
         if ($forceRun === false && $isSingleRun === true) {
             $jobData['isEnabled'] = false;
         }
 
-        // Update job with last run time and calculate next run time
+        // Update job with last run time and calculate next run time.
         $jobData['lastRun'] = (new DateTime())->format('c');
         if ($forceRun === false) {
             $nextRun = new DateTime('now + '.($jobData['interval'] ?? 0).' seconds');
 
-            // Handle rate limiting if specified in result
+            // Handle rate limiting if specified in result.
             if (isset($result['nextRun']) === true) {
                 $nextRunRateLimit = DateTime::createFromFormat('U', $result['nextRun'], $nextRun->getTimezone());
-                // Check if the current seconds part is not zero, and if so, round up to the next minute
+                // Check if the current seconds part is not zero, and if so, round up to the next minute.
                 if ($nextRunRateLimit->format('s') !== '00') {
                     $nextRunRateLimit->modify('next minute');
                 }
@@ -354,12 +388,12 @@ class JobService
                 }
             }
 
-            // Set time to the current hour and minute (remove seconds)
+            // Set time to the current hour and minute (remove seconds).
             $nextRun->setTime(hour: $nextRun->format('H'), minute: $nextRun->format('i'));
             $jobData['nextRun'] = $nextRun->format('c');
         }
 
-        // Persist job updates to database
+        // Persist job updates to database.
         $this->objectService->saveObject(
             object: $jobData,
             register: 'openconnector',
@@ -370,34 +404,45 @@ class JobService
         $logRetention   = (int) ($jobData['logRetention'] ?? 0);
         $errorRetention = (int) ($jobData['errorRetention'] ?? 0);
 
-        // Build initial job log data with success status
+        // Build initial job log data with success status.
+        $successExpiry = $this->calculateExpires(...[($logRetention * 1000), $this->successRetention]);
+        if ($successExpiry !== null) {
+            $successExpiryFormatted = $successExpiry->format('c');
+        } else {
+            $successExpiryFormatted = null;
+        }
+
         $logData = [
             'level'         => 'SUCCESS',
             'message'       => 'Success',
             'executionTime' => $executionTime,
-            'expires'       => $this->calculateExpires($logRetention * 1000, $this->successRetention) !== null ? $this->calculateExpires($logRetention * 1000, $this->successRetention)->format('c') : null,
+            'expires'       => $successExpiryFormatted,
         ];
 
-        // Process job execution result and update log accordingly
+        // Process job execution result and update log accordingly.
         if (is_array($result) === true) {
             if (isset($result['level']) === true) {
                 $logData['level'] = $result['level'];
 
                 if ($result['level'] !== 'SUCCESS') {
-                    $expiresDate        = $this->calculateExpires($errorRetention * 1000, $this->errorRetention);
-                    $logData['expires'] = $expiresDate !== null ? $expiresDate->format('c') : null;
+                    $expiresDate = $this->calculateExpires(...[($errorRetention * 1000), $this->errorRetention]);
+                    if ($expiresDate !== null) {
+                        $logData['expires'] = $expiresDate->format('c');
+                    } else {
+                        $logData['expires'] = null;
+                    }
                 }
             }
 
             if (isset($result['message']) === true) {
-                // Truncate message if it's too long for database safety
-                $logData['message'] = $this->truncateMessage($result['message']);
+                // Truncate message if it's too long for database safety.
+                $logData['message'] = $this->truncateMessage(message: $result['message']);
             }
 
             if (isset($result['stackTrace']) === true) {
                 $stackTrace = array_merge($stackTrace, $result['stackTrace']);
             }
-        }
+        }//end if
 
         $logData['stackTrace'] = $stackTrace;
 
@@ -429,7 +474,7 @@ class JobService
             $logData
         );
 
-        // Default expiry per level if not already set
+        // Default expiry per level if not already set.
         if (isset($logObject['expires']) === false) {
             switch ($logObject['level'] ?? '') {
                 case 'INFO':
@@ -452,15 +497,16 @@ class JobService
     }//end saveJobLog()
 
     /**
-     * Run all jobs that are scheduled to run (nextRun <= now)
+     * Run all jobs that are scheduled to run (nextRun <= now).
      *
-     * @return         ObjectEntity[] Array of job log results
+     * @return ObjectEntity[] Array of job log results.
+     *
      * @psalm-return   array<ObjectEntity>
      * @phpstan-return ObjectEntity[]
      */
     public function run(): array
     {
-        // Fetch all jobs that are enabled and whose nextRun is in the past or null
+        // Fetch all jobs that are enabled and whose nextRun is in the past or null.
         $now     = (new DateTime())->format('c');
         $matches = $this->objectService->findAll(
                 config: [
@@ -471,24 +517,25 @@ class JobService
                     ],
                 ]
                 );
-        $jobs    = $matches['results'] ?? $matches;
+        $jobs    = ($matches['results'] ?? $matches);
         $results = [];
 
         foreach ($jobs as $job) {
             $jobData = $job->getObject();
-            $nextRun = $jobData['nextRun'] ?? null;
+            $nextRun = ($jobData['nextRun'] ?? null);
 
-            // Skip jobs that are not yet due
+            // Skip jobs that are not yet due.
             if ($nextRun !== null && (new DateTime($nextRun)) > new DateTime()) {
                 continue;
             }
 
-            $log = $this->executeJob($job);
+            $log = $this->executeJob(job: $job);
             if ($log !== null) {
                 $results[] = $log;
             }
         }
 
         return $results;
+
     }//end run()
 }//end class

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * OpenConnector MappingService.
+ *
+ * Mapping service that delegates core execution to OpenRegister's MappingService
+ * when available, falling back to its own implementation.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Service;
 
@@ -73,7 +90,14 @@ class MappingService
     ) {
         $this->twig = new Environment($loader);
         $this->twig->addExtension(new MappingExtension());
-        $this->twig->addRuntimeLoader(new MappingRuntimeLoader(mappingService: $this, callService: $callService, fileService: $fileService, objectService: $objectService));
+        $this->twig->addRuntimeLoader(
+            new MappingRuntimeLoader(
+                mappingService: $this,
+                callService: $callService,
+                fileService: $fileService,
+                objectService: $objectService
+            )
+        );
 
         // Try to load OpenRegister's MappingService for delegation.
         try {
@@ -106,7 +130,7 @@ class MappingService
             $newKey = str_replace($toReplace, $replacement, $key);
 
             if (\is_array($value) === true && $value !== []) {
-                $result[$newKey] = $this->encodeArrayKeys($value, $toReplace, $replacement);
+                $result[$newKey] = $this->encodeArrayKeys(array: $value, toReplace: $toReplace, replacement: $replacement);
                 continue;
             }
 
@@ -166,7 +190,8 @@ class MappingService
             );
         }
 
-        return $this->executeMappingLocal($mapping, $input, $list);
+        return $this->executeMappingLocal(mapping: $mapping, input: $input, list: $list);
+
     }//end executeMapping()
 
     /**
@@ -184,7 +209,7 @@ class MappingService
      */
     private function executeMappingLocal(\OCA\OpenRegister\Db\Mapping $mapping, array $input, bool $list=false): array
     {
-        // Check for list
+        // Check for list.
         if ($list === true) {
             $list        = [];
             $extraValues = [];
@@ -199,22 +224,22 @@ class MappingService
             foreach ($input as $key => $value) {
                 // Mapping function expects an array for $input, make sure we always pass an array to this function.
                 if (is_array($value) === false || empty($extraValues) === false) {
-                    // todo: we want to remove ['value' => $value] from this at some point, for now required for DOWR to work
+                    // Todo: we want to remove ['value' => $value] from this at some point, for now required for DOWR to work.
                     $value = array_merge((array) $value, ['value' => $value], $extraValues);
                 }
 
-                $list[$key] = $this->executeMapping($mapping, $value);
+                $list[$key] = $this->executeMapping(mapping: $mapping, input: $value);
             }
 
             return $list;
         }//end if
 
         $originalInput = $input;
-        $input         = $this->encodeArrayKeys($input, '.', '&#46;');
+        $input         = $this->encodeArrayKeys(array: $input, toReplace: '.', replacement: '&#46;');
 
         // Determine pass through.
         // Let's get the dot array based on https://github.com/adbario/php-dot-notation.
-        if ($mapping->getPassThrough()) {
+        if ($mapping->getPassThrough() === true) {
             $dotArray = new Dot($input);
         } else {
             $dotArray = new Dot();
@@ -225,7 +250,7 @@ class MappingService
         // Let's do the actual mapping.
         foreach ($mapping->getMapping() as $key => $value) {
             // If the value exists in the input dot take it from there.
-            if ($dotInput->has($value)) {
+            if ($dotInput->has($value) === true) {
                 $dotArray->set($key, $dotInput->get($value));
                 continue;
             }
@@ -237,7 +262,7 @@ class MappingService
             }
 
             try {
-                $dotArray->set($key, $this->renderTemplateString($value, $originalInput));
+                $dotArray->set($key, $this->renderTemplateString(template: $value, context: $originalInput));
             } catch (Throwable $e) {
                 throw new Exception("Error for mapping: {$mapping->getName()}, key: $key, value: $value and with message thrown: {$e->getMessage()}");
             }
@@ -270,29 +295,38 @@ class MappingService
             }
 
             foreach ($cast as $singleCast) {
-                $this->handleCast($dotArray, $key, $singleCast);
+                $this->handleCast(dotArray: $dotArray, key: $key, cast: $singleCast);
             }
         }
 
         // Back to array.
         $output = $dotArray->all();
 
-        $output = $this->encodeArrayKeys($output, '&#46;', '.');
+        $output = $this->encodeArrayKeys(array: $output, toReplace: '&#46;', replacement: '.');
 
         // If something has been defined to work on root level (i.e. the object lives on root level), we can use # to define writing the root object.
         $keys = array_keys($output);
         if (count($keys) === 1 && $keys[0] === '#') {
-            // Ensure we always return an array, even if the value is null
+            // Ensure we always return an array, even if the value is null.
             $rootValue = $output['#'];
-            $output    = is_array($rootValue) ? $rootValue : [$rootValue];
+            if (is_array($rootValue) === true) {
+                $output = $rootValue;
+            } else {
+                $output = [$rootValue];
+            }
+
             if ($rootValue === null) {
                 $output = [];
             }
         }
 
-        // Ensure output is always an array
+        // Ensure output is always an array.
         if (is_array($output) === false) {
-            $output = $output === null ? [] : [$output];
+            if ($output === null) {
+                $output = [];
+            } else {
+                $output = [$output];
+            }
         }
 
         return $output;
@@ -404,7 +438,7 @@ class MappingService
                 $value = json_decode($value, true);
                 break;
             case 'utf8':
-                // https://www.php.net/manual/en/function.iconv.php
+                // See https://www.php.net/manual/en/function.iconv.php.
                 setlocale(LC_CTYPE, 'cs_CZ');
                 $value = iconv('UTF-8', 'ASCII//TRANSLIT', $value);
                 break;
@@ -414,36 +448,36 @@ class MappingService
                 }
                 break;
             case 'coordinateStringToArray':
-                $value = $this->coordinateStringToArray($value);
+                $value = $this->coordinateStringToArray(coordinates: $value);
                 break;
             case 'keyCantBeValue':
-                if ($key == $value) {
+                if ($key === $value) {
                     $dotArray->delete($key);
                 }
                 break;
             case 'unsetIfValue':
                 if (isset($unsetIfValue) === true
-                    && $value == $unsetIfValue
-                    || ($unsetIfValue === '' && empty($value))
+                    && $value === $unsetIfValue
+                    || ($unsetIfValue === '' && empty($value) === true)
                     || ($unsetIfValue === '' && $value === null)
                 ) {
                     $dotArray->delete($key);
                 }
 
-                if ($unsetIfValue === '' && is_array($value) === true && $this->areAllArrayKeysNull($value) === true) {
+                if ($unsetIfValue === '' && is_array($value) === true && $this->areAllArrayKeysNull(array: $value) === true) {
                     $dotArray->delete($key);
                 }
                 break;
             case 'setNullIfValue':
                 if (isset($setNullIfValue) === true
-                    && $value == $setNullIfValue
-                    || ($setNullIfValue === '' && empty($value))
+                    && $value === $setNullIfValue
+                    || ($setNullIfValue === '' && empty($value) === true)
                     || ($setNullIfValue === '' && $value === null)
                 ) {
                     $value = null;
                 }
 
-                if ($setNullIfValue === '' && is_array($value) === true && $this->areAllArrayKeysNull($value) === true) {
+                if ($setNullIfValue === '' && is_array($value) === true && $this->areAllArrayKeysNull(array: $value) === true) {
                     $value = null;
                 }
                 break;
@@ -469,7 +503,7 @@ class MappingService
         }//end switch
 
         // Don't reset key that was deleted on purpose.
-        if ($dotArray->has($key)) {
+        if ($dotArray->has($key) === true) {
             $dotArray->set($key, $value);
         }
 
@@ -490,7 +524,7 @@ class MappingService
 
         foreach ($array as $value) {
             if (is_array($value) === true) {
-                if ($this->areAllArrayKeysNull($value) === false) {
+                if ($this->areAllArrayKeysNull(array: $value) === false) {
                     return false;
                 }
 
@@ -545,12 +579,14 @@ class MappingService
      * mappings through this service layer, rather than accessing the storage directly.
      * This maintains proper encapsulation and separation of concerns.
      *
-     * @param  string $mappingId The unique identifier of the mapping to retrieve
-     * @return ObjectEntity The requested mapping entity
+     * @param string $mappingId The unique identifier of the mapping to retrieve.
+     *
+     * @return ObjectEntity The requested mapping entity.
      */
     public function getMapping(string $mappingId): ObjectEntity
     {
         return $this->orObjectService->find(id: $mappingId, register: 'openconnector', schema: 'mapping');
+
     }//end getMapping()
 
     /**
@@ -566,6 +602,7 @@ class MappingService
     public function getMappings(): array
     {
         $result = $this->orObjectService->findAll(config: ['filters' => ['register' => 'openconnector', 'schema' => 'mapping']]);
-        return $result['results'] ?? $result;
+        return ($result['results'] ?? $result);
+
     }//end getMappings()
 }//end class

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * OpenConnector SearchService.
+ *
+ * Federated/aggregated search helper for catalog data, with Elasticsearch and
+ * MongoDB-style filter helpers plus MySQL adapters for sort/limit/filter.
+ *
+ * @category Service
+ * @package  OCA\OpenConnector\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
 
 namespace OCA\OpenConnector\Service;
 
@@ -8,6 +25,8 @@ use OCP\IURLGenerator;
 use Symfony\Component\Uid\Uuid;
 
 /**
+ * Helper service for catalog search, facets and query parameter handling.
+ *
  * @SuppressWarnings(PHPMD.ShortVariable)
  * @SuppressWarnings(PHPMD.LongVariable)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -22,19 +41,38 @@ use Symfony\Component\Uid\Uuid;
 class SearchService
 {
 
-    public $client;
-
     public const BASE_OBJECT = [
         'database'   => 'objects',
         'collection' => 'json',
     ];
 
+    /**
+     * Guzzle HTTP client used to fan-out remote search requests.
+     *
+     * @var Client
+     */
+    public $client;
+
+    /**
+     * Constructor.
+     *
+     * @param IURLGenerator $urlGenerator URL generator used to resolve directory routes.
+     */
     public function __construct(
         private readonly IURLGenerator $urlGenerator,
     ) {
         $this->client = new Client();
+
     }//end __construct()
 
+    /**
+     * Merge two facet aggregations by _id, summing the count.
+     *
+     * @param array $existingAggregation Already-collected aggregation entries.
+     * @param array $newAggregation      New aggregation entries to merge.
+     *
+     * @return array
+     */
     public function mergeFacets(array $existingAggregation, array $newAggregation): array
     {
         $results = [];
@@ -48,17 +86,30 @@ class SearchService
         foreach ($newAggregation as $value) {
             $newAggregationMapped[$value['_id']] = $value['count'];
             if (isset($existingAggregationMapped[$value['_id']]) === true) {
-                $newAggregationMapped[$value['_id']] = $existingAggregationMapped[$value['_id']] + $value['count'];
+                $newAggregationMapped[$value['_id']] = ($existingAggregationMapped[$value['_id']] + $value['count']);
             }
         }
 
-        foreach (array_merge(array_diff($existingAggregationMapped, $newAggregationMapped), array_diff($newAggregationMapped, $existingAggregationMapped)) as $key => $value) {
+        $merged = array_merge(
+            array_diff($existingAggregationMapped, $newAggregationMapped),
+            array_diff($newAggregationMapped, $existingAggregationMapped)
+        );
+        foreach ($merged as $key => $value) {
             $results[] = ['_id' => $key, 'count' => $value];
         }
 
         return $results;
+
     }//end mergeFacets()
 
+    /**
+     * Merge two aggregation sets keyed by facet name.
+     *
+     * @param array|null $existingAggregations Already-collected aggregations.
+     * @param array|null $newAggregations      New aggregations to merge.
+     *
+     * @return array
+     */
     private function mergeAggregations(?array $existingAggregations, ?array $newAggregations): array
     {
         if ($newAggregations === null) {
@@ -71,19 +122,36 @@ class SearchService
                 continue;
             }
 
-            $existingAggregations[$key] = $this->mergeFacets($existingAggregations[$key], $aggregation);
+            $existingAggregations[$key] = $this->mergeFacets(existingAggregation: $existingAggregations[$key], newAggregation: $aggregation);
         }
 
         return $existingAggregations;
+
     }//end mergeAggregations()
 
+    /**
+     * Comparator (usort) that orders search results by descending `_score`.
+     *
+     * @param array $a Left side.
+     * @param array $b Right side.
+     *
+     * @return integer
+     */
     public function sortResultArray(array $a, array $b): int
     {
-        return $a['_score'] <=> $b['_score'];
+        return ($a['_score'] <=> $b['_score']);
+
     }//end sortResultArray()
 
     /**
+     * Run the federated search across local and remote endpoints.
      *
+     * @param array $parameters    Request query parameters.
+     * @param array $elasticConfig Elasticsearch configuration block.
+     * @param array $dbConfig      Database configuration block.
+     * @param array $catalogi      Optional catalog filter array.
+     *
+     * @return array
      */
     public function search(array $parameters, array $elasticConfig, array $dbConfig, array $catalogi=[]): array
     {
@@ -92,8 +160,17 @@ class SearchService
         $localResults['facets']  = [];
 
         $totalResults = 0;
-        $limit        = isset($parameters['.limit']) === true ? $parameters['.limit'] : 30;
-        $page         = isset($parameters['.page']) === true ? $parameters['.page'] : 1;
+        if (isset($parameters['.limit']) === true) {
+            $limit = $parameters['.limit'];
+        } else {
+            $limit = 30;
+        }
+
+        if (isset($parameters['.page']) === true) {
+            $page = $parameters['.page'];
+        } else {
+            $page = 1;
+        }
 
         if ($elasticConfig['location'] !== '') {
             $localResults = $this->elasticService->searchObject(filters: $parameters, config: $elasticConfig, totalResults: $totalResults,);
@@ -101,16 +178,20 @@ class SearchService
 
         $directory = $this->directoryService->listDirectory(limit: 1000);
 
-        // $directory = $this->objectService->findObjects(filters: ['_schema' => 'directory'], config: $dbConfig);
+        // $directory = $this->objectService->findObjects(filters: ['_schema' => 'directory'], config: $dbConfig);.
         if (count($directory) === 0) {
             $pages = (int) ceil($totalResults / $limit);
+            if ($pages === 0) {
+                $pages = 1;
+            }
+
             return [
                 'results' => $localResults['results'],
                 'facets'  => $localResults['facets'],
                 'count'   => count($localResults['results']),
                 'limit'   => $limit,
                 'page'    => $page,
-                'pages'   => $pages === 0 ? 1 : $pages,
+                'pages'   => $pages,
                 'total'   => $totalResults,
             ];
         }
@@ -122,10 +203,13 @@ class SearchService
 
         $promises = [];
         foreach ($directory as $instance) {
+            $directoryIndexUrl = $this->urlGenerator->getAbsoluteURL(
+                $this->urlGenerator->linkToRoute(routeName: "opencatalogi.directory.index")
+            );
             if ($instance['default'] === false
-                || isset($parameters['.catalogi']) === true
-                && in_array($instance['catalogId'], $parameters['.catalogi']) === false
-                || $instance['search'] = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute(routeName:"opencatalogi.directory.index"))
+                || (isset($parameters['.catalogi']) === true
+                && in_array($instance['catalogId'], $parameters['.catalogi']) === false)
+                || $instance['search'] === $directoryIndexUrl
             ) {
                 continue;
             }
@@ -157,11 +241,14 @@ class SearchService
 
                 usort($results, [$this, 'sortResultArray']);
 
-                $aggregations = $this->mergeAggregations($aggregations, $responseData['facets']);
+                $aggregations = $this->mergeAggregations(existingAggregations: $aggregations, newAggregations: $responseData['facets']);
             }
         }
 
         $pages = (int) ceil($totalResults / $limit);
+        if ($pages === 0) {
+            $pages = 1;
+        }
 
         return [
             'results' => $results,
@@ -169,23 +256,25 @@ class SearchService
             'count'   => count($results),
             'limit'   => $limit,
             'page'    => $page,
-            'pages'   => $pages === 0 ? 1 : $pages,
+            'pages'   => $pages,
             'total'   => $totalResults,
         ];
+
     }//end search()
 
     /**
-     * This function adds a single query param to the given $vars array. ?$name=$value
+     * This function adds a single query param to the given $vars array. ?$name=$value.
+     *
      * Will check if request query $name has [...] inside the parameter, like this: ?queryParam[$nameKey]=$value.
      * Works recursive, so in case we have ?queryParam[$nameKey][$anotherNameKey][etc][etc]=$value.
      * Also checks for queryParams ending on [] like: ?queryParam[$nameKey][] (or just ?queryParam[]), if this is the case
      * this function will add given value to an array of [queryParam][$nameKey][] = $value or [queryParam][] = $value.
      * If none of the above this function will just add [queryParam] = $value to $vars.
      *
-     * @param array  $vars    The vars array we are going to store the query parameter in
-     * @param string $name    The full $name of the query param, like this: ?$name=$value
-     * @param string $nameKey The full $name of the query param, unless it contains [] like: ?queryParam[$nameKey]=$value
-     * @param string $value   The full $value of the query param, like this: ?$name=$value
+     * @param array  $vars    The vars array we are going to store the query parameter in.
+     * @param string $name    The full $name of the query param, like this: ?$name=$value.
+     * @param string $nameKey The full $name of the query param, unless it contains [] like: ?queryParam[$nameKey]=$value.
+     * @param string $value   The full $value of the query param, like this: ?$name=$value.
      *
      * @return void
      */
@@ -283,7 +372,7 @@ class SearchService
     public function unsetSpecialQueryParams(array $filters): array
     {
         foreach ($filters as $key => $value) {
-            if (str_starts_with($key, '_')) {
+            if (str_starts_with($key, '_') === true) {
                 unset($filters[$key]);
             }
         }
@@ -303,7 +392,7 @@ class SearchService
     {
         $searchParams = [];
         if (isset($filters['_search']) === true) {
-            $searchParams['search'] = '%'.strtolower($filters['_search']).'%';
+            $searchParams['search'] = ('%'.strtolower($filters['_search']).'%');
         }
 
         return $searchParams;
@@ -320,9 +409,14 @@ class SearchService
     public function createSortForMySQL(array $filters): array
     {
         $sort = [];
-        if (isset($filters['_order']) && is_array($filters['_order'])) {
+        if (isset($filters['_order']) === true && is_array($filters['_order']) === true) {
             foreach ($filters['_order'] as $field => $direction) {
-                $direction    = strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC';
+                if (strtoupper($direction) === 'DESC') {
+                    $direction = 'DESC';
+                } else {
+                    $direction = 'ASC';
+                }
+
                 $sort[$field] = $direction;
             }
         }
@@ -334,18 +428,22 @@ class SearchService
     /**
      * This function creates an sort array based on given order param from request.
      *
-     * @todo Not functional yet. Needs to be fixed (see PublicationsController->index).
-     *
      * @param array $filters Query parameters from request.
      *
      * @return array $sort
+     *
+     * @todo Not functional yet. Needs to be fixed (see PublicationsController->index).
      */
     public function createSortForMongoDB(array $filters): array
     {
         $sort = [];
-        if (isset($filters['_order']) && is_array($filters['_order'])) {
+        if (isset($filters['_order']) === true && is_array($filters['_order']) === true) {
             foreach ($filters['_order'] as $field => $direction) {
-                $sort[$field] = strtoupper($direction) === 'DESC' ? -1 : 1;
+                if (strtoupper($direction) === 'DESC') {
+                    $sort[$field] = -1;
+                } else {
+                    $sort[$field] = 1;
+                }
             }
         }
 
@@ -389,5 +487,6 @@ class SearchService
         }//end foreach
 
         return $vars;
+
     }//end parseQueryString()
 }//end class


### PR DESCRIPTION
## Summary

Phase 3c PHPCS cleanup, **final** batch 5/5: clear the last 297 errors across 7 services. After this lands, `phpcs lib/` shows **0 errors** across the whole codebase.

| File | Errors before | After |
|---|---:|---:|
| `lib/Service/JobService.php` | 56 | 0 |
| `lib/Service/Helper/FlowToken.php` | 52 | 0 |
| `lib/Service/EventService.php` | 47 | 0 |
| `lib/Service/EndpointCacheService.php` | 46 | 0 |
| `lib/Service/AuthorizationService.php` | 34 | 0 |
| `lib/Service/MappingService.php` | 32 | 0 |
| `lib/Service/SearchService.php` | 30 | 0 |
| **Total** | **297** | **0** |

## Changes (all 7 services)

- Convert non-canonical file/class docblocks to canonical Conduction `@category`/`@package`/`@author`/`@copyright`/`@license`/`@version`/`@link` block; preserve all PHPMD suppressions
- Reorder imports alphabetically and add missing `@var` docblocks on member properties (e.g. all 8 FlowToken `$requestOriginal`/`$responseOriginal`/`$syncInput*`/`$syncOutput*` arrays)
- Add full method docblocks (`@param`/`@return`/`@throws`) to every constructor + every method previously missing them (~50 methods across the 7 files)
- Reorder docblock tags so `@param` / `@return` / `@throws` come before `@NoAdminRequired` / `@NoCSRFRequired` / `@psalm-*` / `@phpstan-*` annotations
- Convert internal call sites to named-parameter form (`mergeFacets(existingAggregation: ..., newAggregation: ...)`, `encodeArrayKeys(array: ..., toReplace: ..., replacement: ...)`, `findByPathRegex(path: ..., method: ..., isRetry: ...)`, `validatePayload(payload: ...)`, `checkHeaders(token: ...)`, etc.)
- Convert variadic forwarding to spread `...[expr1, expr2]` form (`calculateExpires(...[$retention * 1000, $this->errorRetention])`)
- Expand inline-IF (`?:`) expressions to `if/else` blocks (pagination `$pages`/`$currentPage`, `$origin` resolution, `$pages === 0 ? 1`, etc.)
- Convert implicit-truth comparisons (`!isset()`, `!is_string()`, `!is_array()`, `str_starts_with()`, `empty()`) to explicit `=== true` / `=== false`
- Convert `==` / `!=` to strict `===` / `!==`
- Wrap over-long log/exception strings via concatenation or multi-line argument lists
- Add inline-comment punctuation; fix swapped capital-letter / period-terminator violations
- FlowToken: kept the original `array|Request` / `array|Response` native union types intact; @param tags for those parameters use the no-type-annotation form (`@param $name Description`) so the existing PHPStan baseline counts for "invalid type OC\AppFramework\Http\Request" stay at the expected `count: 1` per method

## Test plan

- [x] `phpcs --standard=phpcs.xml lib/`: **0 errors** across all 94 files (was 297 errors across these 7)
- [x] `phpstan analyse` on the 7 touched files: 4 pre-existing errors only (same count as baseline — 3 in JobService array-shape inference + 1 in EndpointCacheService unused-private-method)