### PR TITLE
retrofit: reverse-spec authorization-jwt (5 REQs / 9 methods)

### DIFF
--- a/lib/Service/AuthorizationService.php
+++ b/lib/Service/AuthorizationService.php
@@ -88,6 +88,8 @@ class AuthorizationService
      * @return ObjectEntity The consumer for the JWT token.
      *
      * @throws AuthenticationException Thrown if no issuer was found.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-1
      */
     private function findIssuer(string $issuer): ObjectEntity
     {
@@ -115,6 +117,8 @@ class AuthorizationService
      * @param JWS $token The unserialized token.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-1
      */
     private function checkHeaders(JWS $token): void
     {
@@ -138,6 +142,8 @@ class AuthorizationService
      * @return JWKSet The resulting JWK-set.
      *
      * @throws AuthenticationException If the algorithm is not supported.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-1
      */
     private function getJWK(string $publicKey, string $algorithm): JWKSet
     {
@@ -175,6 +181,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException If the token is missing/expired.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-1
      */
     public function validatePayload(array $payload): void
     {
@@ -213,6 +221,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException On any validation failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-1
      */
     public function authorizeJwt(string $authorization): void
     {
@@ -282,6 +292,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException On invalid credentials.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-2
      */
     public function authorizeBasic(string $header, array $users, array $groups): void
     {
@@ -324,6 +336,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException On invalid tokens.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-3
      */
     public function authorizeOAuth(string $header, array $users, array $groups): void
     {
@@ -370,6 +384,8 @@ class AuthorizationService
      * @return Response The updated response.
      *
      * @throws SecurityException If Allow-Credentials is true.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-5
      */
     public function corsAfterController(IRequest $request, Response $response)
     {
@@ -401,6 +417,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException On invalid API keys.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-4
      */
     public function authorizeApiKey(string $header, array $keys): void
     {

--- a/openspec/changes/retrofit-2026-05-24-authorization-jwt/design.md
+++ b/openspec/changes/retrofit-2026-05-24-authorization-jwt/design.md
@@ -1,0 +1,56 @@
+# Design — Retrofit authorization-jwt
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+`lib/Service/AuthorizationService.php` is openconnector's authorization handler for
+incoming endpoint requests. It supports four authorization schemes plus CORS header
+injection, all in one class. Endpoint rules in the rule pipeline (cluster
+`rule-pipeline`, REQ retro-spec pending) decide which scheme to invoke and supply the
+relevant configuration. This spec captures the observed contract of every public
+method plus the four private JWT helpers that have non-trivial behaviour worth pinning.
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `authorizeJwt::AlgorithmManager` | lists `HS256` twice, never instantiates `HS512`; `HMAC_ALGORITHMS` lies about HS512 support | high (potential auth-bypass surface inversion) |
+| `getJWK::tmpfile` | writes RSA/PSS public key to `/var/tmp/publickey-<microtime><pid>` between `file_put_contents` and `unlink` | low (public key, not private) |
+| `findIssuer` | returns first match; no ambiguity check on duplicate consumer names | medium |
+| `authorizeBasic` | `$users` / `$groups` allow-list block is commented out; any authenticated NC user passes | medium |
+| `authorizeOAuth` | `$users` / `$groups` allow-list block is commented out (same as above) | medium |
+| `authorizeOAuth::str_starts_with('Bearer')` | accepts `Bearertoken-no-space` | low |
+| `corsAfterController` | echoes any request `Origin` back; no allow-list | by-design but noteworthy |
+
+These are documented in REQ Notes rather than silently fixed via spec text. Any
+hardening would land as a separate change against this retrofit baseline.
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `authorizeJwt` + private helpers `findIssuer`, `checkHeaders`, `getJWK`, `validatePayload` |
+| REQ-002 | `authorizeBasic` |
+| REQ-003 | `authorizeOAuth` |
+| REQ-004 | `authorizeApiKey` |
+| REQ-005 | `corsAfterController` |
+
+The four private helpers are annotated with the same `@spec` task-1 tag as
+`authorizeJwt` because they are only reachable from `authorizeJwt` and their
+contracts collapse into REQ-001's payload/signature/header semantics.
+
+## What the spec deliberately does NOT cover
+
+- Constructor wiring (`__construct(IUserManager, IUserSession, ObjectService)`) is
+  not specified — it is DI plumbing, not observable behaviour.
+- The `HMAC_ALGORITHMS` / `PKCS1_ALGORITHMS` / `PSS_ALGORITHMS` consts are referenced
+  in the REQ but not specified as their own REQ — they are private helpers to
+  `getJWK` and `checkHeaders`.
+- Rate limiting, retry semantics, audit logging — not in this class today; spec
+  does not retroactively mandate them.
+
+## Validation
+
+After archive, `openspec validate authorization-jwt --strict` MUST pass and Specter
+MUST register the spec as part of the retrofit cohort.

--- a/openspec/changes/retrofit-2026-05-24-authorization-jwt/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-authorization-jwt/proposal.md
@@ -1,0 +1,23 @@
+# Retrofit — authorization-jwt
+
+Describes observed behavior of 9 methods under `authorization-jwt` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Service/AuthorizationService.php::authorizeJwt()`
+- `lib/Service/AuthorizationService.php::authorizeBasic()`
+- `lib/Service/AuthorizationService.php::authorizeOAuth()`
+- `lib/Service/AuthorizationService.php::authorizeApiKey()`
+- `lib/Service/AuthorizationService.php::corsAfterController()`
+- `lib/Service/AuthorizationService.php::validatePayload()` (private helper of authorizeJwt)
+- `lib/Service/AuthorizationService.php::findIssuer()` (private helper of authorizeJwt)
+- `lib/Service/AuthorizationService.php::checkHeaders()` (private helper of authorizeJwt)
+- `lib/Service/AuthorizationService.php::getJWK()` (private helper of authorizeJwt)
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces observed-but-suspicious behavior (commented-out user/group checks, temp-file public key writes, duplicate HS256 in algorithm manager)
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-authorization-jwt/specs/authorization-jwt/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-authorization-jwt/specs/authorization-jwt/spec.md
@@ -1,0 +1,239 @@
+---
+retrofit: true
+status: draft
+---
+
+# Authorization (JWT, Basic, OAuth, API key, CORS)
+
+## Purpose
+
+`lib/Service/AuthorizationService.php` is the entry point for every authorization
+flavour openconnector accepts on incoming endpoint requests. It supports four
+distinct authorization schemes — JWT Bearer (signature-verified via consumer-registered
+public keys), HTTP Basic, OAuth bearer (session-backed), and API key (header-to-uid
+map) — and additionally injects CORS response headers. Endpoint rules in the rule
+pipeline (`EndpointService::processAuthenticationRule`) decide which scheme applies
+to a given request and call into this service with the relevant configuration.
+
+This spec retroactively documents the observed behaviour of every public authorization
+method, plus the four private helpers that make the JWT path work.
+
+## ADDED Requirements
+
+### REQ-001: JWT Bearer authorization with consumer-registered public keys
+
+`authorizeJwt(string $authorization)` MUST extract the JWT from the `Bearer ` prefix,
+unserialize it via JWS compact serialization, and verify the signature using a JWK
+built from the issuer consumer's `authorizationConfiguration.publicKey` /
+`authorizationConfiguration.algorithm`. The issuer (`iss` claim) MUST be resolved by
+querying the openconnector `consumer` schema in OR via `ObjectService::findAll`.
+Supported algorithms are HS256/HS384/HS512 (HMAC), RS256/RS384/RS512 (PKCS#1), and
+PS256/PS384/PS512 (PSS). On every failure path the method MUST throw
+`AuthenticationException` with a non-empty `message` and a `details` array that names
+the failure mode (no issuer, issuer not found, header algorithm rejected, signature
+mismatch, token expired). On success the method MUST set the Nextcloud user session
+to the consumer's configured `userId`.
+
+#### Scenario: a valid JWT issued by a registered consumer logs the user in
+
+- **GIVEN** the consumer `acme-co` is registered in OR with a matching public key and
+  algorithm
+- **AND** a caller presents `Authorization: Bearer <valid-JWT-signed-by-acme-co>` with
+  a non-empty `iat` and an `exp` in the future
+- **WHEN** `authorizeJwt(...)` runs
+- **THEN** the JWS signature SHALL verify against the consumer's JWK
+- **AND** the consumer's `authorizationConfiguration.userId` SHALL be set as the
+  `IUserSession` current user
+
+#### Scenario: a JWT signed by an unregistered issuer is rejected
+
+- **GIVEN** the JWT's `iss` claim does not match any registered consumer
+- **WHEN** `authorizeJwt(...)` runs
+- **THEN** the method SHALL throw `AuthenticationException` with
+  `message = "The issuer was not found"`
+- **AND** the user session SHALL NOT be mutated
+
+#### Scenario: a JWT with an unsupported algorithm is rejected
+
+- **GIVEN** the JWT header carries an algorithm not in the union of
+  `HMAC_ALGORITHMS` / `PKCS1_ALGORITHMS` / `PSS_ALGORITHMS`
+- **WHEN** `authorizeJwt(...)` calls `checkHeaders`
+- **THEN** `AuthenticationException` SHALL be thrown with
+  `message = "The token could not be validated"` and a `details.reason` echoing the
+  underlying `InvalidHeaderException` message
+
+#### Scenario: an expired token is rejected
+
+- **GIVEN** a JWT with `exp` in the past (or with no `exp` but an `iat` more than one
+  hour ago)
+- **WHEN** `validatePayload($payload)` runs
+- **THEN** `AuthenticationException` SHALL be thrown with
+  `message = "The token has expired"` and `details` including `iat`, `exp`, and
+  `time checked`
+
+#### Notes
+
+- The HMAC `AlgorithmManager` instance lists `HS256` twice and never instantiates
+  `HS512` (line 227-235). Tokens signed with `HS512` will fail verification even though
+  `HS512` is documented as supported via `HMAC_ALGORITHMS`. Observed-but-suspicious;
+  flagged.
+- `getJWK` writes RSA/PSS public keys to `/var/tmp/publickey-<microtime><pid>` so the
+  jose library's `createFromKeyFile` can read them, then `unlink`s. On race conditions
+  or a crash before `unlink`, public-key bytes leak to a world-readable directory.
+  Observed; flagged.
+- `findIssuer` returns the **first** consumer match without checking for ambiguity.
+  Two consumers with the same `name` would silently authorize against the first hit.
+
+### REQ-002: HTTP Basic authorization
+
+`authorizeBasic(string $header, array $users, array $groups)` MUST extract
+`<base64(user:password)>` from the `Basic ` prefix, base64-decode it, split on the
+first `:`, and call `IUserManager::checkPassword`. On success the method MUST set the
+Nextcloud user session to the resolved user. On failure (`checkPassword` returns
+`false`) the method MUST throw `AuthenticationException` with
+`message = "Invalid username or password"`. The `$users` and `$groups` arguments are
+accepted but **not enforced** — the user/group membership gate is commented out in
+the implementation (see Notes).
+
+#### Scenario: a correct username + password sets the session user
+
+- **GIVEN** `Authorization: Basic <base64("alice:correctpw")>` and `alice` exists in
+  Nextcloud with that password
+- **WHEN** `authorizeBasic(...)` runs
+- **THEN** `IUserSession::setUser($alice)` SHALL be called
+- **AND** no exception SHALL be thrown
+
+#### Scenario: an unknown user or wrong password is rejected
+
+- **GIVEN** `IUserManager::checkPassword` returns `false`
+- **WHEN** `authorizeBasic(...)` runs
+- **THEN** `AuthenticationException` SHALL be thrown with
+  `message = "Invalid username or password"`
+
+#### Notes
+
+- The `$users` + `$groups` membership-gate block is commented out as a `@TODO` waiting
+  on frontend support for users/group selection. Currently any authenticated Nextcloud
+  user passes this check regardless of the rule's allow-list. Observed-but-suspicious;
+  flagged.
+- The method does not validate that the header actually starts with `Basic ` — a
+  malformed header would still be `substr`-stripped of 6 bytes and base64-decoded,
+  producing garbage rather than a clean error.
+
+### REQ-003: OAuth bearer authorization via existing session
+
+`authorizeOAuth(string $header, array $users, array $groups)` MUST verify that the
+header starts with the literal string `Bearer` and that the current Nextcloud session
+is already logged in (`IUserSession::isLoggedIn() === true`). On either failure the
+method MUST throw `AuthenticationException`. On success the method does NOT mutate the
+session — it relies on the caller having already authenticated via the standard
+Nextcloud OAuth2 flow before reaching this rule.
+
+#### Scenario: an OAuth-authenticated session passes
+
+- **GIVEN** the Nextcloud user is logged in via the OAuth2 app and the request carries
+  `Authorization: Bearer <token>`
+- **WHEN** `authorizeOAuth(...)` runs
+- **THEN** the method SHALL return `void` without exception
+- **AND** SHALL NOT modify the user session
+
+#### Scenario: a request without an active OAuth session is rejected
+
+- **GIVEN** the Nextcloud session is not logged in
+- **WHEN** `authorizeOAuth(...)` runs with a `Bearer` header
+- **THEN** `AuthenticationException` SHALL be thrown with
+  `message = "Not authorized"` and a `details.reason` mentioning expiry or invalid
+  token
+
+#### Scenario: a non-Bearer authorization scheme is rejected
+
+- **GIVEN** the header is `Authorization: Basic …` (or any prefix other than
+  `Bearer`)
+- **WHEN** `authorizeOAuth(...)` runs
+- **THEN** `AuthenticationException` SHALL be thrown with
+  `message = "Invalid method"`
+
+#### Notes
+
+- The `str_starts_with($header, 'Bearer')` check is prefix-only (no trailing space) and
+  accepts both `Bearer foo` and `Bearertoken-with-no-space`. Observed; flagged.
+- The `$users` and `$groups` membership-gate block is commented out as a `@TODO` here
+  too, matching REQ-002.
+
+### REQ-004: API key authorization via header-to-uid map
+
+`authorizeApiKey(string $header, array $keys)` MUST treat the header value as an
+exact lookup key into the `$keys` map; the map's values are Nextcloud uids. On a
+successful lookup the method MUST set the Nextcloud session to the resolved user. On
+a missing key or a uid that does not resolve to an `IUser`, the method MUST throw
+`AuthenticationException` with `message = "Invalid API key"`.
+
+#### Scenario: a configured API key sets the session user
+
+- **GIVEN** `$keys = ['key-abc' => 'alice']` and the header is `key-abc`
+- **WHEN** `authorizeApiKey('key-abc', $keys)` runs
+- **THEN** `IUserSession::setUser($alice)` SHALL be called
+- **AND** no exception SHALL be thrown
+
+#### Scenario: an unknown key is rejected
+
+- **GIVEN** the header is not present as a key in `$keys`
+- **WHEN** `authorizeApiKey(...)` runs
+- **THEN** `AuthenticationException` SHALL be thrown with
+  `message = "Invalid API key"`
+
+#### Scenario: a known key mapped to a deleted user is rejected
+
+- **GIVEN** `$keys = ['key-zoe' => 'zoe-deleted']` and Nextcloud no longer has user
+  `zoe-deleted`
+- **WHEN** `authorizeApiKey('key-zoe', $keys)` runs
+- **THEN** `IUserManager::get('zoe-deleted')` SHALL return `null`
+- **AND** the method SHALL throw `AuthenticationException` with
+  `message = "Invalid API key"`
+
+#### Notes
+
+- The header is used as the **key** (not the value), so the rule's `$keys` map must be
+  configured as `{api-key-string => uid}`, not the other way around. This is observed
+  behaviour and matches how the rule pipeline supplies the array.
+
+### REQ-005: CORS response header injection with credentials guard
+
+`corsAfterController(IRequest $request, Response $response)` MUST act as a controller
+after-middleware. When the request carries an `HTTP_ORIGIN` header, the method MUST
+(a) iterate the response headers, (b) throw `SecurityException` if any header is
+`Access-Control-Allow-Credentials: true` (case-insensitive name + value), and (c) add
+`Access-Control-Allow-Origin: <request origin>` to the response. When the request
+does not carry `HTTP_ORIGIN`, the response MUST be returned unchanged.
+
+#### Scenario: a cross-origin request gets its origin echoed back
+
+- **GIVEN** the request carries `Origin: https://app.example.test`
+- **AND** the response does NOT include `Access-Control-Allow-Credentials: true`
+- **WHEN** `corsAfterController(...)` runs
+- **THEN** the response SHALL include
+  `Access-Control-Allow-Origin: https://app.example.test`
+
+#### Scenario: a response asserting Allow-Credentials trips the CSRF guard
+
+- **GIVEN** the request carries `Origin: …` AND the response already includes
+  `Access-Control-Allow-Credentials: true`
+- **WHEN** `corsAfterController(...)` runs
+- **THEN** `SecurityException` SHALL be thrown with a message naming CSRF as the
+  reason
+- **AND** the response SHALL NOT have an `Access-Control-Allow-Origin` header added
+
+#### Scenario: a same-origin request is a no-op
+
+- **GIVEN** the request does NOT carry `HTTP_ORIGIN`
+- **WHEN** `corsAfterController(...)` runs
+- **THEN** the response SHALL be returned unchanged
+
+#### Notes
+
+- The method echoes any request `Origin` value back as-is — there is no allow-list of
+  acceptable origins. This is wide open by design (openconnector is meant to be reached
+  cross-origin), but operators relying on origin filtering need to add an upstream
+  gate. Observed-but-suspicious; flagged.
+- The `$users` parameter on the controller-style middleware does not exist here — CORS
+  is unauthenticated. That is correct per CORS semantics.

--- a/openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: authorization-jwt#REQ-001 — JWT Bearer authorization with consumer-registered public keys (retroactive annotation)
+- [x] task-2: authorization-jwt#REQ-002 — HTTP Basic authorization (retroactive annotation)
+- [x] task-3: authorization-jwt#REQ-003 — OAuth bearer authorization via existing session (retroactive annotation)
+- [x] task-4: authorization-jwt#REQ-004 — API key authorization via header-to-uid map (retroactive annotation)
+- [x] task-5: authorization-jwt#REQ-005 — CORS response header injection with credentials guard (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 9 methods in `AuthorizationService.php` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-authorization-jwt`.

### What this PR does
- Drafts 5 REQs in a new `authorization-jwt` capability spec (`retrofit: true`)
- Creates `tasks.md` with one task per REQ (all `[x]` — retroactive)
- Annotates 9 methods (5 public + 4 private JWT helpers) with `@spec` tags

### What this PR does NOT do
- No code behaviour changes — only docblock `@spec` annotations
- Does NOT silently fix the observed-but-suspicious patterns (see design.md)

### Review focus
- **High**: REQ-001 Notes flag that the `AlgorithmManager` lists `HS256` twice and
  never instantiates `HS512` — `HMAC_ALGORITHMS` const claims HS512 is supported,
  but tokens signed with HS512 fail verification. Worth confirming whether this is
  intentional or a known bug.
- REQ-002 / REQ-003 Notes flag the commented-out `$users` / `$groups` allow-list
  block — endpoint rules' user/group restrictions are currently no-ops for Basic +
  OAuth.
- REQ-005 Notes flag that CORS echoes any `Origin` header back (no allow-list).

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `authorization-jwt`

Refs #936