### PR TITLE
chore(phpstan): fix possibly-undefined variables (advances #848)

### DIFF
--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -749,7 +749,7 @@ class EndpointService
 
             $ids = $main[$property];
 
-            if (isset($ids) === false || $ids === null || empty($ids) === true) {
+            if ($ids === null || empty($ids) === true) {
                 $returnArray = [
                     'count'   => 0,
                     'results' => [],
@@ -1685,6 +1685,9 @@ class EndpointService
             );
         } else if ($config['locking']['action'] === 'unlock') {
             $object = $this->objectService->getOpenRegisters()->unlockObject(identifier: $objectId);
+        } else {
+            // Unknown locking action — leave $data untouched.
+            return $data;
         }
 
         $data['body'] = $object->jsonSerialize();
@@ -1737,7 +1740,8 @@ class EndpointService
             $result = [];
             foreach ($files as $key => $value) {
                 // Check for tags.
-                $tags = [];
+                $tags     = [];
+                $fileName = null;
                 if (is_array($value) === true) {
                     $content = $value['content'];
                     if (isset($value['label']) === true && isset($config['tags']) === true
@@ -1774,7 +1778,6 @@ class EndpointService
                 }
             }//end foreach
 
-            $result[$key] = $file->getPath();
             $dataDot[$config['filePath']] = $result;
         } else {
             $content  = $files;

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -344,7 +344,10 @@ class MappingService
      */
     private function handleCast(Dot $dotArray, string $key, string $cast)
     {
-        $value = $dotArray->get($key);
+        $value          = $dotArray->get($key);
+        $unsetIfValue   = null;
+        $setNullIfValue = null;
+        $countValue     = null;
 
         if (str_starts_with($cast, 'unsetIfValue==') === true) {
             $unsetIfValue = substr($cast, 14);

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -461,6 +461,7 @@ class SearchService
     public function parseQueryString(string $queryString=''): array
     {
         $pairs = explode(separator: '&', string: $queryString);
+        $vars  = [];
 
         foreach ($pairs as $pair) {
             $kvpair = explode(separator: '=', string: $pair);

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -3491,6 +3491,7 @@ class SynchronizationService
         $schema        = $configuration['save_object']['schema'];
         $mapping       = $configuration['save_object']['mapping'] ?? null;
         $patch         = $configuration['save_object']['patch'] ?? false;
+        $id            = null;
 
         if (empty($mapping) === false) {
             if (isset($data['_objectBeforeMapping']['id']) === true) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -195,42 +195,12 @@ parameters:
 			path: lib/Service/EndpointService.php
 
 		-
-			message: "#^Result of \\|\\| is always false\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between array and null will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Service/EndpointService.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Variable \\$file might not be defined\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Variable \\$fileName might not be defined\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Variable \\$ids in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Variable \\$object might not be defined\\.$#"
 			count: 1
 			path: lib/Service/EndpointService.php
 
@@ -290,16 +260,6 @@ parameters:
 			path: lib/Service/MappingService.php
 
 		-
-			message: "#^Variable \\$setNullIfValue might not be defined\\.$#"
-			count: 3
-			path: lib/Service/MappingService.php
-
-		-
-			message: "#^Variable \\$unsetIfValue might not be defined\\.$#"
-			count: 3
-			path: lib/Service/MappingService.php
-
-		-
 			message: "#^Call to an undefined method OCP\\\\DB\\\\IResult\\:\\:fetchAllAssociative\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/Migration/LegacyToRegisterMigrator.php
@@ -351,11 +311,6 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property OCA\\\\OpenConnector\\\\Service\\\\SearchService\\:\\:\\$elasticService\\.$#"
-			count: 1
-			path: lib/Service/SearchService.php
-
-		-
-			message: "#^Variable \\$vars might not be defined\\.$#"
 			count: 1
 			path: lib/Service/SearchService.php
 
@@ -451,11 +406,6 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/SynchronizationService.php
-
-		-
-			message: "#^Variable \\$id might not be defined\\.$#"
 			count: 1
 			path: lib/Service/SynchronizationService.php
 


### PR DESCRIPTION
PHPStan flagged several variables that might not be defined when read. Each is fixed in source: initializing the variable at the top of its scope, restructuring a dead branch, or removing a duplicated-after-loop bug.

## Fixes

- **MappingService::handleCast** — initialize `\$unsetIfValue`, `\$setNullIfValue`, `\$countValue` to null at top. They were only assigned inside conditional `str_starts_with(...)` branches but read unconditionally in the switch arms. (-6 baseline entries)
- **EndpointService::processLockingRule** — add explicit else-branch that returns early when the locking action is neither `lock` nor `unlock`. `\$object` was undefined on that path.
- **EndpointService::processWriteFileRule** — (a) initialize `\$fileName = null` at start of each foreach iteration, (b) drop the duplicate-of-line-1774 `\$result[\$key] = \$file->getPath()` after the loop (real bug: `\$key`/`\$file` undefined if the catch block ran).
- **EndpointService line 752** — simplify dead `isset(\$ids)` check that came one line after `\$ids = ...` assignment.
- **SearchService::parseQueryString** — initialize `\$vars = []` before the foreach. Was returned/passed-by-ref without ever being initialized.
- **SynchronizationService::processSaveObjectRule** — initialize `\$id = null`. Was only set inside a nested `if` but later read in the unconditional patch-find call.

## Baseline progress
- Before: 93 entries (after #931)
- After:  83 entries (-10)

## Verification
- `phpstan analyse` -> `[OK] No errors` with regenerated baseline
- `phpcs lib/` -> 0 errors