### PR TITLE
fix(schemas): rule.conditions accepts object (JsonLogic shape) (closes #909)

### DIFF
--- a/lib/Settings/openconnector_register.json
+++ b/lib/Settings/openconnector_register.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OpenConnector Register",
     "description": "Integration platform register for the OpenConnector Nextcloud app. Manages Sources (outbound integrations), Endpoints (inbound API), Consumers (subscribers), Event/EventMessage/EventSubscription (event bus), Job/Mapping/Rule (workflow engine), Synchronization/SynchronizationContract (sync triad), and the four log schemas (CallLog, JobLog, SynchronizationLog, SynchronizationContractLog).",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "x-openregister": {
     "type": "application",
@@ -319,7 +319,7 @@
         "slug": "rule",
         "title": "Rule",
         "icon": "Filter",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "summary": "A conditional pipeline step applied to an Endpoint or Synchronization",
         "description": "A Rule encodes a conditional action applied at a specific timing point in an Endpoint or Synchronization pipeline. See local ADR-011 for the FlowToken context that rules read/write.",
         "required": ["name", "action"],
@@ -332,7 +332,7 @@
           "version": { "type": "string", "description": "Semver", "default": "1.0.0" },
           "action": { "type": "string", "description": "Action verb (e.g. `error`, `replace`, `appendHeader`)" },
           "timing": { "type": "string", "description": "Pipeline timing slot (pre-request, post-request, pre-response, post-response)" },
-          "conditions": { "type": "array", "items": { "type": "object" }, "description": "Conditional expression list (all-of by default)" },
+          "conditions": { "type": "object", "description": "JsonLogic expression tree (canonical top-level object shape, e.g. {\"and\": [{\"var\": [\"user.email\"]}]}). Backend evaluator (jwadhams/json-logic-php) accepts either object or array; the schema mandates object to match what the visual builder emits." },
           "type": { "type": "string", "description": "Rule kind (authorization, transformation, validation, audit)" },
           "configuration": { "type": "object", "description": "Action-specific configuration" },
           "order": { "type": "integer", "description": "Execution order within its timing slot", "default": 100 },


### PR DESCRIPTION
## Summary

Closes #909. The Rule schema declared `conditions` as `type: array`, but the visual condition builder (#873) emits the canonical JsonLogic top-level object shape — e.g. `{"and": [{"var": ["user.email"]}]}`. Saving a rule from the builder PUT'd that shape and OR returned `HTTP 400 conditions must be array`.

## Fix

`lib/Settings/openconnector_register.json`:

- `rule.conditions`: `type: array, items: object` → `type: object`
- description rewritten to call out the JsonLogic shape and that `jwadhams/json-logic-php` accepts both object and array — the schema mandates object to match what the builder emits
- rule schema bumped `1.0.0` → `1.1.0`
- top-level register version bumped `1.0.0` → `1.1.0` so `ConfigurationService::importFromApp()` re-imports on the next `occ upgrade`

Note: `endpoint.conditions` and `synchronization.conditions` (also in this descriptor) keep the legacy `array of object` shape — they're tail-list filters, not a single JsonLogic tree, so the array stays correct there.

## Verified live (dev container, OR API)

Live-mutated schema id 220 first (via OR `PUT /api/schemas/220`) to validate, then committed the descriptor change so fresh installs / occ upgrades pick it up.

- POST `/objects/openconnector/rule` with object conditions → 200, object round-trips
- PUT updating an existing rule with a deeper builder output (`and` of `var` + `==`) → 200, object round-trips
- PUT with `conditions: null` on existing rule → 200, null preserved
- POST without `conditions` → 200, conditions defaults to null

## Test plan

- [x] Live: round-trip object-shape conditions via POST and PUT (was 400, now 200)
- [x] Live: null + omitted conditions still accepted
- [x] JSON descriptor valid
- [ ] CI: build, phpcs, phpmd, psalm, phpstan
- [ ] Post-merge: `occ upgrade` (or repair step re-run) picks up the bumped descriptor on stock installs