### PR TITLE
retrofit: reverse-spec repair-and-app-boot (2 REQs / 2 methods)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -136,6 +136,8 @@ class Application extends App implements IBootstrap
      * @param IBootContext $context Boot context.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-repair-and-app-boot/tasks.md#task-2
      */
     private function registerIntegrationProviders(IBootContext $context): void
     {

--- a/lib/Repair/InitializeRegister.php
+++ b/lib/Repair/InitializeRegister.php
@@ -88,6 +88,8 @@ class InitializeRegister implements IRepairStep
      * @param IOutput $output progress/info channel piped to occ stdout
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-repair-and-app-boot/tasks.md#task-1
      */
     public function run(IOutput $output): void
     {

--- a/openspec/changes/retrofit-2026-05-24-repair-and-app-boot/design.md
+++ b/openspec/changes/retrofit-2026-05-24-repair-and-app-boot/design.md
@@ -1,0 +1,55 @@
+# Design — Retrofit repair-and-app-boot
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+Two app-lifecycle hooks that run before any user-facing controller is invoked:
+
+1. `lib/Repair/InitializeRegister.php::run()` — an `IRepairStep` wired in
+   `appinfo/info.xml` under both `<install>` and `<post-migration>`. Imports the
+   openconnector register descriptor (`lib/Settings/openconnector_register.json`,
+   15 schemas) into OpenRegister via `ConfigurationService::importFromApp()`.
+2. `lib/AppInfo/Application.php::registerIntegrationProviders()` — runs from
+   `boot()` on every request. Registers openconnector's
+   `SynchronizationContractProvider` with OR's
+   `IntegrationRegistry` (ADR-019 pluggable integration registry) so the SyncContract
+   leaf surfaces in OR object sidebars.
+
+Both hooks are intentionally soft-fail: they catch every `\Throwable`, write a
+warning to `IOutput` (repair step) or the PSR-3 logger (boot), and return cleanly.
+This is the canonical fleet pattern documented in the memory note
+[`reference_or-register-import-via-repair-step.md`] — repair steps run after every
+enabled app's autoloader is wired, which `Migration::postSchemaChange` does not
+guarantee on a cold `occ app:enable`.
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `InitializeRegister::run` catch blocks | every `\Throwable` becomes a `$output->warning()` + `LoggerInterface::error()`; the repair step never fails the upgrade. Install can complete with the register missing and the user only sees a warning line in `occ` output. | medium — install appears green when it actually didn't |
+| `InitializeRegister::run::class_exists` | `class_exists('\\OCA\\OpenRegister\\Service\\ConfigurationService') === false` returns silently with `$output->warning`. No alternative bootstrap path — if OR is disabled at install time and enabled later, openconnector's register never imports until the next `occ upgrade` or manual repair. | medium — fleet pattern but worth pinning in spec |
+| `registerIntegrationProviders` double-catch | the inner `try { logger->warning } catch (\Throwable)` swallows logger-resolution failures so the boot path is exception-safe even when no logger is wired. Defensible, but masks misconfigured DI containers. | low |
+| `InitializeRegister::run` no `storage_migrated` guard | the class docblock (line 47) advertises a `storage_migrated` IAppConfig guard for "the legacy → OR row migration", but `run()` itself never reads or sets that key. Legacy-row migration is implemented elsewhere (or not at all); the docblock is misleading. | low — docstring drift |
+
+These are documented in REQ Notes rather than silently fixed via spec text.
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `InitializeRegister::run` |
+| REQ-002 | `Application::registerIntegrationProviders` |
+
+## What the spec deliberately does NOT cover
+
+- `InitializeRegister::__construct` / `getName` — DI plumbing and a static label
+  string.
+- `Application::__construct` / `register()` — event-listener wiring is a separate
+  concern (cluster `events-cloudevents` covers the listener contracts).
+- The descriptor file contents (`openconnector_register.json`) — the schema /
+  register list is configuration data, not behaviour.
+
+## Validation
+
+After archive, `openspec validate repair-and-app-boot --strict` MUST pass.

--- a/openspec/changes/retrofit-2026-05-24-repair-and-app-boot/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-repair-and-app-boot/proposal.md
@@ -1,0 +1,16 @@
+# Retrofit — repair-and-app-boot
+
+Describes observed behavior of 2 methods under `repair-and-app-boot` as 2 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Repair/InitializeRegister.php::run()`
+- `lib/AppInfo/Application.php::registerIntegrationProviders()`
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces observed-but-suspicious behavior (catch-and-warn-anywhere pattern; silent skip when OR autoloader unavailable)
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-repair-and-app-boot/specs/repair-and-app-boot/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-repair-and-app-boot/specs/repair-and-app-boot/spec.md
@@ -1,0 +1,142 @@
+---
+retrofit: true
+status: draft
+---
+
+# Repair and app boot
+
+## Purpose
+
+Two lifecycle hooks that bootstrap openconnector against OpenRegister: a
+`<repair-step>` that imports the openconnector register descriptor at install /
+upgrade time, and a `boot()`-time registration of openconnector's
+`IntegrationProvider`s with OR's pluggable integration registry.
+
+This spec retroactively documents the observed contract of those two methods.
+
+## ADDED Requirements
+
+### REQ-001: Register descriptor import via OR ConfigurationService on install/upgrade
+
+`InitializeRegister::run(IOutput $output)` MUST attempt to import openconnector's
+register descriptor (`lib/Settings/openconnector_register.json`) into OpenRegister
+via `ConfigurationService::importFromApp(appId, data, version)` on every invocation.
+The method is invoked by Nextcloud's repair-step framework on both first install
+(`<install>` block in `appinfo/info.xml`) and on every subsequent `occ upgrade`
+(`<post-migration>` block).
+
+The method MUST resolve OR's `ConfigurationService` lazily from the server DI
+container so that openconnector can be installed before openregister without crashing
+the install. When OR's `ConfigurationService` class is not loadable (OR not enabled),
+the method MUST emit an `$output->warning` and a `LoggerInterface::warning` then
+return cleanly — install MUST continue.
+
+The descriptor's `version` argument is the value of the
+`openconnector / installed_version` app-config key (defaults to `"1.0.0"` if unset)
+so that OR's `importFromApp` can short-circuit when the existing register is up to
+date.
+
+Every failure path (container resolution, missing descriptor file, descriptor JSON
+parse failure, OR import failure) is observed to be a `$output->warning` +
+`LoggerInterface::error` + early return — the repair step NEVER throws and NEVER
+fails the upgrade.
+
+#### Scenario: install with OR present imports the register
+
+- **GIVEN** openregister is enabled before openconnector
+- **AND** `lib/Settings/openconnector_register.json` exists on disk
+- **WHEN** `InitializeRegister::run(...)` runs as part of `occ app:enable openconnector`
+- **THEN** OR's `ConfigurationService::importFromApp` is called with
+  `appId='openconnector'`, `data=<parsed descriptor>`, `version=<installed_version
+  app-config>`
+- **AND** an `$output->info('register descriptor imported …')` message is emitted
+
+#### Scenario: install without OR succeeds with a warning
+
+- **GIVEN** openregister is NOT enabled at the time openconnector installs
+- **WHEN** `InitializeRegister::run(...)` runs
+- **THEN** the method emits `$output->warning('OpenRegister is not installed or enabled…')`
+- **AND** the method returns without throwing
+- **AND** the openconnector install completes
+
+#### Scenario: import failure does not fail the upgrade
+
+- **GIVEN** OR is enabled but `importFromApp` throws (e.g. transient DB error)
+- **WHEN** `InitializeRegister::run(...)` runs
+- **THEN** the exception is caught, `$output->warning('register import failed: …')`
+  is emitted, and `LoggerInterface::error` is logged
+- **AND** the method returns without rethrowing
+- **AND** the upgrade reports success
+
+#### Notes
+
+- The "install appears green when it actually didn't" property is OBSERVED, not a
+  desired behaviour. Operators reading `occ` output need to look for `warning`
+  lines; `occ` exit status alone is not sufficient. Tightening this (e.g.
+  reraising on `importFromApp` failure for non-fresh-installs) is a separate
+  hardening change.
+- The class docblock advertises a `storage_migrated` IAppConfig guard for a legacy
+  → OR row migration, but `run()` itself reads no such key. Treat the docstring
+  as drift until a follow-up either implements the migration or removes the
+  reference.
+
+---
+
+### REQ-002: IntegrationProvider boot-time registration with OR IntegrationRegistry
+
+`Application::registerIntegrationProviders(IBootContext $context)` MUST be called
+from `Application::boot()` on every request and MUST register openconnector's
+`SynchronizationContractProvider` with OR's `IntegrationRegistry` so that
+SyncContract leaves render in OR object sidebars per ADR-019.
+
+The method MUST short-circuit cleanly with no log emission when
+`IntegrationRegistry::class` is not loadable (OR not enabled / earlier in boot
+order). When the class is loadable but resolution from the DI container throws,
+the method MUST log a `LoggerInterface::warning` with the message
+`openconnector: failed to register IntegrationProviders with OR — <reason>` and
+return without rethrowing — boot MUST NOT crash.
+
+Provider registration is observed to happen exactly once per app instance per
+boot invocation (called from `boot()`, which Nextcloud invokes once per request
+after `register()`).
+
+#### Scenario: OR present registers the SynchronizationContractProvider
+
+- **GIVEN** openregister is enabled and `OCA\OpenRegister\Service\IntegrationRegistry`
+  is loadable
+- **WHEN** `Application::registerIntegrationProviders($context)` runs
+- **THEN** the server container resolves `IntegrationRegistry`
+- **AND** `$registry->addProvider(<SynchronizationContractProvider instance>)` is
+  invoked
+- **AND** the method returns without throwing
+
+#### Scenario: OR absent short-circuits silently
+
+- **GIVEN** `OCA\OpenRegister\Service\IntegrationRegistry` is NOT loadable
+- **WHEN** `Application::registerIntegrationProviders($context)` runs
+- **THEN** the method returns early
+- **AND** no log entry is emitted
+- **AND** the openconnector boot completes
+
+#### Scenario: provider resolution failure logs and continues
+
+- **GIVEN** OR is loadable but `$container->get(SynchronizationContractProvider::class)`
+  throws (e.g. constructor dependency missing)
+- **WHEN** `Application::registerIntegrationProviders($context)` runs
+- **THEN** the outer `\Throwable` catch logs
+  `openconnector: failed to register IntegrationProviders with OR — <message>`
+  via the server container's `LoggerInterface`
+- **AND** if logger resolution itself fails, the inner catch swallows it
+- **AND** the method returns without rethrowing
+- **AND** the openconnector boot completes (SyncContract leaves simply will not
+  appear in OR sidebars on this request)
+
+#### Notes
+
+- The inner `try { logger->warning } catch (\Throwable)` swallows logger
+  resolution failures so the boot path is exception-safe even on a broken DI
+  container. Defensible for early-boot resilience but masks misconfigured
+  containers in dev.
+- Provider list is currently one entry (`SynchronizationContractProvider`).
+  Future additions land here; this REQ scopes the registration pattern, not the
+  catalogue.

--- a/openspec/changes/retrofit-2026-05-24-repair-and-app-boot/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-repair-and-app-boot/tasks.md
@@ -1,0 +1,4 @@
+# Tasks
+
+- [x] task-1: repair-and-app-boot#REQ-001 — Register descriptor import via OR ConfigurationService on install/upgrade (retroactive annotation)
+- [x] task-2: repair-and-app-boot#REQ-002 — IntegrationProvider boot-time registration with OR IntegrationRegistry (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 2 methods under `repair-and-app-boot` as 2 new REQs.

Ghost change: `retrofit-2026-05-24-repair-and-app-boot` (drafted in `openspec/changes/`).

### What this PR does
- Drafts 2 REQs as a new capability spec (`retrofit: true`)
- Creates tasks.md with one task per REQ
- Annotates 2 methods with `@spec openspec/changes/retrofit-.../tasks.md#task-N`
- design.md flags observed-but-suspicious behaviour per the retrofit playbook

### What this PR does NOT do
- No code behavior changes — only docblock `@spec` annotations
- Does not silently fix observed-but-buggy behaviour — notes/design surface it

### Security / soft-fail findings flagged (not fixed)
- `InitializeRegister::run` catches every `\Throwable` and warns-and-returns; an install can complete with the register missing while `occ` only emits a warning line.
- `class_exists` short-circuit: if OR is enabled AFTER openconnector, the register import never re-runs until the next `occ upgrade` or manual repair.
- Class docblock advertises a `storage_migrated` guard that `run()` does not read — drift.
- `registerIntegrationProviders` swallows logger-resolution failures via a nested try/catch; defensible for boot resilience but masks misconfigured DI containers.

### Review focus
- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- One REQ per observable lifecycle hook

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `repair-and-app-boot`

Refs ConductionNL/openconnector#936