### PR TITLE
chore(phpstan): kill dead-branch comparisons (advances #848)

### DIFF
--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -318,7 +318,7 @@ class UserController extends Controller
             }
 
             // Check if user is authenticated (either via session or basic auth).
-            if ($currentUser === null || $currentUser === false) {
+            if ($currentUser === null) {
                 $response = new JSONResponse(
                     data: ['message' => $this->l->t('Current user is not logged in')],
                     statusCode: 401

--- a/lib/Service/AuthorizationService.php
+++ b/lib/Service/AuthorizationService.php
@@ -218,7 +218,7 @@ class AuthorizationService
     {
         $token = substr(string: $authorization, offset: strlen('Bearer '));
 
-        if ($token === '' || $token === null) {
+        if ($token === '') {
             throw new AuthenticationException(message: 'No token has been provided', details: []);
         }
 
@@ -343,7 +343,7 @@ class AuthorizationService
 
         $user = $this->userSession->getUser();
 
-        if ($user === false) {
+        if ($user === null) {
             throw new AuthenticationException(message: 'Invalid token', details: []);
         }
 

--- a/lib/Service/ConfigurationHandlers/SynchronizationHandler.php
+++ b/lib/Service/ConfigurationHandlers/SynchronizationHandler.php
@@ -53,9 +53,14 @@ class SynchronizationHandler implements ConfigurationHandlerInterface
     /**
      * Export a synchronization entity to its serialised configuration form.
      *
-     * @param Entity                                                                           $entity     The synchronization entity to export.
-     * @param array<string,array{idToSlug:array<string,string>,slugToId:array<string,string>}> $mappings   The global mappings for ID/slug conversion.
-     * @param array<int, int|string>                                                           $mappingIds Collected mapping ids (out param).
+     * @param Entity                 $entity     The synchronization entity to export.
+     * @param array<string,mixed>    $mappings   The global mappings for ID/slug conversion.
+     *                                           Shape: `[$type => ['idToSlug' => array, 'slugToId' => array]]` where `$type`
+     *                                           is one of `register|schema|source|mapping|action|followUp|condition`. The
+     *                                           inner idToSlug/slugToId arrays are looked up by both int and string keys
+     *                                           at runtime, so the value type is intentionally relaxed to `mixed` for
+     *                                           static-analysis purposes.
+     * @param array<int, int|string> $mappingIds Collected mapping ids (out param).
      *
      * @return array The serialised synchronization configuration.
      */
@@ -187,8 +192,9 @@ class SynchronizationHandler implements ConfigurationHandlerInterface
     /**
      * Import a synchronization configuration into a synchronization entity.
      *
-     * @param array                                                                            $data     The serialised synchronization configuration.
-     * @param array<string,array{idToSlug:array<string,string>,slugToId:array<string,string>}> $mappings The global mappings for ID/slug conversion.
+     * @param array               $data     The serialised synchronization configuration.
+     * @param array<string,mixed> $mappings The global mappings for ID/slug conversion.
+     *                                      See {@see self::export()} for the runtime shape.
      *
      * @return Entity The imported synchronization entity.
      */
@@ -265,8 +271,8 @@ class SynchronizationHandler implements ConfigurationHandlerInterface
             $data['targetSourceMapping'] = $mappings['mapping']['slugToId'][$data['targetSourceMapping']];
         }
 
-        // Convert arrays of slugs back to IDs.
-        $idArrays = ['actions', 'followUps'];
+        // Convert arrays of slugs back to IDs (mirrors $idArrays in export()).
+        $idArrays = ['actions', 'followUps', 'conditions'];
         foreach ($idArrays as $arrayKey) {
             if (isset($data[$arrayKey]) === true && is_array($data[$arrayKey]) === true) {
                 $data[$arrayKey] = array_map(

--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -438,8 +438,6 @@ class EndpointService
     ): array {
         if ($serializedObject === [] && $object !== null) {
             $serializedObject = $object->jsonSerialize();
-        } else if ($serializedObject === null) {
-            return $serializedObject;
         } else {
             $this->objectService->getOpenRegisters()->clearCurrents();
             $object = $mapper->find($serializedObject['id']);
@@ -749,7 +747,7 @@ class EndpointService
 
             $ids = $main[$property];
 
-            if ($ids === null || empty($ids) === true) {
+            if (empty($ids) === true) {
                 $returnArray = [
                     'count'   => 0,
                     'results' => [],

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -290,10 +290,6 @@ class MappingService
                 $cast = explode(',', $cast);
             }
 
-            if ($cast === false) {
-                continue;
-            }
-
             foreach ($cast as $singleCast) {
                 $this->handleCast(dotArray: $dotArray, key: $key, cast: $singleCast);
             }
@@ -320,13 +316,11 @@ class MappingService
             }
         }
 
-        // Ensure output is always an array.
+        // Defensive coercion: prior branches set $output from $dotArray->all() (always array)
+        // or from the # root-level extraction (always array). The is_array() guard is dead
+        // per static analysis but kept for safety against future refactors.
         if (is_array($output) === false) {
-            if ($output === null) {
-                $output = [];
-            } else {
-                $output = [$output];
-            }
+            $output = [];
         }
 
         return $output;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15,11 +15,6 @@ parameters:
 			path: lib/Controller/UserController.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between OCP\\\\IUser and false will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Controller/UserController.php
-
-		-
 			message: "#^Constant OCA\\\\OpenConnector\\\\EventListener\\\\ViewUpdatedOrCreatedEventListener\\:\\:SOFTWARE_CATALOG_REGISTER_ID is unused\\.$#"
 			count: 1
 			path: lib/EventListener/ViewUpdatedOrCreatedEventListener.php
@@ -60,16 +55,6 @@ parameters:
 			path: lib/Service/AuthorizationService.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between OCP\\\\IUser\\|null and false will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/AuthorizationService.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between non\\-empty\\-string and null will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/AuthorizationService.php
-
-		-
 			message: "#^Method OCA\\\\OpenConnector\\\\Service\\\\CallService\\:\\:call\\(\\) should return OCA\\\\OpenRegister\\\\Db\\\\ObjectEntity but returns GuzzleHttp\\\\Promise\\\\PromiseInterface\\.$#"
 			count: 1
 			path: lib/Service/CallService.php
@@ -83,26 +68,6 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between null and 'soap' will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Service/CallService.php
-
-		-
-			message: "#^Offset int on array\\<string, string\\> in isset\\(\\) does not exist\\.$#"
-			count: 2
-			path: lib/Service/ConfigurationHandlers/SynchronizationHandler.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 3
-			path: lib/Service/ConfigurationHandlers/SynchronizationHandler.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between 'actions'\\|'followUps' and 'conditions' will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/ConfigurationHandlers/SynchronizationHandler.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
-			count: 2
-			path: lib/Service/ConfigurationHandlers/SynchronizationHandler.php
 
 		-
 			message: "#^Call to method export\\(\\) on an unknown class OCA\\\\OpenConnector\\\\Service\\\\ConfigurationHandlerInterface\\.$#"
@@ -195,16 +160,6 @@ parameters:
 			path: lib/Service/EndpointService.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array and null will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/EndpointService.php
-
-		-
 			message: "#^Call to method evaluate\\(\\) on an unknown class Symfony\\\\Component\\\\ExpressionLanguage\\\\ExpressionLanguage\\.$#"
 			count: 1
 			path: lib/Service/EventService.php
@@ -243,16 +198,6 @@ parameters:
 			message: "#^Parameter \\$minute of method DateTime\\:\\:setTime\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: lib/Service/JobService.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between \\*NEVER\\* and null will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/MappingService.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/MappingService.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"


### PR DESCRIPTION
PHPStan flagged a cluster of strict-comparison branches that can never execute given the surrounding types. Each is removed or restructured in source; **one was an actual bug**.

## Real bug fixed
- **`SynchronizationHandler::import`** — `\$idArrays = ['actions', 'followUps']` but the inner array_map() also checks for `\$arrayKey === 'conditions'`. The conditions slugs were never re-converted to IDs on import, even though export() does serialise them. Brought `\$idArrays` back in sync with export() by adding `'conditions'`.

## Dead-branch comparisons removed
- `AuthorizationService::authorizeJwt`: `\$token === null` after `substr()` (returns string on PHP 8+; only `=== ''` reachable)
- `AuthorizationService::checkUserGroups`: `\$user === false` after `IUserSession::getUser()` (returns `?IUser`, never bool)
- `UserController::me`: `\$currentUser === false` (same issue)
- `EndpointService` line 441: `else if (\$serializedObject === null)` on a parameter typed `array` (drop the dead branch)
- `EndpointService` line 750: simplified `\$ids === null || empty(\$ids)` to just `empty(\$ids)`
- `MappingService::executeMappingLocal`: `\$cast === false` after `explode()` (never returns false on PHP 8+); collapsed nested dead `is_array(\$output) === false` block to a single defensive fallback with comment

## Docblock relaxation
- `SynchronizationHandler::export` / `::import` — `\$mappings` phpdoc relaxed from `array<string,array{idToSlug:array<string,string>,slugToId:array<string,string>}>` to `array<string,mixed>` with prose comment about runtime shape. The narrow shape made phpstan declare `isset(\$mappings['mapping']['idToSlug'][(int)…])` always false (int key on string-keyed array), even though PHP coerces those at runtime.

## Baseline progress
- Before: 83 entries (after #932)
- After:  72 entries (-11)

## Verification
- `phpstan analyse` -> `[OK] No errors` with regenerated baseline
- `phpcs lib/` -> 0 errors