### PR TITLE
chore(phpstan): fix docblock types + IRequest migration (advances #848)

### DIFF
--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -26,7 +26,6 @@ use Exception;
 use GuzzleHttp\Exception\GuzzleException;
 use JWadhams\JsonLogic;
 use OC\AppFramework\Http;
-use OC\AppFramework\Http\Request;
 use OC\Files\Node\File;
 use OCA\OpenRegister\Service\ObjectService as ORObjectService;
 use OCA\OpenRegister\Service\ObjectServiceMapperAdapter;
@@ -179,11 +178,11 @@ class EndpointService
      * Transform outgoing errors according to a specified format
      *
      * @param Response $result  The result from either the rules or the target of the endpoint.
-     * @param Request  $request The current request, used to determine the request identifier.
+     * @param IRequest $request The current request, used to determine the request identifier.
      *
      * @return Response
      */
-    private function transformError(Response $result, Request $request): Response
+    private function transformError(Response $result, IRequest $request): Response
     {
         if ($result->getStatus() < 200 || $result->getStatus() >= 300) {
             $resultData = $result->getData();
@@ -1035,8 +1034,8 @@ class EndpointService
     /**
      * Check conditions for using an endpoint.
      *
-     * @param Endpoint $endpoint The endpoint for which the checks should be done.
-     * @param IRequest $request  The inbound request.
+     * @param ObjectEntity $endpoint The endpoint for which the checks should be done.
+     * @param IRequest     $request  The inbound request.
      *
      * @return array
      * @throws Exception
@@ -1046,7 +1045,7 @@ class EndpointService
         $endpointData       = $endpoint->getObject();
         $conditions         = ($endpointData['conditions'] ?? []);
         $data['parameters'] = $request->getParams();
-        $data['headers']    = $this->getHeaders(server: $request->server, proxyHeaders: true);
+        $data['headers']    = $this->getHeaders(server: $_SERVER, proxyHeaders: true);
 
         $result = JsonLogic::apply(logic: $conditions, data: $data);
 
@@ -1069,7 +1068,7 @@ class EndpointService
     private function handleSourceRequest(ObjectEntity $endpoint, IRequest $request): JSONResponse
     {
         $endpointData = $endpoint->getObject();
-        $headers      = $this->getHeaders(server: $request->server);
+        $headers      = $this->getHeaders(server: $_SERVER);
 
         // Fetch the source entity by targetId.
         $source = $this->orObjectService->find(id: ($endpointData['targetId'] ?? ''), register: 'openconnector', schema: 'source');
@@ -1096,11 +1095,11 @@ class EndpointService
     /**
      * Generates url based on available endpoints for the object type.
      *
-     * @param string                           $id           The id of the object to generate an url for.
-     * @param OCA\OpenRegister\Db\SchemaMapper $schemaMapper The mapper to get schemas
-     * @param int|null                         $register     The register of the object (aids performance).
-     * @param int|null                         $schema       The schema of the object (aids performance).
-     * @param array                            $parentIds    The ids of the main object on subobjects.
+     * @param string                            $id           The id of the object to generate an url for.
+     * @param \OCA\OpenRegister\Db\SchemaMapper $schemaMapper The mapper to get schemas
+     * @param int|null                          $register     The register of the object (aids performance).
+     * @param int|null                          $schema       The schema of the object (aids performance).
+     * @param array                             $parentIds    The ids of the main object on subobjects.
      *
      * @return string The generated url.
      * @throws ContainerExceptionInterface
@@ -1400,8 +1399,8 @@ class EndpointService
     /**
      * Processes authentication rules
      *
-     * @param Rule  $rule The rule to process
-     * @param array $data The data of the request
+     * @param ObjectEntity $rule The rule to process
+     * @param array        $data The data of the request
      *
      * @return array|JSONResponse the unchanged $data array if authentication succeeds, or a JSONResponse containing an error on authentication.
      */
@@ -1546,8 +1545,8 @@ class EndpointService
     /**
      * Processes a mapping rule
      *
-     * @param Rule  $rule The rule object containing mapping details
-     * @param array $data The data to be processed through the mapping rule
+     * @param ObjectEntity $rule The rule object containing mapping details
+     * @param array        $data The data to be processed through the mapping rule
      *
      * @return array The processed data after applying the mapping rule
      * @throws DoesNotExistException When the mapping configuration does not exist
@@ -1568,8 +1567,8 @@ class EndpointService
     /**
      * Extends input for performing business logic
      *
-     * @param Rule  $rule The rule containing the configuration which parameters could be extended
-     * @param array $data The data array containing the input parameters.
+     * @param ObjectEntity $rule The rule containing the configuration which parameters could be extended
+     * @param array        $data The data array containing the input parameters.
      *
      * @return array The data array with the extended parameters in the 'extendedParameters' key.
      * @throws ContainerExceptionInterface
@@ -1624,10 +1623,10 @@ class EndpointService
     /**
      * Fetches the audit trail for an object, returns a specific audit rule if the path parameter audittrail-id is specified.
      *
-     * @param Rule     $rule     The rule to execute
-     * @param Endpoint $endpoint The endpoint on which the rule is executed
-     * @param array    $data     The data from the request.
-     * @param string   $objectId The object id for which the request was done.
+     * @param ObjectEntity $rule     The rule to execute
+     * @param ObjectEntity $endpoint The endpoint on which the rule is executed
+     * @param array        $data     The data from the request.
+     * @param string       $objectId The object id for which the request was done.
      *
      * @return array|Response The updated data array, or a json response with a not found error.
      *
@@ -1696,8 +1695,8 @@ class EndpointService
     /**
      * Process a custom rule
      *
-     * @param Rule  $rule The rule to process
-     * @param array $data The data to process
+     * @param ObjectEntity $rule The rule to process
+     * @param array        $data The data to process
      *
      * @return array The updated data array.
      */
@@ -2083,7 +2082,7 @@ class EndpointService
      *
      * @param ObjectEntity $rule     The rule to process.
      * @param array        $data     The data from the object in array form.
-     * @param Request      $request  The current request used to read the uploaded part body.
+     * @param IRequest     $request  The current request used to read the uploaded part body.
      * @param string|null  $objectId The id of the object.
      *
      * @return array The updated object data.
@@ -2095,7 +2094,7 @@ class EndpointService
      * @throws \OCP\Files\InvalidPathException
      * @throws \OCP\Files\NotFoundException
      */
-    private function processFilePartUploadRule(ObjectEntity $rule, array $data, Request $request, ?string $objectId=null): array
+    private function processFilePartUploadRule(ObjectEntity $rule, array $data, IRequest $request, ?string $objectId=null): array
     {
         $ruleConfig = $rule->getObject()['configuration'] ?? [];
         if (isset($ruleConfig['filepart_upload']) === false) {
@@ -2138,8 +2137,8 @@ class EndpointService
     /**
      * Processes a JavaScript rule
      *
-     * @param Rule  $rule The rule object containing JavaScript execution details
-     * @param array $data The input data to be processed by the JavaScript rule
+     * @param ObjectEntity $rule The rule object containing JavaScript execution details
+     * @param array        $data The input data to be processed by the JavaScript rule
      *
      * @return array The processed data after executing the JavaScript rule
      */
@@ -2154,9 +2153,9 @@ class EndpointService
     /**
      * Downloads a file based upon configuration
      *
-     * @param Rule   $rule     The rule to execute.
-     * @param array  $data     The data to perform the rule on.
-     * @param string $objectId The id of the requested object.
+     * @param ObjectEntity $rule     The rule to execute.
+     * @param array        $data     The data to perform the rule on.
+     * @param string       $objectId The id of the requested object.
      *
      * @return Response A response containing the file requested.
      *
@@ -2278,11 +2277,11 @@ class EndpointService
     /**
      * Parse raw content into structured data based on content type.
      *
-     * @param Request $request The current request, used to inspect headers and raw body.
+     * @param IRequest $request The current request, used to inspect headers and raw body.
      *
      * @return mixed Parsed data (array for JSON/XML) or original string.
      */
-    private function parseContent(Request $request): mixed
+    private function parseContent(IRequest $request): mixed
     {
         $contentType = $request->getHeader('Content-Type');
 
@@ -2310,7 +2309,7 @@ class EndpointService
 
         // Try XML decode if content type suggests XML or content looks like XML.
         if ($contentType === 'application/xml' || $contentType === 'text/xml'
-            || ($contentType === null && $this->looksLikeXml(content: $content) === true)
+            || ($contentType === '' && $this->looksLikeXml(content: $content) === true)
         ) {
             libxml_use_internal_errors(true);
             $xml = simplexml_load_string($content);

--- a/lib/Service/Helper/FlowToken.php
+++ b/lib/Service/Helper/FlowToken.php
@@ -19,8 +19,8 @@
 
 namespace OCA\OpenConnector\Service\Helper;
 
-use OC\AppFramework\Http\Request;
 use OCP\AppFramework\Http\Response;
+use OCP\IRequest;
 
 /**
  * Container for original + amended payloads passed through the rule pipeline.
@@ -96,7 +96,7 @@ class FlowToken
      * @param string|null $path               Request path used when serialising a Request.
      */
     public function __construct(
-        Request|array $requestOriginal=[],
+        IRequest|array $requestOriginal=[],
         Response|array $responseOriginal=[],
         array $syncInputOriginal=[],
         array $syncOutputOriginal=[],
@@ -197,7 +197,7 @@ class FlowToken
      *
      * @return mixed Parsed data (array for JSON/XML) or original string.
      */
-    private function parseContent(Request $request): mixed
+    private function parseContent(IRequest $request): mixed
     {
         $contentType = $request->getHeader('Content-Type');
 
@@ -224,7 +224,7 @@ class FlowToken
 
         // Try XML decode if content type suggests XML or content looks like XML.
         if ($contentType === 'application/xml' || $contentType === 'text/xml'
-            || ($contentType === null && $this->looksLikeXml(content: $content) === true)
+            || ($contentType === '' && $this->looksLikeXml(content: $content) === true)
         ) {
             libxml_use_internal_errors(true);
             $xml = simplexml_load_string($content);
@@ -248,13 +248,13 @@ class FlowToken
      *
      * @return array The stored array shape.
      */
-    public function setRequestOriginal(array|Request $requestOriginal, ?string $path=null): array
+    public function setRequestOriginal(array|IRequest $requestOriginal, ?string $path=null): array
     {
-        if ($requestOriginal instanceof Request) {
+        if ($requestOriginal instanceof IRequest) {
             $request         = $requestOriginal;
             $requestOriginal = [
                 'method'     => $request->getMethod(),
-                'headers'    => $this->getHeaders(server: $request->server, proxyHeaders: true),
+                'headers'    => $this->getHeaders(server: $_SERVER, proxyHeaders: true),
                 'parameters' => array_merge($request->getParams(), $this->parseContent(request: $request)),
                 'path'       => $path,
             ];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -140,11 +140,6 @@ parameters:
 			path: lib/Service/EndpointCacheService.php
 
 		-
-			message: "#^Access to an undefined property OCP\\\\IRequest\\:\\:\\$server\\.$#"
-			count: 2
-			path: lib/Service/EndpointService.php
-
-		-
 			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Http\\\\Response\\:\\:getData\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/EndpointService.php
@@ -190,107 +185,12 @@ parameters:
 			path: lib/Service/EndpointService.php
 
 		-
-			message: "#^PHPDoc tag @param for parameter \\$endpoint with type OCA\\\\OpenConnector\\\\Service\\\\Endpoint is not subtype of native type OCA\\\\OpenRegister\\\\Db\\\\ObjectEntity\\.$#"
-			count: 2
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$rule with type OCA\\\\OpenConnector\\\\Service\\\\Rule is not subtype of native type OCA\\\\OpenRegister\\\\Db\\\\ObjectEntity\\.$#"
-			count: 7
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$schemaMapper with type OCA\\\\OpenConnector\\\\Service\\\\OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper is not subtype of native type OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
 			message: "#^PHPDoc tag @return with type array\\|null is not subtype of native type array\\.$#"
 			count: 1
 			path: lib/Service/EndpointService.php
 
 		-
 			message: "#^PHPDoc tag @throws with type GuzzleHttp\\\\Exception\\\\GuzzleException\\|OCA\\\\OpenRegister\\\\Exception\\\\ValidationException\\|OCP\\\\AppFramework\\\\Db\\\\DoesNotExistException\\|OCP\\\\AppFramework\\\\Db\\\\MultipleObjectsReturnedException\\|OCP\\\\Files\\\\InvalidPathException\\|OCP\\\\Files\\\\NotFoundException\\|Psr\\\\Container\\\\ContainerExceptionInterface\\|Twig\\\\Error\\\\LoaderError\\|Twig\\\\Error\\\\SyntaxError is not subtype of Throwable$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$endpoint of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:checkConditions\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\Endpoint\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$endpoint of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processAuditTrailRule\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\Endpoint\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:parseContent\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
-			count: 2
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processFilePartUploadRule\\(\\) expects OC\\\\AppFramework\\\\Http\\\\Request, OCP\\\\IRequest given\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processFilePartUploadRule\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
-			count: 2
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:transformError\\(\\) expects OC\\\\AppFramework\\\\Http\\\\Request, OCP\\\\IRequest given\\.$#"
-			count: 3
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:transformError\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
-			count: 2
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$requestOriginal of class OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken constructor expects array\\|OC\\\\AppFramework\\\\Http\\\\Request, OCP\\\\IRequest given\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$rule of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processAuditTrailRule\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\Rule\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$rule of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processAuthenticationRule\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\Rule\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$rule of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processCustomRule\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\Rule\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$rule of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processDownloadRule\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\Rule\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$rule of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processExtendInputRule\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\Rule\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$rule of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processJavaScriptRule\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\Rule\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$rule of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:processMappingRule\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\Rule\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Parameter \\$schemaMapper of method OCA\\\\OpenConnector\\\\Service\\\\EndpointService\\:\\:generateEndpointUrl\\(\\) has invalid type OCA\\\\OpenConnector\\\\Service\\\\OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\.$#"
 			count: 1
 			path: lib/Service/EndpointService.php
 
@@ -345,27 +245,7 @@ parameters:
 			path: lib/Service/EventService.php
 
 		-
-			message: "#^Class OC\\\\AppFramework\\\\Http\\\\Request not found\\.$#"
-			count: 1
-			path: lib/Service/Helper/FlowToken.php
-
-		-
 			message: "#^Function request_parse_body not found\\.$#"
-			count: 1
-			path: lib/Service/Helper/FlowToken.php
-
-		-
-			message: "#^Parameter \\$request of method OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken\\:\\:parseContent\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
-			count: 1
-			path: lib/Service/Helper/FlowToken.php
-
-		-
-			message: "#^Parameter \\$requestOriginal of method OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken\\:\\:__construct\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
-			count: 1
-			path: lib/Service/Helper/FlowToken.php
-
-		-
-			message: "#^Parameter \\$requestOriginal of method OCA\\\\OpenConnector\\\\Service\\\\Helper\\\\FlowToken\\:\\:setRequestOriginal\\(\\) has invalid type OC\\\\AppFramework\\\\Http\\\\Request\\.$#"
 			count: 1
 			path: lib/Service/Helper/FlowToken.php
 


### PR DESCRIPTION
Two related cleanups in EndpointService.php and Service/Helper/FlowToken.php that together remove 24 phpstan-baseline entries.

## What

1. **Fixed @param docblock types that referenced non-existent classes:**
   - 7x `@param Rule` -> `@param ObjectEntity` (these methods take OR ObjectEntity rule objects; `\\OCA\\OpenConnector\\Service\\Rule` does not exist)
   - 2x `@param Endpoint` -> `@param ObjectEntity` (same pattern for endpoint objects)
   - 1x `@param OCA\\OpenRegister\\Db\\SchemaMapper` -> `@param \\OCA\\OpenRegister\\Db\\SchemaMapper` (the missing leading backslash made phpstan resolve the type as a non-existent nested namespace)

2. **Migrated 5 method/constructor signatures** from the internal `OC\\AppFramework\\Http\\Request` to the public `OCP\\IRequest` interface (phpstan can't see the internal class). All the methods only call interface-public methods on the parameter, so the migration is type-safe.

3. **Side effects of the IRequest migration** that needed accompanying fixes:
   - `\$request->server` -> `\$_SERVER` (IRequest has no public `\$server` property; this also clears 2 pre-existing baseline entries)
   - `getHeader()` returns string (not mixed), so `\$contentType === null` was dead code; replaced with `\$contentType === ''` (matches the empty-string fallback IRequest::getHeader returns for missing headers)

## Baseline progress
- Before: 117 entries (after #930)
- After:  93 entries (-24)
- Goal #848 <=400: well past it (3 PRs in this session reduced 544 -> 93)

## Verification
- `phpstan analyse` -> `[OK] No errors` with regenerated baseline
- `phpcs lib/` -> 0 errors