### PR TITLE
retrofit: reverse-spec http-call-engine (5 REQs / 15 methods)

### DIFF
--- a/lib/Service/CallService.php
+++ b/lib/Service/CallService.php
@@ -155,6 +155,8 @@ class CallService
      * @throws \DateMalformedStringException On invalid datetime string composition.
      *
      * @TODO: At a later point in time this should be changed to using the most specific source for expiration
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-1
      */
     private function calculateExpires(...$retentions): ?\DateTime
     {
@@ -178,6 +180,8 @@ class CallService
      *
      * @throws LoaderError If there is an error loading a Twig template.
      * @throws SyntaxError If there is a syntax error in a Twig template.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-1
      */
     private function renderValue(array|string $value, array $sourceData): array|string
     {
@@ -217,6 +221,8 @@ class CallService
      *
      * @throws LoaderError If there is an error loading a Twig template.
      * @throws SyntaxError If there is a syntax error in a Twig template.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-1
      */
     private function renderConfiguration(array $configuration, array $sourceData): array
     {
@@ -241,6 +247,8 @@ class CallService
      * @param boolean $read          For GET as default: decides if we are in a list or read (singular) endpoint.
      *
      * @return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-1
      */
     private function decideMethod(string $default, array $configuration, bool $read=false): string
     {
@@ -282,6 +290,8 @@ class CallService
      * @param string $contents     File contents to write.
      *
      * @return string File location on disk.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-2
      */
     private function writeFile(string $baseFileName, string $contents): string
     {
@@ -303,6 +313,8 @@ class CallService
      * @param string $filename Filesystem path to remove.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-2
      */
     private function removeFile($filename): void
     {
@@ -316,6 +328,8 @@ class CallService
      * @param array $config The configuration as stored in the source.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-2
      */
     public function getCertificate(array &$config)
     {
@@ -351,6 +365,8 @@ class CallService
      * @param array $config The configuration with filenames.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-2
      */
     public function removeFiles(array $config): void
     {
@@ -399,6 +415,8 @@ class CallService
      * @throws LoaderError       On Twig loader error.
      * @throws SyntaxError       On Twig syntax error.
      * @throws \OCP\DB\Exception On persistence failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-1
      */
     public function call(
         ObjectEntity $source,
@@ -718,6 +736,8 @@ class CallService
      * @return array The updated response headers.
      *
      * @throws \OCP\DB\Exception On persistence failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-3
      */
     private function sourceRateLimit(ObjectEntity $source, array $sourceData, array $headers): array
     {
@@ -805,6 +825,8 @@ class CallService
      * @param array $config The config array.
      *
      * @return array The updated config array.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-1
      */
     public function applyConfigDot(array $config): array
     {

--- a/lib/Service/SOAPService.php
+++ b/lib/Service/SOAPService.php
@@ -87,6 +87,8 @@ class SOAPService
      * @return int The soap version as specified in constants.
      *
      * @throws BadRequestHttpException When an unsupported numeric soap version is supplied.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-4
      */
     private function getSoapVersion(string|int|null $soapVersion): int
     {
@@ -129,6 +131,8 @@ class SOAPService
      * @return Engine The resulting soap engine.
      *
      * @throws \SoapFault When the SOAP client cannot be created.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-4
      */
     public function setupEngine(ObjectEntity $source, array $passedConfig): Engine
     {
@@ -187,6 +191,8 @@ class SOAPService
      * @param string $xmlString The XML split in two parts: the XSD and the data to parse.
      *
      * @return \SimpleXMLElement|null The resulting XML element, or null when no document element is present.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-5
      */
     private function parseDynamicXsd(string $xmlString): ?\SimpleXMLElement
     {
@@ -237,6 +243,8 @@ class SOAPService
      * @return Response The resulting response.
      *
      * @throws \SoapFault When the SOAP engine cannot satisfy the request.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-4
      */
     public function callSoapSource(ObjectEntity $source, string $soapAction, array $config): Response
     {

--- a/openspec/changes/retrofit-2026-05-24-http-call-engine/design.md
+++ b/openspec/changes/retrofit-2026-05-24-http-call-engine/design.md
@@ -1,0 +1,58 @@
+# Design — Retrofit http-call-engine
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+`CallService` is openconnector's outbound-request hot path: 11 methods, 831 LOC, every
+configured Source's REST dispatch flows through `call()`. `SOAPService` is the SOAP-side
+counterpart (4 methods, 305 LOC) reached via `call()` when the Source is `type=soap`.
+The two services together implement Twig templating over request config, certificate
+materialisation, rate-limit tracking, request/response logging into the OR `call_log`
+schema, and (for SOAP) WSDL-driven engine setup + diffgram payload parsing.
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `CallService::call` + private helpers `decideMethod`, `applyConfigDot`, `renderConfiguration`, `renderValue`, `calculateExpires` |
+| REQ-002 | `CallService::getCertificate`, `removeFiles`, `writeFile`, `removeFile` |
+| REQ-003 | `CallService::sourceRateLimit` |
+| REQ-004 | `SOAPService::callSoapSource`, `setupEngine`, `getSoapVersion` |
+| REQ-005 | `SOAPService::parseDynamicXsd` |
+
+Private helpers are folded under the public REQ they exclusively support — splitting
+them out as their own REQs would inflate the spec without adding clarity.
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `SOAPService::callSoapSource` | permissive `libxml_set_external_entity_loader` (returns `$system` verbatim) — XXE risk window | **high** |
+| `CallService::call` line 562-568 | secrets stripping via `str_contains('authentication')` substring match | medium |
+| `CallService::writeFile` | `microtime().getmypid()` filename suffix; no collision lock | medium |
+| `CallService::sourceRateLimit` | hot-path OR write on every dispatch when decrement-only | medium |
+| `SOAPService` | hard-coded handling of `edcLk01.inhoud`, `QueryExecute2Result`, `FileBytes` | low |
+| `SOAPService::parseDynamicXsd` | substring `NewDataSet → DocumentElement` rewrite | low |
+| `SOAPService::parseDynamicXsd` | `libxml_use_internal_errors(true)` never restored | low |
+| `CallService::writeFile` | SSL keys land in `/var/tmp`, world-readable | medium |
+| `CallService::removeFiles` | unsuppressed `unlink` warnings on missing files | low |
+
+These are documented in REQ Notes rather than silently fixed via spec text. The XXE
+window in REQ-004 deserves a separate hardening change.
+
+## What the spec deliberately does NOT cover
+
+- Twig extension wiring (`AuthenticationExtension`, `AuthenticationRuntimeLoader`) is
+  constructor-time DI and not observable behaviour from the caller's perspective.
+- The `errorRetention` / `successRetention` constants and their `IAppConfig` override
+  path are implicit in REQ-001's `expires` derivation but not enumerated as their
+  own REQ.
+- Async dispatch (`$asynchronous = true`) returns the Guzzle `Promise` directly,
+  bypassing the CallLog persistence. This is observable but a corner case; flagged
+  in the REQ-001 description rather than as its own scenario.
+
+## Validation
+
+After archive, `openspec validate http-call-engine --strict` MUST pass and Specter
+MUST register the spec as part of the retrofit cohort.

--- a/openspec/changes/retrofit-2026-05-24-http-call-engine/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-http-call-engine/proposal.md
@@ -1,0 +1,38 @@
+# Retrofit — http-call-engine
+
+Describes observed behavior of 15 methods under `http-call-engine` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+CallService.php (11 methods):
+
+- `lib/Service/CallService.php::call()`
+- `lib/Service/CallService.php::calculateExpires()`
+- `lib/Service/CallService.php::renderValue()`
+- `lib/Service/CallService.php::renderConfiguration()`
+- `lib/Service/CallService.php::decideMethod()`
+- `lib/Service/CallService.php::writeFile()`
+- `lib/Service/CallService.php::removeFile()`
+- `lib/Service/CallService.php::removeFiles()`
+- `lib/Service/CallService.php::getCertificate()`
+- `lib/Service/CallService.php::sourceRateLimit()`
+- `lib/Service/CallService.php::applyConfigDot()`
+
+SOAPService.php (4 methods):
+
+- `lib/Service/SOAPService.php::setupEngine()`
+- `lib/Service/SOAPService.php::callSoapSource()`
+- `lib/Service/SOAPService.php::getSoapVersion()`
+- `lib/Service/SOAPService.php::parseDynamicXsd()`
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces observed-but-suspicious behavior (synchronous source-save in
+  rate-limit reset; mid-flight Source write to OR; XXE exposure window in SOAP via
+  `libxml_set_external_entity_loader` that returns `$system` unguarded;
+  PdokConnector-style hard-coded XML-element names; secrets-stripping via
+  `str_contains('authentication')` substring match)
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-http-call-engine/specs/http-call-engine/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-http-call-engine/specs/http-call-engine/spec.md
@@ -1,0 +1,294 @@
+---
+retrofit: true
+status: draft
+---
+
+# HTTP Call Engine (CallService + SOAPService)
+
+## Purpose
+
+`CallService` is openconnector's outbound-request engine: every Source-targeted REST
+call across the app routes through `CallService::call()`. It renders Twig templates
+into the request configuration, materialises certificates to disk, dispatches via
+Guzzle (or hands off to the SOAP service for `type=soap` sources), parses rate-limit
+response headers back into the Source entity, and persists every result as a
+`call_log` OR object. `SOAPService` handles the alternate transport for SOAP sources
+via the `php-soap/ext-soap-engine` stack. This spec retroactively documents the
+observed behaviour of all 15 cluster methods (11 in CallService, 4 in SOAPService).
+
+## ADDED Requirements
+
+### REQ-001: Outbound HTTP call orchestration with CallLog persistence
+
+`CallService::call(ObjectEntity $source, string $endpoint, string $method, array $config,
+bool $asynchronous, bool $createCertificates, bool $overruleAuth, bool $read, bool
+$runningSupportRequest)` MUST validate that `$source->getObject().isEnabled === true`
+and `$source->getObject().location` is non-empty before dispatching; on either guard
+failure it MUST persist a synthetic `call_log` (status 409) and return that entity
+without an outbound HTTP call. When the source's rate-limit window is exhausted
+(`rateLimitRemaining <= 0`), the method MUST persist a synthetic 429 `call_log` and
+return. The method MUST flatten dotted config keys via `applyConfigDot`, render every
+templated config value via `renderConfiguration` (Twig over `{{ ... }}`), invoke
+`getCertificate` to materialise any inline cert/ssl_key/verify blobs to temp files,
+strip every config key whose name (case-insensitively) contains `authentication`
+before dispatch, and resolve the effective HTTP method via `decideMethod` from
+configured per-CRUD-operation overrides (`createMethod` / `updateMethod` /
+`destroyMethod` / `listMethod` / `readMethod`). For non-async, non-SOAP sources the
+method MUST dispatch via the internal Guzzle client with `http_errors = false`; on
+`BadResponseException` it MUST capture the response; on `ConnectException` it MUST
+synthesise a 503 response. For SOAP sources (`sourceData.type === 'soap'`) the
+method MUST delegate to `SOAPService::callSoapSource`. After dispatch the method MUST
+remove any materialised certificate temp files, build a `call_log` object with
+request + response payload (the response body is omitted unless `statusCode >= 400 &&
+< 600` AND `logBody === true`, in which case it is kept), persist via the OR
+`call_log` schema with `expires` computed from the maximum of source-level retention
+and global retention, and return the persisted `ObjectEntity`. When `config.preRequest`
+or `config.postRequest` is set AND `runningSupportRequest === false`, the method MUST
+recursively call itself with `runningSupportRequest = true` before/after the main call
+respectively, so support-call payloads do not themselves trigger nested support calls.
+
+#### Scenario: a disabled source short-circuits with a synthetic 409 CallLog
+
+- **GIVEN** a Source ObjectEntity with `isEnabled = false`
+- **WHEN** `call($source, $endpoint, $method, $config)` runs
+- **THEN** the Guzzle client SHALL NOT be invoked
+- **AND** a `call_log` SHALL be persisted with `statusCode = 409`, `statusMessage =
+  "This source is not enabled"`, and the source UUID
+
+#### Scenario: a rate-limited source short-circuits with a synthetic 429 CallLog
+
+- **GIVEN** a Source with `rateLimitRemaining <= 0` and `rateLimitReset` in the future
+- **WHEN** `call(...)` runs
+- **THEN** a `call_log` SHALL be persisted with `statusCode = 429` and the source UUID
+- **AND** the Guzzle client SHALL NOT be invoked
+
+#### Scenario: a successful REST call persists a CallLog without the response body by default
+
+- **GIVEN** a healthy Source AND a 200 OK upstream response
+- **WHEN** `call(...)` runs with `config.logBody = false` (or unset)
+- **THEN** a `call_log` SHALL be persisted whose `response.body` field is removed
+  before persistence
+- **AND** the in-memory entity returned to the caller SHALL still carry the full
+  `response.body` for downstream processing
+
+#### Scenario: a 4xx/5xx with logBody=true persists the response body
+
+- **GIVEN** a Source with `config.logBody = true` AND an upstream 500 response
+- **WHEN** `call(...)` runs
+- **THEN** the persisted `call_log.response.body` SHALL contain the response body
+  (UTF-8 verbatim, or base64-encoded if the body fails UTF-8 validation)
+
+#### Scenario: preRequest support call does not trigger its own support call
+
+- **GIVEN** `config.preRequest = {endpoint: 'x', config: {...}}` AND the main call
+  context has `runningSupportRequest = false`
+- **WHEN** `call(...)` runs
+- **THEN** the inner `call(...)` invocation SHALL pass `runningSupportRequest = true`
+- **AND** the inner invocation SHALL NOT recurse into its own preRequest/postRequest
+
+#### Notes
+
+- `decideMethod` translates HTTP verbs to per-CRUD-operation overrides (POST →
+  `createMethod`, GET → `listMethod` or `readMethod` depending on `$read`, etc.).
+  Unknown verbs fall through to `default` and return `$default` unchanged. The
+  override unset on lines 421-422 happens AFTER `decideMethod` already returned, so
+  the actual dispatched method is not affected by the unset — the unset only prevents
+  the verbs from showing up in the persisted `request.method` field.
+- `renderValue` recursively walks arrays and renders strings that contain both `{{`
+  and `}}`. Non-string non-array leaf values are passed through untouched (observed:
+  the inner `array_map` guards on `is_string === false && is_array === false` to
+  return the value verbatim).
+- The authentication-secrets stripping at line 562-568 uses
+  `str_contains(strtolower($key), 'authentication')`. Any config key whose name
+  contains the substring "authentication" anywhere is removed before dispatch.
+  Operators relying on this for secrets-hiding need to know it is a substring match,
+  not an exact field match. Observed.
+
+### REQ-002: Certificate materialisation and cleanup
+
+`CallService::getCertificate(array &$config)` MUST detect inline certificate/SSL-key
+payloads in the caller's `$config` array and materialise them to temp files on disk so
+the Guzzle client can pass file paths to `curl`. The method MUST recognise three
+config keys — `cert`, `ssl_key`, and `verify` — each of which may be either a string
+(single PEM blob) or a `[blob, passphrase]` tuple. For each materialised file the
+method MUST mutate `$config` in place, replacing the inline blob with the file path
+produced by `writeFile`. `removeFiles(array $config)` MUST be invoked after every
+dispatch (success path, `BadResponseException`, and `ConnectException`) and MUST
+`unlink` every file path it finds at the same three config keys. `writeFile`
+MUST generate a unique filename of shape `<baseFileName>-<microtime><pid>` and MUST
+substitute escaped newlines (`\\n`) with literal newlines before writing the blob,
+so PEM content shipped as a single-line string still parses.
+
+#### Scenario: an inline cert blob is materialised to a uniquely-named file
+
+- **GIVEN** `$config = ['cert' => '-----BEGIN CERTIFICATE-----\n…']`
+- **WHEN** `getCertificate($config)` runs
+- **THEN** `$config['cert']` SHALL be mutated to a string of shape
+  `certificate-<microtime><pid>`
+- **AND** the named file SHALL exist on disk with the PEM content
+
+#### Scenario: removeFiles deletes every materialised path
+
+- **GIVEN** a `$config` with `cert`, `ssl_key`, and `verify` all pointing at
+  previously-materialised file paths
+- **WHEN** `removeFiles($config)` runs
+- **THEN** all three files SHALL be `unlink`-ed
+- **AND** the method SHALL return without exception even if a file is already missing
+  (NOTE: `unlink` warning suppression is at the PHP level, not in this method — see
+  Notes)
+
+#### Notes
+
+- `writeFile` uses `microtime().getmypid()` for the suffix. Under high concurrency
+  two requests on the same FPM worker that hit `writeFile` in the same microsecond
+  would collide. Observed; no locking; flagged for follow-up.
+- `unlink` on a missing file emits a PHP warning. The current code does not suppress
+  it; operator-visible warnings may appear in php-fpm error logs on partial-cleanup
+  paths. Observed; flagged.
+- `getCertificate` writes private SSL keys to `/var/tmp` (the current working
+  directory of the writeFile resolution; see `BASE_FILENAME_LOCATION = "%s-%s"`).
+  The location should be hardened to a chmod-0700 per-worker dir. Observed; flagged.
+
+### REQ-003: Source rate-limit tracking across dispatches
+
+`CallService::sourceRateLimit(ObjectEntity $source, array $sourceData, array $headers)`
+MUST inspect the upstream response headers for `X-RateLimit-Reset`, `X-RateLimit-Limit`,
+and `X-RateLimit-Remaining`; when any of those headers are present the method MUST
+mirror their values onto the source's `rateLimitReset` / `rateLimitLimit` /
+`rateLimitRemaining` fields. When `X-RateLimit-Reset` is absent AND the source has
+no in-progress reset window AND a `rateLimitWindow` is configured, the method MUST
+compute `rateLimitReset = time() + rateLimitWindow` and persist it. When
+`X-RateLimit-Remaining` is absent AND a `rateLimitLimit` is configured, the method
+MUST decrement the cached remaining counter by 1 (initialising from `rateLimitLimit`
+on the first call). On any change the method MUST persist the source via OR
+`saveObject(register='openconnector', schema='source', uuid=source.uuid)`. Finally,
+when `rateLimitLimit OR rateLimitWindow` is set, the method MUST inject five
+synthesised `X-RateLimit-*` headers into the response header array so downstream
+consumers see a consistent rate-limit shape even when upstream did not emit one. Also,
+when `CallService::call()` enters with `rateLimitReset <= time()` AND a non-null
+`rateLimitRemaining`, the method MUST clear both fields and persist the source before
+dispatch (rate-limit window has rolled over).
+
+#### Scenario: upstream X-RateLimit-Reset is mirrored to the source
+
+- **GIVEN** an upstream response with header `X-RateLimit-Reset: 1700000000`
+- **WHEN** `sourceRateLimit(...)` runs
+- **THEN** the source's `rateLimitReset` field SHALL be set to `1700000000`
+- **AND** OR `saveObject` SHALL be called for the source
+
+#### Scenario: rate-limit window rolls over before dispatch
+
+- **GIVEN** a source with `rateLimitReset = (time() - 60)` (60 seconds in the past)
+  AND `rateLimitRemaining = 0`
+- **WHEN** `call(...)` enters
+- **THEN** both fields SHALL be cleared on the source AND persisted
+- **AND** the dispatch SHALL proceed (no 429 short-circuit)
+
+#### Scenario: synthetic headers are injected when only a window is configured
+
+- **GIVEN** a source with `rateLimitWindow = 3600` AND `rateLimitLimit = null`
+- **WHEN** `sourceRateLimit(...)` returns
+- **THEN** the response header array SHALL contain `X-RateLimit-Window: 3600` AND
+  `X-RateLimit-Used: 1`
+
+#### Notes
+
+- The synthesised header values are PHP-side strings cast from int via `(string)`.
+  If `$rateLimitReset` is `null`, the header value becomes the empty string `""` — an
+  HTTP-spec-debatable but observably-present behaviour. Flagged.
+- The decrement path (REQ-003 fourth sentence) writes the new `rateLimitRemaining`
+  to the source on every call when the upstream does not send the header. This is a
+  hot-path persistence; every outbound call to a configured-limit source incurs an
+  OR write. Observed; flagged for follow-up if it becomes a bottleneck.
+
+### REQ-004: SOAP source invocation via WSDL
+
+`SOAPService::callSoapSource(ObjectEntity $source, string $soapAction, array $config)`
+MUST extract the request body from `$config['body']` (JSON-decoded) or
+`$config['json']`, set the libxml external-entity loader to a permissive callback that
+returns the requested system URI verbatim, set up a SOAP engine via `setupEngine`,
+invoke `$engine->request($soapAction, $body)`, then reset the libxml external-entity
+loader to a null-returning callback. The method MUST decode any inline
+`edcLk01.object.inhoud` field as base64 before the request (legacy CMIS document
+transport). On a SOAP result with a `QueryExecute2Result.any` child, the method MUST
+hand off to `parseDynamicXsd` for diffgram XSD parsing; on a result with a `FileBytes`
+field that fails `json_encode`, the method MUST base64-encode `FileBytes` for safe
+JSON serialisation. The method MUST always return a Guzzle `Response` of status 200
+with a JSON-encoded body. `setupEngine` MUST require a `wsdl` config field
+(throwing if absent), build a Psr18-backed WSDL loader provider (permanent vs.
+temporary based on `config.permanentWsdl`), and assemble an `ExtSoapDriver`-backed
+`SimpleEngine` with `cache_wsdl = WSDL_CACHE_NONE` and `trace = true`. `getSoapVersion`
+MUST accept `'1.1'`, `'1_1'`, `'soap1.1'`, `'soap1_1'`, `'soap_1_1'`, `'SOAP_1_1'`
+(returning the `SOAP_1_1` constant) and the 1.2 equivalents (returning `SOAP_1_2`);
+an integer in `(0,3)` is returned as-is; any other integer throws
+`BadRequestHttpException`; any other value falls through to `SOAP_1_2`.
+
+#### Scenario: a SOAP source dispatch returns a 200 Response with JSON body
+
+- **GIVEN** a healthy SOAP Source with a valid WSDL configured AND `soapAction = 'doThing'`
+- **WHEN** `callSoapSource(...)` runs
+- **THEN** the SOAP engine SHALL be invoked with `('doThing', $decodedBody)`
+- **AND** the response SHALL be a Guzzle `Response` with status 200 AND a
+  JSON-encoded body
+
+#### Scenario: setupEngine without a WSDL throws
+
+- **GIVEN** a Source whose configuration lacks a `wsdl` field
+- **WHEN** `setupEngine(...)` runs
+- **THEN** a `Symfony\Component\Config\Definition\Exception\Exception` SHALL be
+  thrown with `message = "No wsdl provided"`
+
+#### Scenario: getSoapVersion accepts string and integer variants
+
+- **GIVEN** the input `'soap_1_1'`
+- **WHEN** `getSoapVersion(...)` runs
+- **THEN** the method SHALL return `SOAP_1_1`
+- **GIVEN** the input `4`
+- **WHEN** `getSoapVersion(...)` runs
+- **THEN** `BadRequestHttpException` SHALL be thrown
+
+#### Notes
+
+- The permissive `libxml_set_external_entity_loader` callback on lines 250-253 is an
+  XXE-risk surface: any external entity referenced from the SOAP response payload
+  will be fetched/loaded by `simplexml_load_string` later. The reset on lines 296-300
+  closes the window AFTER the request, so concurrent requests on the same FPM worker
+  can race. Observed-but-suspicious; flagged with high severity.
+- The hard-coded handling of `edcLk01.object.inhoud` (CMIS-StUF), `QueryExecute2Result`
+  (legacy WCF service), and `FileBytes` (likely DMS export) reveals that
+  `SOAPService` was built against a small number of named integrations and is not
+  truly generic. New SOAP sources requiring other binary-field handling will need
+  this code edited. Observed; flagged.
+
+### REQ-005: Diffgram-wrapped dynamic-XSD payload parsing
+
+`SOAPService::parseDynamicXsd(string $xmlString)` MUST wrap the payload in a synthetic
+`<any>…</any>` element after substituting `NewDataSet` → `DocumentElement` in the raw
+input, load the result via `DOMDocument::loadXML`, attempt schema validation
+(clearing errors on failure rather than aborting), then `simplexml_load_string` the
+payload with the `diffgr` namespace registered. The method MUST navigate to
+`//DocumentElement` via XPath, return `null` when no `DocumentElement` is present,
+and otherwise return the `QueryExecResult` child of the `DocumentElement`.
+
+#### Scenario: a diffgram payload with QueryExecResult returns the parsed child
+
+- **GIVEN** an `$xmlString` containing a `<NewDataSet>` envelope and a
+  `<QueryExecResult>` child
+- **WHEN** `parseDynamicXsd($xmlString)` runs
+- **THEN** `NewDataSet` SHALL be substring-replaced with `DocumentElement`
+- **AND** the method SHALL return the `QueryExecResult` `SimpleXMLElement`
+
+#### Scenario: a payload without a DocumentElement returns null
+
+- **GIVEN** an `$xmlString` that does not contain a `DocumentElement` XPath match
+- **WHEN** `parseDynamicXsd($xmlString)` runs
+- **THEN** the method SHALL return `null`
+
+#### Notes
+
+- Per the in-line `@TODO`, the substring `NewDataSet → DocumentElement` is fragile —
+  any `NewDataSet` string appearing inside payload text would also be rewritten.
+  Observed; flagged.
+- `libxml_use_internal_errors(true)` is set inside this method but never restored to
+  its previous state on exit. Side-effect leaks to the rest of the request. Observed;
+  flagged.

--- a/openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: http-call-engine#REQ-001 — Outbound HTTP call orchestration with CallLog persistence (retroactive annotation)
+- [x] task-2: http-call-engine#REQ-002 — Certificate materialisation and cleanup (retroactive annotation)
+- [x] task-3: http-call-engine#REQ-003 — Source rate-limit tracking across dispatches (retroactive annotation)
+- [x] task-4: http-call-engine#REQ-004 — SOAP source invocation via WSDL (retroactive annotation)
+- [x] task-5: http-call-engine#REQ-005 — Diffgram-wrapped dynamic-XSD payload parsing (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 15 methods (CallService 11 + SOAPService 4) as 5 new REQs.

Ghost change: `retrofit-2026-05-24-http-call-engine`.

### What this PR does
- Drafts 5 REQs in a new `http-call-engine` capability spec (`retrofit: true`)
- Creates `tasks.md` with one task per REQ (all `[x]` — retroactive)
- Annotates 15 methods (CallService + SOAPService) with `@spec` tags
- design.md folds private helpers under the public REQ they exclusively support

### What this PR does NOT do
- No code behaviour changes — only docblock `@spec` annotations
- Does NOT silently fix observed-but-suspicious behaviour

### Review focus
- **High severity**: REQ-004 Notes flag the permissive
  `libxml_set_external_entity_loader` in `SOAPService::callSoapSource` — XXE-risk
  window between request setup and reset. Worth a separate hardening change.
- REQ-001 Notes flag the secrets-stripping substring match
  (`str_contains('authentication')`) — config keys are silently dropped if their
  name contains the substring anywhere.
- REQ-002 Notes flag `microtime+pid` filename collision potential and SSL keys
  landing in world-readable `/var/tmp`.
- REQ-003 Notes flag hot-path OR write per dispatch when rate-limit decrement is
  inferred (no upstream header).

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `http-call-engine`

Refs #936