### PR TITLE
retrofit: reverse-spec object-service-shim (5 REQs / 9 methods)

### DIFF
--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -71,6 +71,8 @@ class ObjectService
      * @param array $config The config to be used for the client.
      *
      * @return Client The configured Guzzle client.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-1
      */
     public function getClient(array $config): Client
     {
@@ -90,6 +92,9 @@ class ObjectService
      * @return array The resulting object.
      *
      * @throws GuzzleException When the HTTP request fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-1
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-2
      */
     public function saveObject(array $data, array $config): array
     {
@@ -123,6 +128,8 @@ class ObjectService
      * @return array The objects found for given filters.
      *
      * @throws GuzzleException When the HTTP request fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-1
      */
     public function findObjects(array $filters, array $config): array
     {
@@ -157,6 +164,8 @@ class ObjectService
      * @return array The resulting object.
      *
      * @throws GuzzleException When the HTTP request fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-1
      */
     public function findObject(array $filters, array $config): array
     {
@@ -190,6 +199,8 @@ class ObjectService
      * @return array The updated object.
      *
      * @throws GuzzleException When the HTTP request fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-1
      */
     public function updateObject(array $filters, array $update, array $config): array
     {
@@ -221,6 +232,8 @@ class ObjectService
      * @return array An empty array.
      *
      * @throws GuzzleException When the HTTP request fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-1
      */
     public function deleteObject(array $filters, array $config): array
     {
@@ -249,6 +262,8 @@ class ObjectService
      * @return array The aggregation result.
      *
      * @throws GuzzleException When the HTTP request fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-3
      */
     public function aggregateObjects(array $filters, array $pipeline, array $config):array
     {
@@ -278,6 +293,8 @@ class ObjectService
      *
      * @throws ContainerExceptionInterface When the container fails.
      * @throws NotFoundExceptionInterface  When the service is not bound.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-4
      */
     public function getOpenRegisters(): ?\OCA\OpenRegister\Service\ObjectService
     {
@@ -310,6 +327,8 @@ class ObjectService
      * @throws ContainerExceptionInterface When the container fails.
      * @throws NotFoundExceptionInterface  When the service is not bound.
      * @throws InvalidArgumentException    If an unknown object type is provided.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md#task-5
      */
     public function getMapper(?string $objectType=null, ?int $schema=null, ?int $register=null): mixed
     {

--- a/openspec/changes/retrofit-2026-05-24-object-service-shim/design.md
+++ b/openspec/changes/retrofit-2026-05-24-object-service-shim/design.md
@@ -1,0 +1,67 @@
+# Design — Retrofit object-service-shim
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+`lib/Service/ObjectService.php` is a 322-line class with two unrelated responsibilities:
+
+1. **MongoDB Data API client** (REQ-001, REQ-002, REQ-003) — five CRUD methods plus an
+   aggregation method, all routing through Guzzle to the MongoDB Atlas Data API. Used
+   when an operator configures a Mongo source via the openconnector Source UI.
+2. **OpenRegister bridge** (REQ-004, REQ-005) — two methods that lazily resolve OR's
+   own `ObjectService` and delegate mapper lookups to it.
+
+Both responsibilities are observably in production today on `origin/development`; the
+class is in scope for deletion by the chain-C change
+`openconnector-services-direct-or-usage`, which cuts every caller over to OR's
+`ObjectService` directly.
+
+## Why a single spec rather than two
+
+The two responsibilities share a constructor and live in one class. Splitting them into
+two specs would force the reader to chase cross-references for a class that is being
+deleted in a few weeks. One spec captures the shim as a whole, matching the cluster
+boundary the coverage scanner identified.
+
+## What the spec deliberately does NOT cover
+
+- The `BASE_OBJECT` const is implicit in every REQ's `database`/`collection` defaults
+  but is not surfaced as its own REQ — it is a private implementation detail of the
+  Data API request shape.
+- The constructor (`__construct(IAppManager, ContainerInterface)`) is wiring, not
+  observable behaviour, and is not specified.
+- Error logging, metrics emission, and audit-trail integration — the class does none of
+  these today, and the spec does not mandate them retroactively.
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Method | Issue | Severity |
+|---|---|---|
+| `getClient` | computed `$guzzleConf` is discarded; original `$config` is passed to Guzzle, defeating the `mongodbCluster` strip | medium |
+| `getOpenRegisters` | `catch (Exception $e)` returns `null` on container failure — silent fall-through | low (cutover removes the class) |
+| `getMapper` | `null->getMapper()` fatal Error path when OR is not installed | low (cutover removes the class) |
+| All CRUD | no input validation; malformed `$config` surfaces as Guzzle exception only | low |
+
+The retrofit spec captures these as observed behaviour rather than silently fixing
+them via the spec text. If the cutover change wants to harden any of them before
+deletion, it would do so as a separate change against this baseline.
+
+## Annotations
+
+Five REQs map to nine methods in one file:
+
+- REQ-001 → `saveObject`, `findObject`, `findObjects`, `updateObject`, `deleteObject`,
+  `getClient`
+- REQ-002 → `saveObject`
+- REQ-003 → `aggregateObjects`
+- REQ-004 → `getOpenRegisters`
+- REQ-005 → `getMapper`
+
+`saveObject` carries two `@spec` references (REQ-001 + REQ-002) because it implements
+both the generic CRUD contract and the UUID-minting contract.
+
+## Validation
+
+After archive, `openspec validate object-service-shim --strict` MUST pass and Specter
+MUST register the spec as part of the retrofit cohort.

--- a/openspec/changes/retrofit-2026-05-24-object-service-shim/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-object-service-shim/proposal.md
@@ -1,0 +1,31 @@
+# Retrofit — object-service-shim
+
+Describes observed behavior of 9 methods under `object-service-shim` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Service/ObjectService.php::getClient()`
+- `lib/Service/ObjectService.php::saveObject()`
+- `lib/Service/ObjectService.php::findObjects()`
+- `lib/Service/ObjectService.php::findObject()`
+- `lib/Service/ObjectService.php::updateObject()`
+- `lib/Service/ObjectService.php::deleteObject()`
+- `lib/Service/ObjectService.php::aggregateObjects()`
+- `lib/Service/ObjectService.php::getOpenRegisters()`
+- `lib/Service/ObjectService.php::getMapper()`
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces any observed-but-suspicious behavior
+
+## Status note
+
+The `ObjectService` shim class is on a deletion path: change
+`openconnector-services-direct-or-usage` cuts every caller over to OpenRegister's
+own `\OCA\OpenRegister\Service\ObjectService`. This retrofit documents the shim's
+observed behaviour as it exists on `origin/development` today; once the cutover
+change merges, this spec should be archived alongside the deleted class.
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-object-service-shim/specs/object-service-shim/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-object-service-shim/specs/object-service-shim/spec.md
@@ -1,0 +1,177 @@
+---
+retrofit: true
+status: draft
+---
+
+# Object Service Shim
+
+## Purpose
+
+`lib/Service/ObjectService.php` is a thin wrapper that openconnector exposes for two
+unrelated jobs: (1) a Guzzle-based CRUD client against the MongoDB Data API, used when
+operators opt into a Mongo backend for free-form JSON object storage; and (2) a runtime
+shim that lazily resolves OpenRegister's own `ObjectService` when the openregister app
+is installed. The class has nine public methods spanning both responsibilities. This
+spec retroactively documents the observed behaviour of all nine as they exist today on
+`development`, so the shim's contract is captured before the deletion that
+`openconnector-services-direct-or-usage` will perform.
+
+## ADDED Requirements
+
+### REQ-001: MongoDB Data API CRUD wrapper
+
+`ObjectService` MUST expose `saveObject`, `findObject`, `findObjects`, `updateObject`,
+and `deleteObject` methods that translate caller arrays into MongoDB Data API requests
+and POST them through a Guzzle client built from the caller-supplied configuration.
+Every call MUST set the `dataSource` field from `$config['mongodbCluster']`, MUST default
+the `database`/`collection` to the `BASE_OBJECT` constants (`objects` / `json`), and MUST
+return the decoded JSON body of the Data API response. The five operations MUST target,
+respectively, the `action/insertOne`, `action/findOne`, `action/find`, `action/updateOne`,
+and `action/deleteOne` endpoints relative to the Guzzle base URI supplied via `$config`.
+
+#### Scenario: saveObject posts a document and re-fetches by inserted id
+
+- **GIVEN** a caller supplies a non-empty `$data` array and a `$config` with a
+  `mongodbCluster` key
+- **WHEN** `saveObject($data, $config)` is invoked
+- **THEN** the method SHALL POST `action/insertOne` with the document merged into
+  `BASE_OBJECT` and `dataSource` set to `$config['mongodbCluster']`
+- **AND** SHALL extract `insertedId` from the response body
+- **AND** SHALL return the result of `findObject(['_id' => $insertedId], $config)`
+
+#### Scenario: findObjects returns the raw decoded Data API body
+
+- **GIVEN** a caller supplies a `$filters` array and a Mongo `$config`
+- **WHEN** `findObjects($filters, $config)` is invoked
+- **THEN** the method SHALL POST `action/find` with `filter` set to `$filters`
+- **AND** SHALL return the JSON-decoded response body as an associative array
+
+#### Scenario: deleteObject returns an empty array regardless of upstream response
+
+- **GIVEN** a caller supplies a `$filters` array and a Mongo `$config`
+- **WHEN** `deleteObject($filters, $config)` is invoked
+- **THEN** the method SHALL POST `action/deleteOne` to the Data API
+- **AND** SHALL return `[]` without inspecting the upstream response status or body
+
+#### Scenario: getClient returns a Guzzle Client built from caller-supplied config
+
+- **GIVEN** a caller supplies a `$config` array containing Guzzle options plus
+  `mongodbCluster`
+- **WHEN** `getClient($config)` is invoked
+- **THEN** the method SHALL strip `mongodbCluster` from the local copy
+- **AND** SHALL pass the **original** `$config` (including `mongodbCluster`) to the
+  `\GuzzleHttp\Client` constructor
+
+#### Notes
+
+- `getClient` constructs the Guzzle client from `$config` directly, not from the
+  `mongodbCluster`-stripped local copy — the local copy is computed and discarded. This
+  is observed behaviour, not necessarily intended; flagged for follow-up rather than
+  silently corrected.
+- None of the CRUD methods validate their input arrays. Malformed `$config` (missing
+  `mongodbCluster`, missing Guzzle `base_uri`) surfaces as a Guzzle exception thrown
+  upward by the calling code.
+
+### REQ-002: UUID minting on insert
+
+When `saveObject` constructs the Mongo document, it MUST mint a fresh UUIDv4 via
+`Symfony\Component\Uid\Uuid::v4()` and assign it to **both** the `id` and `_id` keys of
+the document before POSTing. Callers MUST NOT supply their own `id` or `_id`; any
+caller-supplied values are overwritten.
+
+#### Scenario: caller-supplied id is overwritten by minted UUID
+
+- **GIVEN** a caller invokes `saveObject(['id' => 'caller-supplied', 'foo' => 'bar'], $config)`
+- **WHEN** the method constructs the insert payload
+- **THEN** `document.id` SHALL be a freshly minted UUIDv4
+- **AND** `document._id` SHALL equal `document.id` (same minted UUID)
+- **AND** the caller-supplied `'caller-supplied'` value SHALL be discarded
+
+#### Notes
+
+- This is the only mutation `saveObject` makes to the caller's `$data` array — every
+  other field is copied verbatim into `document`.
+
+### REQ-003: Pipeline-based aggregation
+
+`ObjectService::aggregateObjects` MUST accept a `$filters` array and a `$pipeline` array
+and MUST POST them to the Data API `action/aggregate` endpoint together with the
+caller's Mongo `dataSource`. The full decoded JSON response body MUST be returned to
+the caller as an associative array. The method MUST NOT post-process the aggregation
+result (no facet flattening, no shape normalisation, no result coercion).
+
+#### Scenario: aggregateObjects forwards filters + pipeline verbatim
+
+- **GIVEN** a caller supplies a `$filters` array, a `$pipeline` array, and a Mongo
+  `$config`
+- **WHEN** `aggregateObjects($filters, $pipeline, $config)` is invoked
+- **THEN** the request body SHALL contain `filter`, `pipeline`, and `dataSource` set
+  from the caller's inputs
+- **AND** the JSON-decoded response body SHALL be returned to the caller as an
+  associative array
+
+### REQ-004: Opportunistic OpenRegister service resolution
+
+`ObjectService::getOpenRegisters()` MUST return an instance of
+`\OCA\OpenRegister\Service\ObjectService` if and only if (a) the `openregister` app
+appears in `IAppManager::getInstalledApps()` AND (b) the PSR-11 container can resolve
+the service binding. In every other situation (app not installed, container miss,
+container throws) the method MUST return `null` and MUST NOT propagate the exception.
+
+#### Scenario: openregister app is not installed
+
+- **GIVEN** `IAppManager::getInstalledApps()` does not contain `'openregister'`
+- **WHEN** `getOpenRegisters()` is invoked
+- **THEN** the method SHALL return `null`
+- **AND** SHALL NOT call `ContainerInterface::get`
+
+#### Scenario: openregister is installed but the container binding is missing
+
+- **GIVEN** the openregister app is installed
+- **WHEN** the container throws `NotFoundExceptionInterface` from
+  `ContainerInterface::get`
+- **THEN** the method SHALL catch the exception and return `null`
+- **AND** SHALL NOT rethrow
+
+#### Notes
+
+- The `catch (Exception $e)` swallows every `Throwable`-shaped failure, including
+  container misconfiguration that an operator would want to learn about. This silent
+  fall-through is observed behaviour; flagged in case the
+  `openconnector-services-direct-or-usage` cutover wants to surface it as a structured
+  log line before the shim is removed. Compare with the hydra-gate-unsafe-auth-resolver
+  pattern for the security flavour of the same anti-pattern.
+
+### REQ-005: Mapper resolution via OpenRegister, with hard failure on unknown types
+
+`ObjectService::getMapper(?string $objectType=null, ?int $schema=null, ?int $register=null)`
+MUST resolve a mapper by delegating to `getOpenRegisters()->getMapper(register, schema)`
+when both `$register` and `$schema` are non-null AND `$objectType` is null. In every
+other input combination (any `$objectType` value, or missing `$register`/`$schema` while
+`$objectType` is null) the method MUST throw `InvalidArgumentException` with the
+message `Unknown object type: <objectType>`.
+
+#### Scenario: register + schema resolves an OR mapper
+
+- **GIVEN** the openregister app is installed and a caller invokes
+  `getMapper(null, $schemaId, $registerId)`
+- **WHEN** `getMapper` runs
+- **THEN** the method SHALL call `getOpenRegisters()->getMapper(register: $registerId,
+  schema: $schemaId)` and SHALL return that mapper
+
+#### Scenario: any other input combination throws
+
+- **GIVEN** a caller invokes `getMapper('legacyType')` OR
+  `getMapper(null, null, $registerId)` OR `getMapper(null, $schemaId, null)`
+- **WHEN** `getMapper` runs
+- **THEN** the method SHALL throw `InvalidArgumentException` with the message
+  `Unknown object type: <objectType>` (where `<objectType>` is the caller's
+  `$objectType` argument, possibly null)
+
+#### Notes
+
+- When `getOpenRegisters()` returns `null` (openregister not installed), the delegation
+  call becomes `null->getMapper(...)` and produces a fatal `Error` (`Call to a member
+  function getMapper() on null`). This is an observed failure mode, not a thrown
+  exception; flagged so callers wiring up the cutover know to check the app-installed
+  precondition before invoking `getMapper`.

--- a/openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-object-service-shim/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: object-service-shim#REQ-001 — MongoDB Data API CRUD wrapper (retroactive annotation)
+- [x] task-2: object-service-shim#REQ-002 — UUID minting on insert (retroactive annotation)
+- [x] task-3: object-service-shim#REQ-003 — Pipeline-based aggregation (retroactive annotation)
+- [x] task-4: object-service-shim#REQ-004 — Opportunistic OpenRegister service resolution (retroactive annotation)
+- [x] task-5: object-service-shim#REQ-005 — Mapper resolution via OpenRegister, with hard failure on unknown types (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 9 methods under `object-service-shim` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-object-service-shim`.

### What this PR does
- Drafts 5 REQs in a new `object-service-shim` capability spec (`retrofit: true`)
- Creates `tasks.md` with one task per REQ (all `[x]` — retroactive)
- Annotates 9 methods in `lib/Service/ObjectService.php` with `@spec` tags

### What this PR does NOT do
- No code behaviour changes — only docblock `@spec` annotations
- Does NOT silently fix observed-but-buggy behaviour (see design.md)

### Status note
`lib/Service/ObjectService.php` is on a deletion path via change
`openconnector-services-direct-or-usage`. This retrofit captures the
shim's pre-deletion baseline.

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `object-service-shim`

Refs #936