### PR TITLE
retrofit: reverse-spec events-cloudevents (5 REQs / 17 methods)

### DIFF
--- a/lib/Controller/EventsController.php
+++ b/lib/Controller/EventsController.php
@@ -88,6 +88,8 @@ class EventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-5
      */
     public function messages(int $id): JSONResponse
     {
@@ -123,6 +125,8 @@ class EventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-5
      */
     public function subscribe(): JSONResponse
     {
@@ -155,6 +159,8 @@ class EventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-5
      */
     public function updateSubscription(string $subscriptionId): JSONResponse
     {
@@ -194,6 +200,8 @@ class EventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-5
      */
     public function unsubscribe(string $subscriptionId): JSONResponse
     {
@@ -215,6 +223,8 @@ class EventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-5
      */
     public function subscriptions(): JSONResponse
     {
@@ -250,6 +260,8 @@ class EventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-5
      */
     public function subscriptionMessages(string $subscriptionId): JSONResponse
     {
@@ -287,6 +299,8 @@ class EventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-3
      */
     public function pull(string $subscriptionId): JSONResponse
     {

--- a/lib/Service/EventService.php
+++ b/lib/Service/EventService.php
@@ -56,6 +56,8 @@ class EventService
      * @return array<ObjectEntity> Array of created message ObjectEntities.
      *
      * @throws Exception On failure to process the event.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-1
      */
     public function processEvent(ObjectEntity $event): array
     {
@@ -107,6 +109,8 @@ class EventService
      * @param ObjectEntity $subscription The subscription whose filters/types are checked.
      *
      * @return boolean
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-1
      */
     private function doesEventMatchSubscription(ObjectEntity $event, ObjectEntity $subscription): bool
     {
@@ -146,6 +150,8 @@ class EventService
      * @param array $filters   Subscription filters.
      *
      * @return boolean
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-1
      */
     private function evaluateFilters(array $eventData, array $filters): bool
     {
@@ -200,6 +206,8 @@ class EventService
      * @return ObjectEntity
      *
      * @throws \OCP\DB\Exception On persistence failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-1
      */
     private function createEventMessage(ObjectEntity $event, ObjectEntity $subscription): ObjectEntity
     {
@@ -228,6 +236,8 @@ class EventService
      * @param ObjectEntity $message The pending message to deliver.
      *
      * @return boolean True when delivered successfully.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-2
      */
     public function deliverMessage(ObjectEntity $message): bool
     {
@@ -315,6 +325,8 @@ class EventService
      * @param integer $maxRetries Maximum number of retry attempts.
      *
      * @return integer Number of successfully delivered messages.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-2
      */
     public function processRetries(int $maxRetries=5): int
     {
@@ -350,6 +362,8 @@ class EventService
      * @param string|null  $cursor       Pagination cursor from the previous call.
      *
      * @return array{messages: ObjectEntity[], cursor: string|null}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-3
      */
     public function pullEvents(ObjectEntity $subscription, ?int $limit=100, ?string $cursor=null): array
     {
@@ -393,6 +407,8 @@ class EventService
      *
      * @throws Exception        On event processing failure.
      * @throws \OCP\DB\Exception On persistence failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-4
      */
     public function handleObjectCreated(ObjectEntity $object): array
     {
@@ -428,6 +444,8 @@ class EventService
      *
      * @throws Exception        On event processing failure.
      * @throws \OCP\DB\Exception On persistence failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-4
      */
     public function handleObjectUpdated(ObjectEntity $oldObject, ObjectEntity $newObject): array
     {
@@ -467,6 +485,8 @@ class EventService
      *
      * @throws Exception        On event processing failure.
      * @throws \OCP\DB\Exception On persistence failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md#task-4
      */
     public function handleObjectDeleted(ObjectEntity $object): array
     {

--- a/openspec/changes/retrofit-2026-05-24-events-cloudevents/design.md
+++ b/openspec/changes/retrofit-2026-05-24-events-cloudevents/design.md
@@ -1,0 +1,59 @@
+# Design — Retrofit events-cloudevents
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+`EventService` (494 LOC, 10 methods) is the producer/dispatcher for openconnector's
+CloudEvents implementation, and `EventsController` (313 LOC, 7 methods) is the REST
+surface. Together they implement: (a) OR object lifecycle → CloudEvent conversion,
+(b) subscription filter matching (types/source/filters with exact/prefix/suffix/
+expression dialects), (c) push delivery with status tracking, and (d) pull-style
+cursor pagination.
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `EventService::processEvent`, `doesEventMatchSubscription`, `evaluateFilters`, `createEventMessage` |
+| REQ-002 | `EventService::deliverMessage`, `processRetries` |
+| REQ-003 | `EventService::pullEvents` + `EventsController::pull` |
+| REQ-004 | `EventService::handleObjectCreated`, `handleObjectUpdated`, `handleObjectDeleted` |
+| REQ-005 | `EventsController::messages`, `subscribe`, `updateSubscription`, `unsubscribe`, `subscriptions`, `subscriptionMessages` |
+
+`EventsController::pull` is folded into REQ-003 (cursor pagination is its
+distinguishing behaviour) rather than REQ-005, so the controller annotation for
+`pull` points at task-3 not task-5.
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `EventsController::subscribe/update/unsubscribe/subscriptions/messages/subscriptionMessages` | `@NoAdminRequired` + no per-object auth gate — any authed user owns every subscription | **high** (IDOR) |
+| `EventsController::subscribe/updateSubscription/unsubscribe` | `@NoCSRFRequired` on state-changing endpoints | high |
+| `EventService::evaluateFilters` | `ExpressionLanguage::evaluate` runs caller-supplied strings against event data; subscription owner = caller | high |
+| `EventService::processRetries` | `retryCount` is read but never written — pending messages re-attempt forever | medium (bug) |
+| `EventService::deliverMessage` | no Retry-After honour | low |
+| `EventService::handle*` | `userId` reflects object owner, not session actor | low (audit trail accuracy) |
+| `EventService::pullEvents` | `id > $cursor` filter relies on monotonic UUID ordering | low |
+| `EventsController::subscribe` | shallow `_*` strip; any non-prefixed field passes through | low |
+
+The IDOR finding (REQ-005 Notes) is the most consequential — every endpoint should
+either be admin-gated or guarded by a per-subscription owner check. Two of the three
+gates the security reviewer will hit are pattern matches for
+`hydra-gate-no-admin-idor` and the IDOR/CSRF combo.
+
+## What the spec deliberately does NOT cover
+
+- The OR `event_subscription` / `event_message` / `event` schemas themselves —
+  those are openregister-side artifacts, not openconnector behaviour.
+- Background job scheduling — `processRetries` is a service method here; the cron
+  job wrapper (if any) lives elsewhere (cluster `job-scheduling`, Wave 5).
+- CloudEvents 1.0 spec compliance — this spec captures what the code produces, not
+  what the CloudEvents spec mandates. Drift between the two would be a separate
+  hardening change.
+
+## Validation
+
+After archive, `openspec validate events-cloudevents --strict` MUST pass and Specter
+MUST register the spec as part of the retrofit cohort.

--- a/openspec/changes/retrofit-2026-05-24-events-cloudevents/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-events-cloudevents/proposal.md
@@ -1,0 +1,39 @@
+# Retrofit — events-cloudevents
+
+Describes observed behavior of 17 methods under `events-cloudevents` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+EventService.php (10 methods):
+
+- `lib/Service/EventService.php::processEvent()`
+- `lib/Service/EventService.php::doesEventMatchSubscription()`
+- `lib/Service/EventService.php::evaluateFilters()`
+- `lib/Service/EventService.php::createEventMessage()`
+- `lib/Service/EventService.php::deliverMessage()`
+- `lib/Service/EventService.php::processRetries()`
+- `lib/Service/EventService.php::pullEvents()`
+- `lib/Service/EventService.php::handleObjectCreated()`
+- `lib/Service/EventService.php::handleObjectUpdated()`
+- `lib/Service/EventService.php::handleObjectDeleted()`
+
+EventsController.php (7 methods):
+
+- `lib/Controller/EventsController.php::messages()`
+- `lib/Controller/EventsController.php::subscribe()`
+- `lib/Controller/EventsController.php::updateSubscription()`
+- `lib/Controller/EventsController.php::unsubscribe()`
+- `lib/Controller/EventsController.php::subscriptions()`
+- `lib/Controller/EventsController.php::subscriptionMessages()`
+- `lib/Controller/EventsController.php::pull()`
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces observed-but-suspicious behavior (every controller endpoint is
+  `@NoAdminRequired`/`@NoCSRFRequired` with no IDOR guard — any authed NC user can
+  modify/delete any subscription by ID; ExpressionLanguage evaluator runs on
+  subscriber-supplied input; no auth on `pull` for cross-subscription access)
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-events-cloudevents/specs/events-cloudevents/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-events-cloudevents/specs/events-cloudevents/spec.md
@@ -1,0 +1,260 @@
+---
+retrofit: true
+status: draft
+---
+
+# Events and CloudEvents Subscriptions
+
+## Purpose
+
+`EventService` + `EventsController` together implement openconnector's CloudEvents
+(`com.nextcloud.openregister.object.*`) producer + delivery pipeline. The service
+materialises OR object lifecycle changes (created/updated/deleted) into `event` records,
+fans them out against active `event_subscription` records via filter matching, and
+either pushes the resulting `event_message` to the subscriber's sink endpoint or
+queues it for pull retrieval. The controller exposes the REST surface for
+subscriptions and message listing.
+
+This spec retroactively documents the observed behaviour of all 17 cluster methods.
+
+## ADDED Requirements
+
+### REQ-001: CloudEvent fan-out to matching subscriptions
+
+`EventService::processEvent(ObjectEntity $event)` MUST query OR for every
+`event_subscription` with `status = 'active'`, evaluate each against the event via
+`doesEventMatchSubscription`, and persist a new `event_message` for each match.
+A subscription matches when (a) its `types[]` is empty OR includes
+`event.type`, AND (b) its `source` is null OR matches `event.source` exactly,
+AND (c) every entry in its `filters[]` array evaluates to true via `evaluateFilters`.
+`evaluateFilters` MUST support four filter dialects per CloudEvents subscription spec:
+`exact` (field equality), `prefix` (`str_starts_with`), `suffix` (`str_ends_with`),
+and `expression` (Symfony ExpressionLanguage evaluated against the event data as
+context). When ANY filter in the array fails, the subscription is rejected; only an
+all-pass result delivers the message. For each created message, when the matched
+subscription has `style = 'push'` the method MUST attempt immediate delivery via
+`deliverMessage`. The method MUST log + rethrow on any exception, and MUST return
+the array of created `event_message` ObjectEntities.
+
+#### Scenario: an event with no matching subscriptions produces zero messages
+
+- **GIVEN** an event with `type = 'com.example.foo'` and no active subscriptions
+  whose `types` array contains that type
+- **WHEN** `processEvent($event)` runs
+- **THEN** the method SHALL return `[]`
+- **AND** no `event_message` SHALL be persisted
+
+#### Scenario: a matching push subscription triggers immediate delivery
+
+- **GIVEN** an event matching subscription `S` (style=push, sink=https://x/cb)
+- **WHEN** `processEvent($event)` runs
+- **THEN** an `event_message` SHALL be persisted with `status='pending'`
+- **AND** `deliverMessage` SHALL be invoked on that message
+- **AND** the message persists `status='delivered'` on 2xx response
+
+#### Scenario: filter array short-circuits on first fail
+
+- **GIVEN** a subscription with `filters = [{exact: {a: 1}}, {prefix: {b: 'pre-'}}]`
+  and an event with `a = 2`
+- **WHEN** `evaluateFilters($eventData, $filters)` runs
+- **THEN** the method SHALL return `false` after evaluating only the `exact` filter
+- **AND** the `prefix` filter SHALL NOT be evaluated
+
+#### Scenario: a subscription with empty types[] matches every event type
+
+- **GIVEN** a subscription with `types = []`
+- **WHEN** `doesEventMatchSubscription` runs against any event
+- **THEN** the `types` gate SHALL be a no-op (no rejection on type mismatch)
+
+#### Notes
+
+- ExpressionLanguage filters evaluate caller-supplied expression strings against the
+  event payload. Subscription owners (whoever can call `subscribe`) effectively get
+  code-execution-equivalent over an event data context. Observed-but-suspicious;
+  flagged for security review (REQ-005 Notes also flag the missing auth on
+  `subscribe`).
+
+### REQ-002: Push delivery with status tracking and retry sweep
+
+`EventService::deliverMessage(ObjectEntity $message)` MUST resolve the message's
+`subscriptionId` to an `event_subscription` via OR `find`, return `false` early if
+either the message's subscription ID is null OR the subscription does not exist OR
+the subscription's `style !== 'push'`. For push subscriptions the method MUST POST
+the message payload (JSON-encoded) to `subscription.sink` with `Content-Type:
+application/cloudevents+json`, a 30-second timeout, and any extra headers from
+`subscription.protocolSettings.headers`. On a 2xx response the method MUST persist
+the message with `status='delivered'`, `deliveredAt` (ISO 8601 timestamp), and a
+`deliveryResponse` block containing `statusCode` + `body`. On any non-2xx response
+OR any thrown exception, the method MUST log the error, persist
+`status='failed'` with the error message, and return `false`. `processRetries(int
+$maxRetries=5)` MUST scan every `event_message` with `status='pending'`, attempt
+delivery for messages whose `retryCount < $maxRetries`, and return the count of
+successes.
+
+#### Scenario: 2xx delivery marks the message delivered
+
+- **GIVEN** a `pending` push message
+- **WHEN** `deliverMessage(...)` runs AND the sink returns HTTP 200
+- **THEN** the message SHALL be persisted with `status='delivered'`, a `deliveredAt`
+  ISO timestamp, and `deliveryResponse.statusCode = 200`
+- **AND** the method SHALL return `true`
+
+#### Scenario: 5xx delivery marks the message failed and returns false
+
+- **GIVEN** a `pending` push message AND the sink returns HTTP 500
+- **WHEN** `deliverMessage(...)` runs
+- **THEN** the method SHALL throw, catch its own exception, log it, and persist
+  `status='failed'` with `error` set to the exception message
+- **AND** the method SHALL return `false`
+
+#### Scenario: processRetries respects the maxRetries cap
+
+- **GIVEN** a pending message with `retryCount = 5` and `processRetries($maxRetries=5)`
+- **WHEN** the sweep runs
+- **THEN** `deliverMessage` SHALL NOT be invoked for that message (retryCount >=
+  maxRetries)
+
+#### Notes
+
+- `processRetries` does NOT increment `retryCount` on the message after a failed
+  delivery — the field is read but never written. So in practice, a pending message
+  with `retryCount = 0` will be re-attempted on every sweep indefinitely. Observed
+  bug; flagged.
+- `deliverMessage` does not respect any Retry-After header from the sink — it just
+  marks the message failed and exits. Observed; flagged.
+
+### REQ-003: Pull subscription cursor pagination
+
+`EventService::pullEvents(ObjectEntity $subscription, ?int $limit=100, ?string
+$cursor=null)` MUST query `event_message` filtered by the subscription's UUID and
+`status='pending'`. When `$cursor` is non-null, the method MUST apply a filter
+`id > $cursor` to skip past previously-delivered messages. The method MUST return
+an array `{messages: ObjectEntity[], cursor: string|null}` where `cursor` is the
+UUID of the last message in the returned set (or `null` when the result is empty),
+so the caller can pass it on the next `pull` call to continue pagination.
+`EventsController::pull(string $subscriptionId)` MUST resolve the subscription via OR
+`find`, return 404 if missing, return 400 if `style !== 'pull'`, and otherwise call
+`EventService::pullEvents` passing `limit` and `cursor` query parameters from the
+request.
+
+#### Scenario: a pull call without a cursor returns the first page
+
+- **GIVEN** a pull subscription with 150 pending messages and `pull(subscriptionId)`
+  with `limit=100`
+- **WHEN** the controller runs
+- **THEN** the response SHALL contain 100 messages
+- **AND** `cursor` SHALL be the UUID of the 100th message
+- **AND** subsequent `pull` calls with that cursor SHALL return the remaining 50
+
+#### Scenario: a pull call on a push-style subscription returns 400
+
+- **GIVEN** a subscription with `style='push'`
+- **WHEN** `EventsController::pull($subscriptionId)` runs
+- **THEN** the response SHALL be HTTP 400 with `error = "Subscription is not pull-based"`
+
+#### Scenario: an empty result returns a null cursor
+
+- **GIVEN** a pull subscription with zero pending messages
+- **WHEN** `pullEvents(...)` runs
+- **THEN** the result SHALL be `{messages: [], cursor: null}`
+
+#### Notes
+
+- The `id > $cursor` filter assumes monotonic UUID ordering. UUIDv4 is not
+  monotonic; UUIDv7 is. Whether this filter does what the code thinks depends on
+  what OR's `findAll` does with the `>` operator on `id`. Observed; flagged.
+
+### REQ-004: OR object lifecycle → CloudEvent producer
+
+`EventService::handleObjectCreated(ObjectEntity $object)`,
+`handleObjectUpdated(ObjectEntity $oldObject, ObjectEntity $newObject)`, and
+`handleObjectDeleted(ObjectEntity $object)` MUST each persist a new `event` record
+in OR with the canonical CloudEvents shape: `source = '/objects/<type>'`, `type` =
+the corresponding `com.nextcloud.openregister.object.{created,updated,deleted}`,
+`time` = ISO 8601 now, `subject` = the object UUID, `data.type` + `data.id` = the
+object's type + UUID, AND (for created/updated) `data.attributes` = the object's
+serialised state. For updated events the `data.previous.attributes` MUST carry the
+old state. After persisting the `event`, each handler MUST invoke `processEvent`
+and return its result.
+
+#### Scenario: created handler emits a CloudEvent with full attributes
+
+- **GIVEN** a newly-created `ObjectEntity` of type `person` with UUID `uuid-1`
+- **WHEN** `handleObjectCreated($object)` runs
+- **THEN** a new `event` record SHALL be persisted with
+  `type='com.nextcloud.openregister.object.created'`, `source='/objects/person'`,
+  `subject='uuid-1'`, AND `data.attributes` equal to the object's serialised state
+- **AND** `processEvent` SHALL be invoked
+
+#### Scenario: updated handler carries previous state under data.previous
+
+- **GIVEN** an `oldObject` (state A) AND a `newObject` (state B)
+- **WHEN** `handleObjectUpdated($oldObject, $newObject)` runs
+- **THEN** the persisted `event.data.previous.attributes` SHALL equal state A
+- **AND** the persisted `event.data.attributes` SHALL equal state B
+
+#### Scenario: deleted handler omits attributes (object is gone)
+
+- **GIVEN** a deleted `ObjectEntity` of type `person` with UUID `uuid-1`
+- **WHEN** `handleObjectDeleted($object)` runs
+- **THEN** the persisted `event.data` SHALL contain `type` and `id` only — no
+  `attributes` block
+
+#### Notes
+
+- All three handlers compute `userId` as `objectData['userId'] ?? null` — the
+  userId reflects the object's owner field, not the actor who triggered the change.
+  For audit-trail purposes the correct field would be the Nextcloud session user.
+  Observed; flagged.
+
+### REQ-005: Events and subscriptions REST surface
+
+`EventsController` MUST expose seven JSON endpoints, each marked
+`@NoAdminRequired` and `@NoCSRFRequired`:
+
+- `messages(int $id)` — returns the event AND its messages (404 if event missing)
+- `subscribe()` — creates a new `event_subscription` from request params, stripping
+  any `_*`-prefixed internal fields; returns 400 on any exception
+- `updateSubscription(string $subscriptionId)` — updates an existing subscription
+  the same way; returns 404 if missing, 400 on other exceptions
+- `unsubscribe(string $subscriptionId)` — deletes the subscription; returns 404
+  if missing
+- `subscriptions()` — lists subscriptions filtered by any request param (with `_*`
+  internal fields stripped); returns `{results: [...]}`
+- `subscriptionMessages(string $subscriptionId)` — returns the subscription + its
+  messages (404 if missing)
+- `pull(string $subscriptionId)` — see REQ-003 (cursor pagination on pull
+  subscriptions)
+
+Every list method MUST honour optional `limit` (default 50) and `offset` (default 0)
+query parameters.
+
+#### Scenario: subscribing with a valid payload returns the saved subscription
+
+- **GIVEN** a request `POST /api/events/subscriptions` with body
+  `{types: ['com.x'], style: 'push', sink: 'https://x/cb'}`
+- **WHEN** `subscribe()` runs
+- **THEN** an `event_subscription` SHALL be persisted in OR
+- **AND** the response SHALL be HTTP 200 with the saved object's serialised state
+
+#### Scenario: updating a missing subscription returns 404
+
+- **GIVEN** `updateSubscription('missing-uuid')`
+- **WHEN** the controller runs
+- **THEN** the response SHALL be HTTP 404 with
+  `error = "Subscription not found"`
+
+#### Notes
+
+- **Security / IDOR**: every controller method is `@NoAdminRequired` with no
+  per-object authorization check — any authenticated Nextcloud user can list, modify,
+  or delete ANY subscription by UUID, regardless of who owns it. Compare with
+  hydra-gate-no-admin-idor pattern. **Severity: high — flagged for security review.**
+- **CSRF**: `@NoCSRFRequired` removes Nextcloud's built-in CSRF token requirement on
+  state-changing endpoints (`subscribe`, `updateSubscription`, `unsubscribe`). The
+  intent is presumably to allow API consumers without a Nextcloud session, but the
+  effect is that any authed browser tab can trigger these endpoints on a victim's
+  session. Observed; flagged.
+- The internal-field strip (`str_starts_with($key, '_')`) is a shallow guard that
+  does not stop the caller from supplying arbitrary other top-level fields on a
+  schema-less save. Observed; flagged.

--- a/openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-events-cloudevents/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: events-cloudevents#REQ-001 — CloudEvent fan-out to matching subscriptions (retroactive annotation)
+- [x] task-2: events-cloudevents#REQ-002 — Push delivery with status tracking and retry sweep (retroactive annotation)
+- [x] task-3: events-cloudevents#REQ-003 — Pull subscription cursor pagination (retroactive annotation)
+- [x] task-4: events-cloudevents#REQ-004 — OR object lifecycle → CloudEvent producer (retroactive annotation)
+- [x] task-5: events-cloudevents#REQ-005 — Events and subscriptions REST surface (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 17 methods (EventService 10 + EventsController 7) as 5 new REQs.

Ghost change: `retrofit-2026-05-24-events-cloudevents`.

### What this PR does
- Drafts 5 REQs in a new `events-cloudevents` capability spec (`retrofit: true`)
- Annotates 17 methods with `@spec` tags

### What this PR does NOT do
- No code behaviour changes — only docblock `@spec` annotations
- Does NOT silently fix the multiple security gaps documented in REQ Notes

### Review focus — multiple high-severity findings worth security-team attention
- **IDOR**: REQ-005 Notes — every controller method is `@NoAdminRequired` with no
  per-object owner check. Any authed NC user can list/modify/delete any
  `event_subscription` by UUID. Matches `hydra-gate-no-admin-idor` pattern exactly.
- **CSRF**: REQ-005 Notes — `@NoCSRFRequired` on `subscribe`/`updateSubscription`/
  `unsubscribe`. Any authed browser tab can trigger these on a victim's session.
- **Code execution**: REQ-001 Notes — `ExpressionLanguage::evaluate` runs
  subscription-owner-supplied expression strings against the event payload.
- **Functional bug**: REQ-002 Notes — `processRetries` reads `retryCount` but never
  writes it. Pending messages re-attempt forever rather than respecting the
  `maxRetries` cap.

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `events-cloudevents`

Refs #936