### PR TITLE
feat(menu): restore pre-refactor MDI icons across the nav menu

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -19,11 +19,28 @@ import customComponents from './registry.js'
 import { setRouter } from './handlers/routerRef.js'
 
 // MDI icons referenced by manifest `headerActions[]` / `actions[]` /
-// `menu[]` entries. CnActionsBar renders them via CnIcon, which reads
-// from the per-app registry below. Anything NOT registered here falls
-// back to HelpCircleOutline (the `?` placeholder) at render time. Keep
-// in PascalCase, matching the file-name in vue-material-design-icons/.
+// `menu[]` entries. CnActionsBar + CnAppNav render them via CnIcon,
+// which reads from the per-app registry below. Anything NOT registered
+// here falls back to HelpCircleOutline (the `?` placeholder) at render
+// time. Keep in PascalCase, matching the file-name in
+// vue-material-design-icons/.
+//
+// Menu icons restore the pre-chain-E set (the chain-E manifest cutover
+// swapped them all to `icon-*` Nextcloud CSS classes which lost the
+// semantic specificity and didn't size-match the rest of the chrome).
+import AccountMultipleOutline from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import Api from 'vue-material-design-icons/Api.vue'
+import BookOpenVariant from 'vue-material-design-icons/BookOpenVariant.vue'
+import CloudUploadOutline from 'vue-material-design-icons/CloudUploadOutline.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
+import DatabaseArrowLeftOutline from 'vue-material-design-icons/DatabaseArrowLeftOutline.vue'
+import Finance from 'vue-material-design-icons/Finance.vue'
+import ScaleBalance from 'vue-material-design-icons/ScaleBalance.vue'
+import SitemapOutline from 'vue-material-design-icons/SitemapOutline.vue'
 import TextBoxOutline from 'vue-material-design-icons/TextBoxOutline.vue'
+import Update from 'vue-material-design-icons/Update.vue'
+import VectorPolylinePlus from 'vue-material-design-icons/VectorPolylinePlus.vue'
+import Webhook from 'vue-material-design-icons/Webhook.vue'
 
 // Library CSS — must be an explicit import (webpack tree-shakes side-effect imports from aliased packages)
 import '@conduction/nextcloud-vue/css/index.css'
@@ -37,7 +54,19 @@ Vue.use(VueRouter)
 
 // Register library-side icon set + lib translations once at bootstrap.
 registerIcons({
+	AccountMultipleOutline,
+	Api,
+	BookOpenVariant,
+	CloudUploadOutline,
+	Cog,
+	DatabaseArrowLeftOutline,
+	Finance,
+	ScaleBalance,
+	SitemapOutline,
 	TextBoxOutline,
+	Update,
+	VectorPolylinePlus,
+	Webhook,
 })
 try {
 	registerTranslations()

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,77 +8,77 @@
     {
       "id": "Dashboard",
       "label": "Dashboard",
-      "icon": "icon-category-dashboard",
+      "icon": "Finance",
       "route": "Dashboard",
       "order": 10
     },
     {
       "id": "Sources",
       "label": "Sources",
-      "icon": "icon-link",
+      "icon": "DatabaseArrowLeftOutline",
       "route": "Sources",
       "order": 20
     },
     {
       "id": "Endpoints",
       "label": "Endpoints",
-      "icon": "icon-category-integration",
+      "icon": "Api",
       "route": "Endpoints",
       "order": 30
     },
     {
       "id": "Consumers",
       "label": "Consumers",
-      "icon": "icon-group",
+      "icon": "AccountMultipleOutline",
       "route": "Consumers",
       "order": 40
     },
     {
       "id": "Webhooks",
       "label": "Webhooks",
-      "icon": "icon-mail",
+      "icon": "Webhook",
       "route": "Webhooks",
       "order": 50
     },
     {
       "id": "Jobs",
       "label": "Jobs",
-      "icon": "icon-category-workflow",
+      "icon": "Update",
       "route": "Jobs",
       "order": 60
     },
     {
       "id": "Mappings",
       "label": "Mappings",
-      "icon": "icon-category-customization",
+      "icon": "SitemapOutline",
       "route": "Mappings",
       "order": 70
     },
     {
       "id": "Rules",
       "label": "Rules",
-      "icon": "icon-toggle",
+      "icon": "ScaleBalance",
       "route": "Rules",
       "order": 80
     },
     {
       "id": "Synchronizations",
       "label": "Synchronizations",
-      "icon": "icon-history",
+      "icon": "VectorPolylinePlus",
       "route": "Synchronizations",
       "order": 90
     },
     {
       "id": "CloudEvents",
       "label": "Cloud events",
-      "icon": "icon-category-monitoring",
+      "icon": "CloudUploadOutline",
       "route": "CloudEvents",
       "order": 100
     },
     {
       "id": "Documentation",
       "label": "Documentation",
-      "icon": "icon-info",
+      "icon": "BookOpenVariant",
       "href": "https://openconnector.conduction.nl",
       "section": "settings",
       "order": 15
@@ -86,7 +86,7 @@
     {
       "id": "Settings",
       "label": "Settings",
-      "icon": "icon-settings",
+      "icon": "Cog",
       "route": "AppSettings",
       "section": "settings",
       "order": 20


### PR DESCRIPTION
Chain-E's manifest cutover replaced all menu icons with Nextcloud `icon-*` CSS classes which lost semantic specificity and didn't size-match the rest of the chrome. Two icons were also outright wrong (Webhooks got an envelope; Sources got a generic chain link).

## Mapping (12 items)

| Item | Before | After | Note |
|---|---|---|---|
| Dashboard | `icon-category-dashboard` | `Finance` | restore (bar-chart) |
| Sources | `icon-link` | `DatabaseArrowLeftOutline` | restore (data into DB) |
| Endpoints | `icon-category-integration` | `Api` | restore |
| Consumers | `icon-group` | `AccountMultipleOutline` | upgrade (pre-refactor Webhook was wrong) |
| Webhooks | `icon-mail` | `Webhook` | **fix — envelope was a regression** |
| Jobs | `icon-category-workflow` | `Update` | restore (rotation arrow) |
| Mappings | `icon-category-customization` | `SitemapOutline` | restore (field tree) |
| Rules | `icon-toggle` | `ScaleBalance` | upgrade (pre-refactor was a SitemapOutline duplicate of Mappings; ScaleBalance conveys 'rule of judgment') |
| Synchronizations | `icon-history` | `VectorPolylinePlus` | restore (connected systems) |
| Cloud events | `icon-category-monitoring` | `CloudUploadOutline` | restore |
| Documentation | `icon-info` | `BookOpenVariant` | upgrade |
| Settings | `icon-settings` | `Cog` | restore |

## Registration

Imported + registered all 13 icons (12 menu + `TextBoxOutline` from #938) in `src/main.js` via `registerIcons({...})` so CnIcon's per-app registry can resolve them. Without registration the fallback is `HelpCircleOutline` (the '?' placeholder).

## Verified

Bundle deployed to dev container; menu icons now render at consistent 20px with the proper semantic glyphs.

Bundle size delta: +12KB compressed (~1KB per vue-material-design-icons component).