### PR TITLE
retrofit: reverse-spec authentication-twig (5 REQs / 22 methods)

### DIFF
--- a/lib/Service/AuthenticationService.php
+++ b/lib/Service/AuthenticationService.php
@@ -92,6 +92,8 @@ class AuthenticationService
      * @param array $configuration Configuration array for authentication.
      *
      * @return array|array[] The call options for OAuth with Client Credentials.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-1
      */
     private function createClientCredentialConfig(array $configuration): array
     {
@@ -142,6 +144,8 @@ class AuthenticationService
      * @param array $configuration Configuration array for authentication.
      *
      * @return array|array[] The call options for OAuth with Password Credentials
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-1
      */
     private function createPasswordConfig(array $configuration): array
     {
@@ -180,6 +184,8 @@ class AuthenticationService
      * @throws BadRequestException                     Thrown if the configuration is not compatible with OAuth.
      * @throws \GuzzleHttp\Exception\GuzzleException Thrown if the token endpoint does not respond with an access token.
      * @todo   Convert GuzzleException to another error.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-1
      */
     public function fetchOAuthTokens(array $configuration): string
     {
@@ -223,6 +229,8 @@ class AuthenticationService
      * @return string The access token
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-3
      */
     public function fetchDecosToken(array $configuration): string
     {
@@ -250,6 +258,8 @@ class AuthenticationService
      * @param array $configuration The auth configuration for the source.
      *
      * @return JWK|null The resulting JWK key, or null when the secret cannot be parsed.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-2
      */
     private function getRSJWK(array $configuration): ?JWK
     {
@@ -278,6 +288,8 @@ class AuthenticationService
      * @param array $configuration The source configuration.
      *
      * @return JWK|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-2
      */
     private function getHSJWK(array $configuration): ?JWK
     {
@@ -298,6 +310,8 @@ class AuthenticationService
      *
      * @throws \Twig\Error\LoaderError When the template cannot be loaded.
      * @throws \Twig\Error\SyntaxError When the template has invalid syntax.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-2
      */
     private function getJWTPayload(array $configuration): array
     {
@@ -312,6 +326,8 @@ class AuthenticationService
      * @param array $configuration The auth configuration for the source.
      *
      * @return JWK|null The resulting JWK key.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-2
      */
     private function getJWK(array $configuration): ?JWK
     {
@@ -334,6 +350,8 @@ class AuthenticationService
      * @param string|null $x5t       If applicable: the Base64 encoded SHA-1 thumbprint of the used certificate.
      *
      * @return string The serialised JWT token.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-2
      */
     private function generateJWT(array $payload, JWK $jwk, string $algorithm, ?string $x5t=null): string
     {
@@ -375,6 +393,8 @@ class AuthenticationService
      * @param array $configuration The auth configuration for the JWT token. Must at least contain payload, algorithm and secret.
      *
      * @return string The generated JWT token
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-2
      */
     public function fetchJWTToken(array $configuration): string
     {

--- a/lib/Twig/AuthenticationRuntime.php
+++ b/lib/Twig/AuthenticationRuntime.php
@@ -48,6 +48,8 @@ class AuthenticationRuntime implements RuntimeExtensionInterface
      * @return string
      *
      * @throws GuzzleException
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-4
      */
     public function oauthToken(array $source): string
     {
@@ -69,6 +71,8 @@ class AuthenticationRuntime implements RuntimeExtensionInterface
      * @return string
      *
      * @throws GuzzleException
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-4
      */
     public function decosToken(array $source): string
     {
@@ -90,6 +94,8 @@ class AuthenticationRuntime implements RuntimeExtensionInterface
      * @return string
      *
      * @throws GuzzleException
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-4
      */
     public function jwtToken(array $source): string
     {

--- a/lib/Twig/MappingRuntime.php
+++ b/lib/Twig/MappingRuntime.php
@@ -68,6 +68,8 @@ class MappingRuntime implements RuntimeExtensionInterface
      * @param string $input The unencoded input.
      *
      * @return string The encoded output.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-5
      */
     public function b64enc(string $input): string
     {
@@ -81,6 +83,8 @@ class MappingRuntime implements RuntimeExtensionInterface
      * @param string $input The encoded input.
      *
      * @return string The decoded output.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-5
      */
     public function b64dec(string $input): string
     {
@@ -94,6 +98,8 @@ class MappingRuntime implements RuntimeExtensionInterface
      * @param string $input The encoded input.
      *
      * @return array The decoded output.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-5
      */
     public function json_decode(string $input): array
     {
@@ -118,6 +124,8 @@ class MappingRuntime implements RuntimeExtensionInterface
      * @throws Exception
      * @throws LoaderError
      * @throws SyntaxError
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-5
      */
     public function callSource(string $sourceId, string $endpoint, string $method='GET', array $configuration=[], bool $decode=true): array|string
     {
@@ -144,6 +152,8 @@ class MappingRuntime implements RuntimeExtensionInterface
      * @param bool                                          $list    Whether the mapping runs on multiple instances of the object.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-5
      */
     public function executeMapping(\OCA\OpenRegister\Db\Mapping|array|string|int $mapping, array $input, bool $list=false): array
     {
@@ -176,6 +186,8 @@ class MappingRuntime implements RuntimeExtensionInterface
      * Generate a UUID v4.
      *
      * @return UuidV4
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-5
      */
     public function generateUuid(): UuidV4
     {
@@ -190,6 +202,8 @@ class MappingRuntime implements RuntimeExtensionInterface
      * @param string     $objectId The object ID that owns the file.
      *
      * @return string|null The file contents when found, otherwise null.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-5
      */
     public function getFileContents(string|int $fileId, string $objectId): ?string
     {
@@ -212,6 +226,8 @@ class MappingRuntime implements RuntimeExtensionInterface
      * @param string $objectId The object ID to fetch files for.
      *
      * @return array The formatted file metadata list.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-5
      */
     public function getFiles(string $objectId): array
     {
@@ -239,6 +255,8 @@ class MappingRuntime implements RuntimeExtensionInterface
      * @param string $text The text to convert to a slug.
      *
      * @return string The generated slug.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md#task-5
      */
     public function createSlug(string $text): string
     {

--- a/openspec/changes/retrofit-2026-05-24-authentication-twig/design.md
+++ b/openspec/changes/retrofit-2026-05-24-authentication-twig/design.md
@@ -1,0 +1,53 @@
+# Design — Retrofit authentication-twig
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+`AuthenticationService` (405 LOC, 10 methods) is the outbound-auth toolkit: it builds
+Guzzle call options for OAuth Client Credentials / Password / Decos, and mints signed
+JWTs using HS256/384/512 + RS256/384/512 + PS256. Two Twig runtimes
+(`AuthenticationRuntime`, `MappingRuntime`) expose these primitives plus generic
+encoding/mapping/file helpers to source-configuration Twig templates so an operator
+can write `{{ oauthToken(source) }}` directly into a templated header.
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `fetchOAuthTokens`, `createClientCredentialConfig`, `createPasswordConfig` |
+| REQ-002 | `fetchJWTToken`, `getJWK`, `getRSJWK`, `getHSJWK`, `getJWTPayload`, `generateJWT` |
+| REQ-003 | `fetchDecosToken` |
+| REQ-004 | `AuthenticationRuntime::oauthToken/decosToken/jwtToken` |
+| REQ-005 | `MappingRuntime::b64enc/b64dec/json_decode/callSource/executeMapping/generateUuid/getFileContents/getFiles/createSlug` |
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `getRSJWK` | private key written to `/var/tmp/privatekey-<microtime+pid>` then unlink — leak window | **high** |
+| `generateJWT` | catches its own Exception, returns the error message AS the JWT string — silently broken tokens | **high** (functional bug) |
+| `getHSJWK` | `addslashes` before base64-encoding the secret — peer mismatch on quote/backslash/NUL chars | medium |
+| `getJWTPayload` | Twig-renders payload before JSON-decoding — template injection if payload is caller-controlled | medium |
+| `fetchDecosToken` | posts entire remaining config as JSON body, not just credentials | low |
+| `MappingRuntime::executeMapping` | hydrates caller-supplied array directly into Mapping entity | medium |
+| `MappingRuntime::callSource` | `$decode` parameter accepted but never used | low |
+| `MappingRuntime::createSlug` | regex permits only ASCII; non-ASCII silently stripped | low |
+
+The combo of REQ-002's `generateJWT` swallowing exceptions and REQ-001 inlining a
+JWT via `fetchJWTToken` for client_assertion means a misconfigured RSA key would
+result in an `Authorization: Bearer <error message>` header being sent upstream.
+
+## What the spec deliberately does NOT cover
+
+- The Twig extensions themselves (`AuthenticationExtension`, `MappingExtension`)
+  that register the runtime — they are wiring, not observable behaviour.
+- `MappingService::executeMapping` — that lives in cluster `mapping-and-search`
+  (Wave 5).
+- The `REQUIRED_PARAMETERS_*` constants are referenced in REQ-001 prose but not
+  spelled out as their own REQ.
+
+## Validation
+
+After archive, `openspec validate authentication-twig --strict` MUST pass and Specter
+MUST register the spec as part of the retrofit cohort.

--- a/openspec/changes/retrofit-2026-05-24-authentication-twig/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-authentication-twig/proposal.md
@@ -1,0 +1,20 @@
+# Retrofit — authentication-twig
+
+Describes observed behavior of 22 methods under `authentication-twig` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+AuthenticationService.php (10 methods):
+- `fetchOAuthTokens`, `fetchDecosToken`, `fetchJWTToken`, `createClientCredentialConfig`, `createPasswordConfig`, `getRSJWK`, `getHSJWK`, `getJWK`, `getJWTPayload`, `generateJWT`
+
+AuthenticationRuntime.php (3 methods, Twig runtime):
+- `oauthToken`, `decosToken`, `jwtToken`
+
+MappingRuntime.php (9 methods, Twig runtime):
+- `b64enc`, `b64dec`, `json_decode`, `callSource`, `executeMapping`, `generateUuid`, `getFileContents`, `getFiles`, `createSlug`
+
+## Approach
+
+- Observed-but-suspicious behaviour flagged in REQ Notes (private RSA key written to `/var/tmp/privatekey-<microtime+pid>` then unlink — leak window on crash; HS-secret base64 includes `addslashes` quirk; JWT payload Twig-rendered then JSON-decoded — template injection if payload comes from caller-controlled data; `generateJWT` catches its own exception and returns the error message as the JWT — silently broken tokens propagate)
+
+Source: openspec/coverage-report.md generated 2026-05-24.

--- a/openspec/changes/retrofit-2026-05-24-authentication-twig/specs/authentication-twig/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-authentication-twig/specs/authentication-twig/spec.md
@@ -1,0 +1,210 @@
+---
+retrofit: true
+status: draft
+---
+
+# Authentication Service + Twig Runtimes
+
+## Purpose
+
+`AuthenticationService` builds outbound-call authentication configurations and signs
+JWT tokens for use by `CallService`. Two Twig runtimes — `AuthenticationRuntime` and
+`MappingRuntime` — expose the service's primitives (plus generic mapping/encoding
+helpers) to Twig templates used in source configurations. The runtimes are the
+template-side equivalent of the rule-pipeline's authentication processing: a source's
+`configuration.authentication.<scheme>Token` template is rendered before dispatch,
+and the runtime fetches the appropriate token for the source.
+
+## ADDED Requirements
+
+### REQ-001: OAuth Client Credentials and Password token fetch
+
+`AuthenticationService::fetchOAuthTokens(array $configuration)` MUST require
+`grant_type` and `tokenUrl` on the input; absence of either MUST throw
+`BadRequestException`. It MUST dispatch to `createClientCredentialConfig` (when
+`grant_type === 'client_credentials'`) or `createPasswordConfig` (when
+`grant_type === 'password'`); any other value MUST throw `BadRequestException` with
+message `Grant type not supported`. Each builder MUST verify all REQUIRED_PARAMETERS_*
+fields are present (else `BadRequestException` listing the missing keys). For both
+builders, when `configuration.authentication === 'body'` the credentials MUST be sent
+in `form_params`; when `'basic_auth'` they MUST be sent via Guzzle's `auth` option as
+`[client_id, client_secret]` (client_credentials) or `[username, password]` (password).
+The Client Credentials builder MUST additionally support a JWT-bearer client assertion
+when `configuration.client_assertion_type === 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'`
+by minting an inline JWT via `fetchJWTToken(algorithm=PS256, secret=private_key,
+x5t=x5t, payload=payload)` and attaching it as `client_assertion` in `form_params`.
+After dispatch the method MUST decode the JSON response and return either
+`$result[$configuration['tokenLocation']]` if a token location is configured, or
+`$result['access_token']` as the default.
+
+#### Scenario: client_credentials with basic_auth attaches credentials to Guzzle auth
+
+- **GIVEN** `configuration = {grant_type: 'client_credentials', scope: 'x',
+  authentication: 'basic_auth', client_id: 'cid', client_secret: 'sec', tokenUrl: '...'}`
+- **WHEN** `fetchOAuthTokens(...)` runs
+- **THEN** the Guzzle POST options SHALL include `auth: ['cid', 'sec']`
+- **AND** `form_params` SHALL contain only `grant_type` and `scope`
+
+#### Scenario: missing grant_type throws BadRequestException
+
+- **GIVEN** `configuration = {tokenUrl: 'https://idp/token'}` (no `grant_type`)
+- **WHEN** `fetchOAuthTokens(...)` runs
+- **THEN** `BadRequestException` SHALL be thrown with message
+  `"Grant type not set, cannot request token"`
+
+#### Notes
+
+- The two builder methods do NOT validate that the credentials they extract are
+  non-empty strings. An empty `client_secret` would be accepted and propagated to
+  the IdP, surfacing as a 401 from the upstream rather than a clear local error.
+  Observed.
+
+### REQ-002: JWT token minting with HS/RS/PS algorithms
+
+`AuthenticationService::fetchJWTToken(array $configuration)` MUST require `payload`,
+`secret`, and `algorithm` (else `BadRequestException`). It MUST render the payload
+through Twig (`getJWTPayload`), build a JWK appropriate for the algorithm family
+(`getJWK` → `getHSJWK` for HS256/HS512, `getRSJWK` for RS256/RS384/RS512/PS256), and
+sign via `generateJWT`. The signed JWT MUST be returned in compact serialisation
+format. When `configuration.x5t` is supplied, it MUST be attached as the JWT header
+`x5t`. The supported algorithms are HS256/HS384/HS512 (instantiated even though
+`getJWK` only branches on HS256/HS512), RS256/RS384/RS512, and PS256. PS384/PS512
+are NOT supported.
+
+#### Scenario: a valid PS256 configuration mints a compact-serialised JWT
+
+- **GIVEN** `configuration = {payload: '{"sub":"x"}', secret: <base64 RSA priv key>,
+  algorithm: 'PS256'}`
+- **WHEN** `fetchJWTToken(...)` runs
+- **THEN** the JWT payload SHALL be Twig-rendered then JSON-decoded
+- **AND** an RS private-key JWK SHALL be built from the secret
+- **AND** a compact-serialised JWS SHALL be returned
+
+#### Scenario: an unsupported algorithm throws
+
+- **GIVEN** `configuration.algorithm = 'PS384'`
+- **WHEN** `getJWK(...)` runs
+- **THEN** `BadRequestException` SHALL be thrown with message
+  `"Algorithm not supported by key generator"`
+
+#### Notes
+
+- **High severity**: `getRSJWK` writes the base64-decoded private key to
+  `/var/tmp/privatekey-<microtime+pid>`, then `JWKFactory::createFromKeyFile` reads
+  it, then `unlink`. On a crash, exception, or concurrent worker race in the same
+  microsecond, private key bytes leak to `/var/tmp` (which is world-readable on many
+  systems). Compare with the same pattern in `AuthorizationService::getJWK`
+  (REQ-001 of `authorization-jwt`). Observed; flagged.
+- **Medium severity**: `getHSJWK` builds the symmetric key as
+  `rtrim(base64_encode(addslashes($configuration['secret'])), '=')`. `addslashes`
+  before base64-encoding is unusual — if the secret contains `'`, `"`, `\`, or NUL,
+  the JWK key bytes will not match what a peer signing with the raw secret
+  produces. Observed; flagged.
+- **Medium severity**: `generateJWT` catches its own `Exception` and **returns the
+  exception message as the JWT string**. Downstream code (`fetchOAuthTokens`,
+  `AuthenticationRuntime::jwtToken`) takes that string as if it were a valid token
+  and sends it. A signing failure surfaces as an authentication 401, not as a clear
+  error. Observed; flagged as a functional bug.
+- `getJWTPayload` Twig-renders the payload before JSON-decoding. If the payload
+  template comes from caller-controlled data (e.g., per-source configuration
+  managed via the openconnector UI), template injection lets the operator extract
+  any Twig-accessible context. Observed.
+
+### REQ-003: Decos non-standard OAuth token fetch
+
+`AuthenticationService::fetchDecosToken(array $configuration)` MUST extract `tokenUrl`
++ `tokenLocation` from the configuration, then POST the remaining configuration as a
+JSON body to `tokenUrl`. The response MUST be JSON-decoded; the token MUST be
+returned from `$result[$tokenLocation]` if specified, else from `$result['token']`.
+
+#### Scenario: Decos token fetch returns the token field by default
+
+- **GIVEN** `configuration = {tokenUrl: '...', username: '...', password: '...'}`
+- **WHEN** `fetchDecosToken(...)` runs
+- **THEN** a POST SHALL be issued to `tokenUrl` with the remaining configuration as
+  JSON body
+- **AND** the method SHALL return `$response['token']`
+
+#### Notes
+
+- `fetchDecosToken` posts the **entire remaining configuration** (including
+  `tokenLocation`) as the JSON body, not just credentials. Sources whose `auth`
+  block contains unrelated config keys leak those keys to the Decos endpoint.
+  Observed.
+
+### REQ-004: Twig authentication runtime — token injection into sources
+
+`AuthenticationRuntime` MUST expose three Twig functions — `oauthToken(source)`,
+`decosToken(source)`, `jwtToken(source)` — each of which extracts
+`$source['configuration']['authentication']` (via Adbar Dot for dotted keys) and
+forwards it to the matching `AuthenticationService::fetch*` method. The return value
+of each function is the token string, ready for direct injection into a templated
+header (e.g. `Authorization: Bearer {{ oauthToken(source) }}`).
+
+#### Scenario: jwtToken function returns the result of fetchJWTToken
+
+- **GIVEN** a source with `configuration.authentication = {algorithm: 'HS256',
+  secret: 'abc', payload: '{"sub": "x"}'}`
+- **WHEN** a Twig template invokes `{{ jwtToken(source) }}`
+- **THEN** the runtime SHALL call `AuthenticationService::fetchJWTToken($authConfig)`
+- **AND** SHALL return the signed JWT string
+
+#### Notes
+
+- The three runtime methods are thin Adbar-Dot adapters with no error handling — any
+  exception from the service propagates to the Twig template evaluation, which
+  becomes a `LoaderError`/`SyntaxError` at the call site. Observed.
+
+### REQ-005: Twig mapping runtime — encoding, mapping execution, file lookup, slug
+
+`MappingRuntime` MUST expose nine Twig helpers used by source-configuration
+templates and by the mapping engine:
+
+- `b64enc(string)` → `base64_encode`
+- `b64dec(string)` → `base64_decode`
+- `json_decode(string)` → `json_decode($input, associative=true)`
+- `generateUuid()` → `Symfony\Component\Uid\Uuid::v4()`
+- `createSlug(string)` → lowercase + space/underscore-to-hyphen + non-`[a-z0-9-]`
+  removal + collapse-multi-hyphen + trim-leading-trailing-hyphen
+- `callSource(sourceId, endpoint, method='GET', config=[], decode=true)` →
+  resolves the source via OR `find`, strips any `source.location` prefix from
+  `endpoint`, calls `CallService::call(...)`, returns `response.body` from the
+  resulting CallLog (or empty string when absent)
+- `executeMapping(mapping, input, list=false)` → accepts `\OCA\OpenRegister\Db\Mapping`
+  / array / string / int; hydrates an array or resolves a string/int via OR `find`;
+  delegates to `MappingService::executeMapping`
+- `getFileContents(fileId, objectId)` → resolves the object's files via `FileService`,
+  filters to the matching `fileId`, returns the file contents (or `null` when not
+  exactly one match)
+- `getFiles(objectId)` → returns the formatted file metadata list for the object via
+  `FileService::getFiles` + `formatFile`
+
+#### Scenario: createSlug normalises a mixed-case underscored title
+
+- **GIVEN** `createSlug('Hello_World 2026!')`
+- **WHEN** the helper runs
+- **THEN** the result SHALL be `'hello-world-2026'`
+
+#### Scenario: callSource strips the source location prefix from the endpoint
+
+- **GIVEN** a source with `location = 'https://api.example.test/v1'` AND a Twig
+  call `callSource(sourceId, 'https://api.example.test/v1/things', 'GET')`
+- **WHEN** `callSource(...)` runs
+- **THEN** the effective endpoint passed to `CallService::call` SHALL be `'/things'`
+
+#### Scenario: getFileContents returns null on ambiguous matches
+
+- **GIVEN** an object with TWO files sharing the same `fileId`
+- **WHEN** `getFileContents($fileId, $objectId)` runs
+- **THEN** the method SHALL return `null` (count !== 1)
+
+#### Notes
+
+- `executeMapping` accepts caller-supplied arrays and hydrates them directly into a
+  `Mapping` entity (line 151-155). If the array comes from caller-controlled input
+  (e.g., a request body that flows into a Twig template), the caller can hydrate
+  arbitrary fields onto a Mapping object. Observed; flagged.
+- `callSource` returns the response body as a string by default but the `$decode`
+  parameter is accepted and never used. Observed; flagged.
+- `createSlug` regex permits only ASCII; non-ASCII characters (umlauts, accents,
+  Cyrillic, etc.) are silently stripped. Observed.

--- a/openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-authentication-twig/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: authentication-twig#REQ-001 — OAuth Client Credentials and Password token fetch (retroactive annotation)
+- [x] task-2: authentication-twig#REQ-002 — JWT token minting with HS/RS/PS algorithms (retroactive annotation)
+- [x] task-3: authentication-twig#REQ-003 — Decos non-standard OAuth token fetch (retroactive annotation)
+- [x] task-4: authentication-twig#REQ-004 — Twig authentication runtime — token injection into sources (retroactive annotation)
+- [x] task-5: authentication-twig#REQ-005 — Twig mapping runtime — encoding, mapping execution, file lookup, slug (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 22 methods across `AuthenticationService` +
`AuthenticationRuntime` + `MappingRuntime` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-authentication-twig`.

### What this PR does
- Drafts 5 REQs in a new `authentication-twig` capability spec (`retrofit: true`)
- Annotates 22 methods (10 service + 3 auth runtime + 9 mapping runtime) with
  `@spec` tags

### Review focus — multiple high-severity findings (REQ-002)
- **Private key file leak**: `getRSJWK` writes the base64-decoded RSA private key
  to `/var/tmp/privatekey-<microtime+pid>` then `unlink`s. Crash/race window leaks
  the key. Same pattern as `authorization-jwt#REQ-001`.
- **Silent JWT bug**: `generateJWT` catches its own `Exception` and
  **returns the exception message as the JWT string**. The downstream code
  (`fetchOAuthTokens`, `AuthenticationRuntime::jwtToken`) treats that error string
  as a valid token and ships it as `Authorization: Bearer <error message>`.
- **HS-key encoding quirk**: `getHSJWK` `addslashes` before base64-encoding —
  silently mismatches the peer's symmetric key on `'`, `"`, `\`, NUL.
- **Twig template injection**: `getJWTPayload` renders the payload through Twig
  before JSON-decoding; if the payload template is operator-controlled, template
  injection is trivial.

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `authentication-twig`

Refs #936