### PR TITLE
chore(phpstan): remove 24 unread properties (advances #848)

### DIFF
--- a/lib/Action/EventAction.php
+++ b/lib/Action/EventAction.php
@@ -19,30 +19,16 @@
 
 namespace OCA\OpenConnector\Action;
 
-use OCA\OpenConnector\Service\CallService;
-
 /**
  * Runs event-driven actions wired into the OpenConnector cron job list.
  */
 class EventAction
 {
-
-    /**
-     * Service used to execute outbound calls.
-     *
-     * @var CallService
-     */
-    private CallService $callService;
-
     /**
      * Constructor.
-     *
-     * @param CallService $callService Service used to execute outbound calls.
      */
-    public function __construct(
-        CallService $callService,
-    ) {
-        $this->callService = $callService;
+    public function __construct()
+    {
 
     }//end __construct()
 

--- a/lib/Controller/ConsumersController.php
+++ b/lib/Controller/ConsumersController.php
@@ -21,8 +21,6 @@ namespace OCA\OpenConnector\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IAppConfig;
-use OCP\IL10N;
 use OCP\IRequest;
 
 /**
@@ -37,16 +35,12 @@ class ConsumersController extends Controller
     /**
      * Constructor for the ConsumerController.
      *
-     * @param string     $appName The name of the app.
-     * @param IRequest   $request The request object.
-     * @param IAppConfig $config  The app configuration object.
-     * @param IL10N      $l       The localization service.
+     * @param string   $appName The name of the app.
+     * @param IRequest $request The request object.
      */
     public function __construct(
         $appName,
         IRequest $request,
-        private IAppConfig $config,
-        private IL10N $l
     ) {
         parent::__construct(appName: $appName, request: $request);
 

--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -34,7 +34,6 @@ use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -83,7 +82,6 @@ class EndpointsController extends Controller
      *
      * @param string               $appName              The name of the app.
      * @param IRequest             $request              The request object.
-     * @param IAppConfig           $config               The app configuration object.
      * @param EndpointService      $endpointService      Service for handling endpoint operations.
      * @param AuthorizationService $authorizationService Service for handling authorization.
      * @param ObjectService        $objectService        Service for direct ObjectService operations.
@@ -97,7 +95,6 @@ class EndpointsController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private IAppConfig $config,
         private EndpointService $endpointService,
         private AuthorizationService $authorizationService,
         private ObjectService $objectService,

--- a/lib/Controller/EventsController.php
+++ b/lib/Controller/EventsController.php
@@ -25,7 +25,6 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 
@@ -45,7 +44,6 @@ class EventsController extends Controller
      *
      * @param string          $appName         The name of the app.
      * @param IRequest        $request         The request object.
-     * @param IAppConfig      $config          The app configuration object.
      * @param OrObjectService $orObjectService The OR object service.
      * @param EventService    $eventService    The event service.
      * @param IL10N           $l               The localization service.
@@ -53,7 +51,6 @@ class EventsController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config,
         private readonly OrObjectService $orObjectService,
         private readonly EventService $eventService,
         private readonly IL10N $l

--- a/lib/Controller/JobsController.php
+++ b/lib/Controller/JobsController.php
@@ -27,7 +27,6 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 
@@ -50,7 +49,6 @@ class JobsController extends Controller
      *
      * @param string          $appName         The name of the app.
      * @param IRequest        $request         The request object.
-     * @param IAppConfig      $config          The app configuration object.
      * @param OrObjectService $orObjectService The OR object service.
      * @param JobService      $jobService      The job service (used by run/test action methods).
      * @param IL10N           $l               The localization service.
@@ -60,7 +58,6 @@ class JobsController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private IAppConfig $config,
         private OrObjectService $orObjectService,
         private JobService $jobService,
         private IL10N $l

--- a/lib/Controller/MappingsController.php
+++ b/lib/Controller/MappingsController.php
@@ -29,7 +29,6 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -54,7 +53,6 @@ class MappingsController extends Controller
      *
      * @param string         $appName        The name of the app.
      * @param IRequest       $request        The request object.
-     * @param IAppConfig     $config         The app configuration object.
      * @param MappingService $mappingService The mapping service.
      * @param ObjectService  $objectService  The object service (OC).
      * @param IL10N          $l              The localization service.
@@ -62,7 +60,6 @@ class MappingsController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config,
         private readonly MappingService $mappingService,
         private readonly ObjectService $objectService,
         private readonly IL10N $l

--- a/lib/Controller/RulesController.php
+++ b/lib/Controller/RulesController.php
@@ -21,8 +21,6 @@ namespace OCA\OpenConnector\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IAppConfig;
-use OCP\IL10N;
 use OCP\IRequest;
 
 /**
@@ -37,16 +35,12 @@ class RulesController extends Controller
     /**
      * Constructor for the RuleController.
      *
-     * @param string     $appName The name of the app.
-     * @param IRequest   $request The request object.
-     * @param IAppConfig $config  The app configuration object.
-     * @param IL10N      $l       The localization service.
+     * @param string   $appName The name of the app.
+     * @param IRequest $request The request object.
      */
     public function __construct(
         $appName,
         IRequest $request,
-        private IAppConfig $config,
-        private IL10N $l
     ) {
         parent::__construct(appName: $appName, request: $request);
 

--- a/lib/Controller/SourcesController.php
+++ b/lib/Controller/SourcesController.php
@@ -25,7 +25,6 @@ use OCA\OpenRegister\Service\ObjectService as OrObjectService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -48,7 +47,6 @@ class SourcesController extends Controller
      *
      * @param string          $appName         The name of the app.
      * @param IRequest        $request         The request object.
-     * @param IAppConfig      $config          The app configuration object.
      * @param OrObjectService $orObjectService The OR object service.
      * @param IL10N           $l               The localization service.
      *
@@ -57,7 +55,6 @@ class SourcesController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config,
         private readonly OrObjectService $orObjectService,
         private readonly IL10N $l
     ) {

--- a/lib/Controller/SynchronizationsController.php
+++ b/lib/Controller/SynchronizationsController.php
@@ -28,7 +28,6 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use Psr\Container\ContainerExceptionInterface;
@@ -57,7 +56,6 @@ class SynchronizationsController extends Controller
      *
      * @param string                 $appName                The name of the app.
      * @param IRequest               $request                The request object.
-     * @param IAppConfig             $config                 The app configuration object.
      * @param OrObjectService        $orObjectService        The OR object service.
      * @param SynchronizationService $synchronizationService The synchronization service.
      * @param IL10N                  $l                      The localization service.
@@ -66,7 +64,6 @@ class SynchronizationsController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config,
         private readonly OrObjectService $orObjectService,
         private readonly SynchronizationService $synchronizationService,
         private readonly IL10N $l,

--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -21,10 +21,8 @@ declare(strict_types=1);
 
 namespace OCA\OpenConnector\Controller;
 
-use OCA\OpenConnector\Service\AuthorizationService;
 use OCA\OpenConnector\Service\SecurityService;
 use OCA\OpenConnector\Service\UserService;
-use OCA\OpenConnector\Service\OrganisationBridgeService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -73,13 +71,6 @@ class UserController extends Controller
     private readonly IUserSession $userSession;
 
     /**
-     * Authorization service for handling authentication
-     *
-     * @var AuthorizationService
-     */
-    private readonly AuthorizationService $authorizationService;
-
-    /**
      * Security service for handling rate limiting and XSS protection
      *
      * @var SecurityService
@@ -92,13 +83,6 @@ class UserController extends Controller
      * @var UserService
      */
     private readonly UserService $userService;
-
-    /**
-     * Organisation bridge service for organization management
-     *
-     * @var OrganisationBridgeService
-     */
-    private readonly OrganisationBridgeService $organisationBridgeService;
 
     /**
      * Logger for application events
@@ -141,29 +125,25 @@ class UserController extends Controller
      * Initializes the controller with required dependencies for user management
      * and authentication operations.
      *
-     * @param string                    $appName                   The name of the app
-     * @param IRequest                  $request                   The request object for handling HTTP requests
-     * @param IUserManager              $userManager               The user manager for user operations
-     * @param IUserSession              $userSession               The user session manager
-     * @param AuthorizationService      $authorizationService      The authorization service
-     * @param ICacheFactory             $cacheFactory              The cache factory for rate limiting
-     * @param LoggerInterface           $logger                    The logger for security events
-     * @param UserService               $userService               The user service for user-related operations
-     * @param OrganisationBridgeService $organisationBridgeService The organization bridge service
-     * @param IL10N                     $l                         The localization service
-     * @param string                    $corsMethods               Allowed CORS methods
-     * @param string                    $corsAllowedHeaders        Allowed CORS headers
-     * @param int                       $corsMaxAge                CORS max age
+     * @param string          $appName            The name of the app
+     * @param IRequest        $request            The request object for handling HTTP requests
+     * @param IUserManager    $userManager        The user manager for user operations
+     * @param IUserSession    $userSession        The user session manager
+     * @param ICacheFactory   $cacheFactory       The cache factory for rate limiting
+     * @param LoggerInterface $logger             The logger for security events
+     * @param UserService     $userService        The user service for user-related operations
+     * @param IL10N           $l                  The localization service
+     * @param string          $corsMethods        Allowed CORS methods
+     * @param string          $corsAllowedHeaders Allowed CORS headers
+     * @param int             $corsMaxAge         CORS max age
      *
      * @psalm-param   string $appName
      * @psalm-param   IRequest $request
      * @psalm-param   IUserManager $userManager
      * @psalm-param   IUserSession $userSession
-     * @psalm-param   AuthorizationService $authorizationService
      * @psalm-param   ICacheFactory $cacheFactory
      * @psalm-param   LoggerInterface $logger
      * @psalm-param   UserService $userService
-     * @psalm-param   OrganisationBridgeService $organisationBridgeService
      * @psalm-param   IL10N $l
      * @psalm-param   string $corsMethods
      * @psalm-param   string $corsAllowedHeaders
@@ -172,11 +152,9 @@ class UserController extends Controller
      * @phpstan-param IRequest $request
      * @phpstan-param IUserManager $userManager
      * @phpstan-param IUserSession $userSession
-     * @phpstan-param AuthorizationService $authorizationService
      * @phpstan-param ICacheFactory $cacheFactory
      * @phpstan-param LoggerInterface $logger
      * @phpstan-param UserService $userService
-     * @phpstan-param OrganisationBridgeService $organisationBridgeService
      * @phpstan-param IL10N $l
      * @phpstan-param string $corsMethods
      * @phpstan-param string $corsAllowedHeaders
@@ -187,25 +165,21 @@ class UserController extends Controller
         IRequest $request,
         IUserManager $userManager,
         IUserSession $userSession,
-        AuthorizationService $authorizationService,
         ICacheFactory $cacheFactory,
         LoggerInterface $logger,
         UserService $userService,
-        OrganisationBridgeService $organisationBridgeService,
         IL10N $l,
         string $corsMethods='PUT, POST, GET, DELETE, PATCH',
         string $corsAllowedHeaders='Authorization, Content-Type, Accept',
         int $corsMaxAge=1728000
     ) {
         parent::__construct(appName: $appName, request: $request);
-        $this->userManager          = $userManager;
-        $this->userSession          = $userSession;
-        $this->authorizationService = $authorizationService;
-        $this->securityService      = new SecurityService(cacheFactory: $cacheFactory, logger: $logger);
-        $this->userService          = $userService;
-        $this->organisationBridgeService = $organisationBridgeService;
-        $this->logger = $logger;
-        $this->l      = $l;
+        $this->userManager     = $userManager;
+        $this->userSession     = $userSession;
+        $this->securityService = new SecurityService(cacheFactory: $cacheFactory, logger: $logger);
+        $this->userService     = $userService;
+        $this->logger          = $logger;
+        $this->l = $l;
 
         $this->corsMethods        = $corsMethods;
         $this->corsAllowedHeaders = $corsAllowedHeaders;

--- a/lib/EventListener/ViewDeletedEventListener.php
+++ b/lib/EventListener/ViewDeletedEventListener.php
@@ -28,7 +28,6 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Event\ObjectDeletedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use Psr\Log\LoggerInterface;
 
 /**
  * Event listener that removes extended views when a view is deleted.
@@ -40,13 +39,11 @@ class ViewDeletedEventListener implements IEventListener
     /**
      * Constructor.
      *
-     * @param LoggerInterface $logger         Logger instance.
-     * @param SchemaMapper    $schemaMapper   Schema mapper used to resolve view + extendview schemas.
-     * @param RegisterMapper  $registerMapper Register mapper used to resolve the vng-gemma register.
-     * @param ObjectService   $objectService  Service providing access to the OR object layer.
+     * @param SchemaMapper   $schemaMapper   Schema mapper used to resolve view + extendview schemas.
+     * @param RegisterMapper $registerMapper Register mapper used to resolve the vng-gemma register.
+     * @param ObjectService  $objectService  Service providing access to the OR object layer.
      */
     public function __construct(
-        private readonly LoggerInterface $logger,
         private readonly SchemaMapper $schemaMapper,
         private readonly RegisterMapper $registerMapper,
         private readonly ObjectService $objectService,

--- a/lib/EventListener/ViewUpdatedOrCreatedEventListener.php
+++ b/lib/EventListener/ViewUpdatedOrCreatedEventListener.php
@@ -22,12 +22,10 @@
 
 namespace OCA\OpenConnector\EventListener;
 
-use OCA\OpenConnector\Service\SynchronizationService;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use Psr\Log\LoggerInterface;
 
 /**
  * Event listener that handles view updates and creations.
@@ -60,14 +58,9 @@ class ViewUpdatedOrCreatedEventListener implements IEventListener
 
     /**
      * Constructor.
-     *
-     * @param SynchronizationService $synchronizationService Service that performs the synchronization.
-     * @param LoggerInterface        $logger                 Logger instance.
      */
-    public function __construct(
-        private readonly SynchronizationService $synchronizationService,
-        private readonly LoggerInterface $logger,
-    ) {
+    public function __construct()
+    {
 
     }//end __construct()
 

--- a/lib/Service/AuthorizationService.php
+++ b/lib/Service/AuthorizationService.php
@@ -44,9 +44,7 @@ use OCP\IRequest;
 use OC\AppFramework\Middleware\Security\Exceptions\SecurityException;
 use OCP\AppFramework\Http\Attribute\CORS;
 use OCP\AppFramework\Http\Response;
-use OCP\Authentication\Token\IProvider;
 use OCP\IGroup;
-use OCP\IGroupManager;
 use OCP\ISession;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -73,15 +71,11 @@ class AuthorizationService
      * @param IUserManager                            $userManager     The user manager.
      * @param IUserSession                            $userSession     The user session.
      * @param \OCA\OpenRegister\Service\ObjectService $orObjectService OR ObjectService used to resolve consumers.
-     * @param IGroupManager                           $groupManager    The group manager.
-     * @param IProvider                               $tokenProvider   OAuth token provider.
      */
     public function __construct(
         private readonly IUserManager $userManager,
         private readonly IUserSession $userSession,
         private readonly \OCA\OpenRegister\Service\ObjectService $orObjectService,
-        private readonly IGroupManager $groupManager,
-        private readonly IProvider $tokenProvider,
     ) {
 
     }//end __construct()

--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -41,7 +41,6 @@ use OCP\AppFramework\Db\QBMapper;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
-use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -92,7 +91,6 @@ class EndpointService
      * @param MappingService         $mappingService         Service used to apply request/response mappings.
      * @param ORObjectService        $orObjectService        OpenRegister object service for register/schema CRUD.
      * @param IConfig                $config                 Nextcloud system configuration.
-     * @param IAppConfig             $appConfig              Nextcloud app-scoped configuration.
      * @param StorageService         $storageService         Service used for file part and attachment storage.
      * @param AuthorizationService   $authorizationService   Service used to authorize incoming endpoint requests.
      * @param ContainerInterface     $containerInterface     PSR container used to resolve optional services.
@@ -109,7 +107,6 @@ class EndpointService
         private readonly MappingService $mappingService,
         private readonly ORObjectService $orObjectService,
         private readonly IConfig $config,
-        private readonly IAppConfig $appConfig,
         private readonly StorageService $storageService,
         private readonly AuthorizationService $authorizationService,
         private readonly ContainerInterface $containerInterface,

--- a/lib/Service/RuleService.php
+++ b/lib/Service/RuleService.php
@@ -30,7 +30,6 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\ValidationException;
 use OCA\OpenRegister\Service\ObjectService as ORObjectService;
 use OCP\AppFramework\Http\JSONResponse;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 use DateTime;
 
@@ -170,7 +169,6 @@ class RuleService
     /**
      * Constructor for RuleService.
      *
-     * @param LoggerInterface          $logger           Logger used for rule processing diagnostics.
      * @param ObjectService            $objectService    OpenConnector object-service facade.
      * @param SoftwareCatalogueService $catalogueService Software-catalog rule helper.
      * @param RegisterMapper           $registerMapper   Mapper used to resolve register IDs.
@@ -181,7 +179,6 @@ class RuleService
      * @return void
      */
     public function __construct(
-        private readonly LoggerInterface $logger,
         private readonly ObjectService $objectService,
         private readonly SoftwareCatalogueService $catalogueService,
         private readonly RegisterMapper $registerMapper,

--- a/lib/Service/SOAPService.php
+++ b/lib/Service/SOAPService.php
@@ -70,13 +70,6 @@ class SOAPService
     private Client $client;
 
     /**
-     * The PSR-18 transport layer of the SOAP engine.
-     *
-     * @var Psr18Transport
-     */
-    private Psr18Transport $transport;
-
-    /**
      * Constructor.
      *
      * @param CookieJar $cookieJar A cookie jar to pass on cookies between SOAP requests.
@@ -178,7 +171,7 @@ class SOAPService
                             ->disableWsdlCache()
                     )
                 ),
-                $this->transport = Psr18Transport::createForClient($this->client),
+                Psr18Transport::createForClient($this->client),
             );
         } catch (\SoapFault $fault) {
             throw $fault;

--- a/lib/Service/StUFFieldMapper.php
+++ b/lib/Service/StUFFieldMapper.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace OCA\OpenConnector\Service;
 
-use Psr\Log\LoggerInterface;
 
 /**
  * Service for mapping StUF fields to/from OpenRegister object properties.
@@ -61,12 +60,9 @@ class StUFFieldMapper
 
     /**
      * StUFFieldMapper constructor.
-     *
-     * @param LoggerInterface $logger Logger for error handling
      */
-    public function __construct(
-        private readonly LoggerInterface $logger
-    ) {
+    public function __construct()
+    {
 
     }//end __construct()
 

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -24,7 +24,6 @@ namespace OCA\OpenConnector\Service;
 
 use OCP\IDBConnection;
 use OCP\IUser;
-use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -54,7 +53,6 @@ class UserService
     /**
      * UserService constructor.
      *
-     * @param IUserManager              $userManager               The user manager service.
      * @param IUserSession              $userSession               The user session service.
      * @param IConfig                   $config                    The configuration service.
      * @param IGroupManager             $groupManager              The group manager service.
@@ -67,7 +65,6 @@ class UserService
      * @return void
      */
     public function __construct(
-        private readonly IUserManager $userManager,
         private readonly IUserSession $userSession,
         private readonly IConfig $config,
         private readonly IGroupManager $groupManager,

--- a/lib/Settings/OpenConnectorAdmin.php
+++ b/lib/Settings/OpenConnectorAdmin.php
@@ -20,23 +20,13 @@ namespace OCA\OpenConnector\Settings;
 
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
-use OCP\IL10N;
 use OCP\Settings\ISettings;
 
 /**
  * Admin settings panel for OpenConnector.
- *
- * @SuppressWarnings(PHPMD.ShortVariable)
  */
 class OpenConnectorAdmin implements ISettings
 {
-
-    /**
-     * Localisation service.
-     *
-     * @var IL10N
-     */
-    private IL10N $l;
 
     /**
      * Nextcloud config service.
@@ -49,12 +39,10 @@ class OpenConnectorAdmin implements ISettings
      * Constructor.
      *
      * @param IConfig $config Nextcloud config service.
-     * @param IL10N   $l      Localisation service.
      */
-    public function __construct(IConfig $config, IL10N $l)
+    public function __construct(IConfig $config)
     {
         $this->config = $config;
-        $this->l      = $l;
 
     }//end __construct()
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,71 +1,11 @@
 # PHPStan baseline — tracked lint debt for openconnector
 #
-# This baseline was generated during the Phase 2 canonical-root-config sync
-# (PR follow-up to shillinq#300 / decidesk#243). PHPStan had never run on
-# this repo before; everything below is pre-existing static-analysis debt
-# absorbed as tracked items, NOT new debt introduced by the sync.
-#
 # Burndown tracked at: https://github.com/ConductionNL/openconnector/issues/848
 # Remove entries here as the underlying code is fixed.
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Action\\\\EventAction\\:\\:\\$callService is never read, only written\\.$#"
-			count: 1
-			path: lib/Action/EventAction.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\ConsumersController\\:\\:\\$config is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/ConsumersController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\ConsumersController\\:\\:\\$l is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/ConsumersController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\EndpointsController\\:\\:\\$config is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/EndpointsController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\EventsController\\:\\:\\$config is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/EventsController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\JobsController\\:\\:\\$config is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/JobsController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\MappingsController\\:\\:\\$config is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/MappingsController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\RulesController\\:\\:\\$config is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/RulesController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\RulesController\\:\\:\\$l is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/RulesController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\SourcesController\\:\\:\\$config is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/SourcesController.php
-
-		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: lib/Controller/SynchronizationsController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\SynchronizationsController\\:\\:\\$config is never read, only written\\.$#"
 			count: 1
 			path: lib/Controller/SynchronizationsController.php
 
@@ -75,37 +15,12 @@ parameters:
 			path: lib/Controller/UserController.php
 
 		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\UserController\\:\\:\\$authorizationService is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/UserController.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Controller\\\\UserController\\:\\:\\$organisationBridgeService is never read, only written\\.$#"
-			count: 1
-			path: lib/Controller/UserController.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between OCP\\\\IUser and false will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Controller/UserController.php
 
 		-
-			message: "#^Property OCA\\\\OpenConnector\\\\EventListener\\\\ViewDeletedEventListener\\:\\:\\$logger is never read, only written\\.$#"
-			count: 1
-			path: lib/EventListener/ViewDeletedEventListener.php
-
-		-
 			message: "#^Constant OCA\\\\OpenConnector\\\\EventListener\\\\ViewUpdatedOrCreatedEventListener\\:\\:SOFTWARE_CATALOG_REGISTER_ID is unused\\.$#"
-			count: 1
-			path: lib/EventListener/ViewUpdatedOrCreatedEventListener.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\EventListener\\\\ViewUpdatedOrCreatedEventListener\\:\\:\\$logger is never read, only written\\.$#"
-			count: 1
-			path: lib/EventListener/ViewUpdatedOrCreatedEventListener.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\EventListener\\\\ViewUpdatedOrCreatedEventListener\\:\\:\\$synchronizationService is never read, only written\\.$#"
 			count: 1
 			path: lib/EventListener/ViewUpdatedOrCreatedEventListener.php
 
@@ -141,16 +56,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @throws with type OC\\\\AppFramework\\\\Middleware\\\\Security\\\\Exceptions\\\\SecurityException is not subtype of Throwable$#"
-			count: 1
-			path: lib/Service/AuthorizationService.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\AuthorizationService\\:\\:\\$groupManager is never read, only written\\.$#"
-			count: 1
-			path: lib/Service/AuthorizationService.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\AuthorizationService\\:\\:\\$tokenProvider is never read, only written\\.$#"
 			count: 1
 			path: lib/Service/AuthorizationService.php
 
@@ -390,11 +295,6 @@ parameters:
 			path: lib/Service/EndpointService.php
 
 		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:\\$appConfig is never read, only written\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
 			message: "#^Result of \\|\\| is always false\\.$#"
 			count: 1
 			path: lib/Service/EndpointService.php
@@ -560,16 +460,6 @@ parameters:
 			path: lib/Service/RuleService.php
 
 		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\RuleService\\:\\:\\$logger is never read, only written\\.$#"
-			count: 1
-			path: lib/Service/RuleService.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\SOAPService\\:\\:\\$transport is never read, only written\\.$#"
-			count: 1
-			path: lib/Service/SOAPService.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between SimpleXMLElement\\|false and null will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Service/SOAPService.php
@@ -598,11 +488,6 @@ parameters:
 			message: "#^Anonymous function has an unused use \\$openRegister\\.$#"
 			count: 2
 			path: lib/Service/SoftwareCatalogueService.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\StUFFieldMapper\\:\\:\\$logger is never read, only written\\.$#"
-			count: 1
-			path: lib/Service/StUFFieldMapper.php
 
 		-
 			message: "#^Access to an undefined property OCA\\\\OpenConnector\\\\Service\\\\StorageService\\:\\:\\$userSession\\.$#"
@@ -695,19 +580,9 @@ parameters:
 			path: lib/Service/SynchronizationService.php
 
 		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Service\\\\UserService\\:\\:\\$userManager is never read, only written\\.$#"
-			count: 1
-			path: lib/Service/UserService.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between OCP\\\\Accounts\\\\IAccountProperty and null will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Service/UserService.php
-
-		-
-			message: "#^Property OCA\\\\OpenConnector\\\\Settings\\\\OpenConnectorAdmin\\:\\:\\$l is never read, only written\\.$#"
-			count: 1
-			path: lib/Settings/OpenConnectorAdmin.php
 
 		-
 			message: "#^Class OC\\\\Files\\\\Node\\\\File not found\\.$#"


### PR DESCRIPTION
Removes 24 private properties that PHPStan flagged as 'never read, only written'. All were auto-wired DI parameters stored on $this but never referenced by any method. Each removal also drops the matching constructor param, docblock entry, and use-statement.

Files touched (19): EventAction, 8 controllers, UserController (drops AuthorizationService + OrganisationBridgeService), 2 view-event listeners, AuthorizationService (drops IGroupManager + IProvider; $groupManager appeared only in commented-out code), EndpointService (drops IAppConfig $appConfig), RuleService, SOAPService, StUFFieldMapper, UserService (drops IUserManager), OpenConnectorAdmin.

Safety: all touched classes are auto-wired by Nextcloud's DI container (no manual factory registration in AppInfo/Application.php), so constructor signature changes don't break the wire.

## Baseline progress
- Before: 141 entries (after #929)
- After:  117 entries (−24)
- Goal #848: <=400 — already there in 2 PRs (this session)

## Verification
- `phpstan analyse` → `[OK] No errors` with regenerated baseline
- `phpcs lib/` → 0 errors (455 warnings, all pre-existing @spec docblock warnings)
