### PR TITLE
fix(icons): restore pre-refactor TextBoxOutline for 'View logs' actions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,13 @@ import bundledManifest from './manifest.json'
 import customComponents from './registry.js'
 import { setRouter } from './handlers/routerRef.js'
 
+// MDI icons referenced by manifest `headerActions[]` / `actions[]` /
+// `menu[]` entries. CnActionsBar renders them via CnIcon, which reads
+// from the per-app registry below. Anything NOT registered here falls
+// back to HelpCircleOutline (the `?` placeholder) at render time. Keep
+// in PascalCase, matching the file-name in vue-material-design-icons/.
+import TextBoxOutline from 'vue-material-design-icons/TextBoxOutline.vue'
+
 // Library CSS — must be an explicit import (webpack tree-shakes side-effect imports from aliased packages)
 import '@conduction/nextcloud-vue/css/index.css'
 
@@ -29,7 +36,9 @@ Vue.use(PiniaVuePlugin)
 Vue.use(VueRouter)
 
 // Register library-side icon set + lib translations once at bootstrap.
-registerIcons()
+registerIcons({
+	TextBoxOutline,
+})
 try {
 	registerTranslations()
 } catch (e) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -144,11 +144,11 @@
         "includeFields": ["name", "description", "type", "isEnabled"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "headerActions": [
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SourceLogs" }
+          { "id": "view-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "navigate", "route": "SourceLogs" }
         ],
         "actions": [
           { "id": "test", "label": "Test connection", "icon": "icon-checkmark", "handler": "testSourceHandler" },
-          { "id": "view-source-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" }
+          { "id": "view-source-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "viewLogsHandler" }
         ]
       }
     },
@@ -184,11 +184,11 @@
         "includeFields": ["name", "description", "endpoint", "method", "targetType"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "headerActions": [
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "EndpointLogs" }
+          { "id": "view-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "navigate", "route": "EndpointLogs" }
         ],
         "actions": [
           { "id": "add-rule", "label": "Add rule", "icon": "icon-add", "handler": "addEndpointRuleHandler" },
-          { "id": "view-endpoint-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" }
+          { "id": "view-endpoint-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "viewLogsHandler" }
         ]
       }
     },
@@ -263,12 +263,12 @@
         },
         "sidebar": { "enabled": true, "showMetadata": true },
         "headerActions": [
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "JobLogs" }
+          { "id": "view-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "navigate", "route": "JobLogs" }
         ],
         "actions": [
           { "id": "run", "label": "Run now", "icon": "icon-play", "handler": "runJobHandler" },
           { "id": "test", "label": "Test (dry run)", "icon": "icon-checkmark", "handler": "testJobHandler" },
-          { "id": "view-job-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" }
+          { "id": "view-job-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "viewLogsHandler" }
         ]
       },
       "slots": {
@@ -349,14 +349,14 @@
         "sidebar": { "enabled": true, "showMetadata": true },
         "rowAction": { "id": "edit", "handler": "navigate", "route": "SynchronizationDetail", "params": { "id": "{id}" } },
         "headerActions": [
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "SynchronizationLogs" },
+          { "id": "view-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "navigate", "route": "SynchronizationLogs" },
           { "id": "view-contracts", "label": "View contracts", "icon": "icon-file", "handler": "navigate", "route": "SynchronizationContracts" }
         ],
         "actions": [
           { "id": "edit", "label": "Open editor", "icon": "icon-edit", "handler": "navigate", "route": "SynchronizationDetail", "params": { "id": "{id}" } },
           { "id": "run", "label": "Run now", "icon": "icon-play", "handler": "runSynchronizationHandler" },
           { "id": "test", "label": "Test (dry run)", "icon": "icon-checkmark", "handler": "testSynchronizationHandler" },
-          { "id": "view-synchronization-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" },
+          { "id": "view-synchronization-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "viewLogsHandler" },
           { "id": "view-contracts", "label": "View contracts", "icon": "icon-file", "handler": "navigate", "route": "SynchronizationContracts" }
         ]
       }
@@ -406,10 +406,10 @@
         "includeFields": ["source", "type", "subject", "data"],
         "sidebar": { "enabled": true, "showMetadata": true },
         "headerActions": [
-          { "id": "view-logs", "label": "View logs", "icon": "icon-history", "handler": "navigate", "route": "CloudEventLogs" }
+          { "id": "view-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "navigate", "route": "CloudEventLogs" }
         ],
         "actions": [
-          { "id": "view-cloud-event-logs", "label": "View logs", "icon": "icon-history", "handler": "viewLogsHandler" }
+          { "id": "view-cloud-event-logs", "label": "View logs", "icon": "TextBoxOutline", "handler": "viewLogsHandler" }
         ]
       }
     },


### PR DESCRIPTION
## Why

User screenshot showed the Actions overflow menu with 'View logs' rendering a tiny back-curved-arrow icon that didn't size-match the neighbouring Refresh / Import / Export (all 20px MDI). Plus the user remembered a different icon being used pre-refactor.

## Root cause

The manifest entries used `"icon": "icon-history"` (a Nextcloud CSS class). CnActionsBar's icon resolver routes `icon-*` strings through a plain `<span class=...>` (Nextcloud built-in CSS icon set), NOT through CnIcon — so the rendered glyph sized differently from the surrounding MDI components.

Pre-refactor (chain-D and earlier, `src/navigation/MainMenu.vue`) every `Logs` nav item used MDI `TextBoxOutline` (document with horizontal text lines) — semantically right for log entries and visually consistent. The `icon-history` was a post-cutover regression introduced in #875 / #934.

## Fix

- Switch all 5 `headerActions[]` + 5 row `actions[]` view-logs entries in `src/manifest.json` from `icon-history` → `TextBoxOutline`
- Import `TextBoxOutline` in `src/main.js` and pass it to `registerIcons({})` so CnIcon's per-app registry can resolve it. Without registration the fallback is `HelpCircleOutline` (the '?' placeholder)

## Verified

Bundle deployed to dev container, icon now renders consistently with Refresh / Import / Export at 20px and matches the pre-refactor look user remembered.

Bundle size unchanged (one new icon imports ~1KB compressed).