### PR TITLE
retrofit: reverse-spec storage-uploads (4 REQs / 4 methods)

### DIFF
--- a/lib/Service/StorageService.php
+++ b/lib/Service/StorageService.php
@@ -132,6 +132,8 @@ class StorageService
      * @throws NotFoundException     When the target path does not exist.
      * @throws InvalidPathException  When the target path is invalid.
      * @throws NotPermittedException When the target path is not writable.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-storage-uploads/tasks.md#task-1
      */
     public function createUpload(string $path, string $fileName, int $size, ?string $objectId=null): array
     {
@@ -199,6 +201,8 @@ class StorageService
      * @throws LockedException       When the target file is locked.
      * @throws NotFoundException     When the path does not exist.
      * @throws NotPermittedException When the path is not writable.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-storage-uploads/tasks.md#task-2
      */
     public function writeFile(string $path, string $fileName, string $content): File
     {
@@ -236,6 +240,8 @@ class StorageService
      * @throws NotFoundException     When a part file does not exist.
      * @throws NotPermittedException When the storage is not writable.
      * @throws InvalidPathException  When a part path is invalid.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-storage-uploads/tasks.md#task-4
      */
     private function attemptCloseUpload(array $folderContents, File $target, int $numParts): bool
     {
@@ -307,6 +313,8 @@ class StorageService
      * @throws LockedException       When the target file is locked.
      * @throws NotFoundException     When the part folder or target does not exist.
      * @throws NotPermittedException When the storage is not writable.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-storage-uploads/tasks.md#task-3
      */
     public function writePart(int $partId, string $partUuid, string $data): bool
     {

--- a/openspec/changes/retrofit-2026-05-24-storage-uploads/design.md
+++ b/openspec/changes/retrofit-2026-05-24-storage-uploads/design.md
@@ -1,0 +1,64 @@
+# Design — Retrofit storage-uploads
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+`lib/Service/StorageService.php` reconciles multi-part file uploads into a single
+target file in Nextcloud's file storage. The flow is:
+
+1. `createUpload($path, $fileName, $size, $objectId?)` — allocates an empty target
+   file plus a sibling `{$fileName}_parts/` folder, splits `$size` by
+   `openconnector.part-size` (default 1 MB), and writes one cache entry per part
+   describing the target file id, parts folder path, and total part count.
+2. `writePart($partId, $partUuid, $data)` — reads the cache entry, writes the
+   incoming part data into `{$partsFolder}/{$partId}.part.{$ext}`, and if the
+   parts folder now contains at least `numParts` entries, calls
+   `attemptCloseUpload(...)`.
+3. `attemptCloseUpload($folderContents, $target, $numParts)` — checks every part
+   `1..numParts` is present, concatenates them in-memory, writes the
+   concatenation into `$target` via `File::putContent`, deletes each part file,
+   and removes the parts folder if it ends up empty.
+
+`writeFile($path, $fileName, $content)` is a separate single-shot helper that
+writes a file under the **current logged-in user's** root folder (not the
+APP_USER fixture the multi-part path uses).
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `writeFile::$this->userSession` | The class never declares `IUserSession $userSession` and the constructor never injects it. Calling `writeFile()` triggers an `Error: Undefined property StorageService::$userSession`. The method appears to be **dead code** at runtime. | **HIGH — broken method, latent bug** |
+| `attemptCloseUpload::$totalContent` | Concatenates every part's content into a single PHP string before `putContent`. Memory scales with upload size — large files (multi-GB) will exhaust PHP memory. The class even imports `IObjectStoreMultiPartUpload` / `IChunkedFileWrite` interfaces but does not use them. | medium — soft DoS via upload size |
+| `writePart::$partData` | Reads upload metadata from the distributed cache by key `upload_$partUuid` with no auth check on the caller. Anyone who learns a UUID can append parts to a foreign upload, including a chosen-ID `objectId` reference. | medium — IDOR via cache-key knowledge |
+| `writePart::$targetFile` resolution | Resolves the target via `rootFolder->getUserFolder(APP_USER)->getFirstNodeById(...)`. If the same id exists in multiple paths under APP_USER, the first match wins — `$partData[UPLOAD_TARGET_PATH]` is recorded but not cross-checked against the resolved file's parent. | low |
+| `attemptCloseUpload::preg_match` | Regex `^[0-9]+\.part\.{$target->getExtension()}$` is not anchored with `\A\z` and uses the raw extension as a regex fragment. An extension containing regex metacharacters (e.g. `.`) is interpreted literally because `.` happens to match itself, but adversarial filenames with regex-special chars in the extension could open false-positives or matching skips. | low |
+| `createUpload::$user` | Resolves `userManager->get(APP_USER)` but never uses the result — the `userFolder` line is commented out. Dead variable. | informational |
+| `createUpload` no auth check | Same IDOR shape as `writePart`: any caller can allocate uploads under arbitrary `$objectId`. Authz is presumably enforced by the controller that calls this service, but the service offers no defence in depth. | low |
+
+These are documented in REQ Notes rather than silently fixed via spec text.
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `createUpload` |
+| REQ-002 | `writeFile` |
+| REQ-003 | `writePart` |
+| REQ-004 | `attemptCloseUpload` |
+
+The private `attemptCloseUpload` is kept as its own REQ rather than folded into
+REQ-003 because its reconciliation contract — total-content rebuild + part
+deletion + folder cleanup — is a distinct observable behaviour worth pinning.
+
+## What the spec deliberately does NOT cover
+
+- `StorageService::__construct` — DI plumbing.
+- Distributed-cache implementation choice (`ICacheFactory::createDistributed`) —
+  internal.
+- The HTTP endpoints that call these methods — covered by the
+  `endpoint-runtime` cluster.
+
+## Validation
+
+After archive, `openspec validate storage-uploads --strict` MUST pass.

--- a/openspec/changes/retrofit-2026-05-24-storage-uploads/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-storage-uploads/proposal.md
@@ -1,0 +1,18 @@
+# Retrofit — storage-uploads
+
+Describes observed behavior of 4 methods under `storage-uploads` as 4 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Service/StorageService.php::createUpload()`
+- `lib/Service/StorageService.php::writeFile()`
+- `lib/Service/StorageService.php::writePart()`
+- `lib/Service/StorageService.php::attemptCloseUpload()` (private helper of writePart)
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces observed-but-suspicious behavior (undeclared `userSession` property in `writeFile`; full-file in-memory reconciliation; cache-derived path traversal surface)
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-storage-uploads/specs/storage-uploads/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-storage-uploads/specs/storage-uploads/spec.md
@@ -1,0 +1,201 @@
+---
+retrofit: true
+status: draft
+---
+
+# Storage uploads
+
+## Purpose
+
+Multi-part file upload reconciliation backed by Nextcloud's file storage. Upload
+sessions are tracked by per-part UUIDs in the distributed cache. Parts are
+appended one HTTP request at a time and reconciled into the target file once all
+parts have arrived. Additionally exposes a single-shot write helper for
+non-chunked file content.
+
+## ADDED Requirements
+
+### REQ-001: Multi-part upload initialisation with cache-tracked parts
+
+`createUpload(string $path, string $fileName, int $size, ?string $objectId = null): array`
+MUST allocate an empty target file at `{$path}/{$fileName}` plus a sibling parts
+folder at `{$path}/{$fileName}_parts/`. The method MUST split `$size` into
+`ceil($size / openconnector.part-size)` parts, where `part-size` is read from
+`IAppConfig` (default 1,000,000 bytes), and for each part MUST write a cache
+entry under key `upload_<UUIDv4>` carrying:
+
+| Field | Value |
+|---|---|
+| `UPLOAD_TARGET_ID` | the target file's NC node id |
+| `UPLOAD_TARGET_PATH` | the parts-folder path |
+| `NUMBER_OF_PARTS` | the total number of parts |
+
+The method MUST return an array of part descriptors, each with keys
+`id` (UUID), `size` (bytes; the last part carries the remainder, all others
+carry `part-size`), `order` (1-based), `object` (the passed `$objectId` or
+`null`), and `successful` (always `false` at creation).
+
+The method MUST throw `NotFoundException` / `InvalidPathException` /
+`NotPermittedException` if the target path does not exist, is invalid, or is not
+writable.
+
+#### Scenario: 2.5 MB upload at default 1 MB part size produces 3 parts
+
+- **GIVEN** `openconnector.part-size = 1_000_000`
+- **AND** the target path exists and is writable
+- **WHEN** `createUpload('/Uploads', 'big.bin', 2_500_000, 'obj-1')` is called
+- **THEN** an empty file `/Uploads/big.bin` is created
+- **AND** a folder `/Uploads/big.bin_parts/` is created
+- **AND** the return array has 3 entries with sizes `[1_000_000, 1_000_000, 500_000]` and orders `[1, 2, 3]`
+- **AND** three cache entries `upload_<uuid>` exist, each carrying the target file id, parts folder path, and `NUMBER_OF_PARTS = 3`
+
+#### Scenario: missing target path raises NotFoundException
+
+- **GIVEN** `/Uploads` does not exist
+- **WHEN** `createUpload('/Uploads', 'x.bin', 100)` is called
+- **THEN** `NotFoundException` is thrown
+- **AND** no cache entries are written
+
+#### Notes
+
+- The method resolves `userManager->get(APP_USER)` but never uses the result —
+  the userFolder line is commented out. Treat the `userManager` dependency as
+  best-effort / dead at this site; the path resolution actually goes via
+  `rootFolder->get($path)`, which is server-relative, not user-relative.
+- No authorisation check: any caller can mint cache entries pointing at
+  arbitrary `$objectId`. Defence in depth is expected from the calling
+  controller. See design.md for the IDOR shape.
+
+---
+
+### REQ-002: Single-shot file write under the active user
+
+`writeFile(string $path, string $fileName, string $content): File` MUST write
+`$content` to `{$path}/{$fileName}` under the currently logged-in user's root
+folder, returning the resulting `OCP\Files\File`. If the file already exists,
+its content MUST be overwritten via `File::putContent`. If it does not exist,
+it MUST be created via `Folder::newFile($fileName, $content)`.
+
+The method MUST surface storage errors as `GenericFileException`, locking errors
+as `LockedException`, missing-path errors as `NotFoundException`, and
+permission errors as `NotPermittedException`.
+
+#### Scenario: overwrite existing file
+
+- **GIVEN** a logged-in user with `/Docs/note.txt` present
+- **WHEN** `writeFile('/Docs', 'note.txt', 'replacement')` is called
+- **THEN** `note.txt`'s content becomes `'replacement'`
+- **AND** the returned `File` references the same node id
+
+#### Scenario: create new file
+
+- **GIVEN** a logged-in user with `/Docs/` present and no `note.txt`
+- **WHEN** `writeFile('/Docs', 'note.txt', 'fresh')` is called
+- **THEN** `/Docs/note.txt` is created with content `'fresh'`
+
+#### Notes
+
+- **HIGH — Observed bug:** The method references `$this->userSession` but the
+  class never declares or injects `IUserSession`. Calling this method at runtime
+  raises `Error: Undefined property StorageService::$userSession`. As written,
+  this method is dead code; this REQ documents the **intended** observable
+  behaviour. A follow-up should either inject `IUserSession` into the
+  constructor and re-enable the method or remove it. The retrofit deliberately
+  does NOT silently fix this — the broken state has been in the tree long
+  enough that we want it on the radar as a separate change.
+
+---
+
+### REQ-003: Upload part append with auto-reconciliation when all parts present
+
+`writePart(int $partId, string $partUuid, string $data): bool` MUST resolve the
+upload metadata from the cache key `upload_$partUuid`, locate the target file
+under `getUserFolder(APP_USER)::getFirstNodeById(<UPLOAD_TARGET_ID>)`, and
+locate the parts folder at the recorded `UPLOAD_TARGET_PATH`. The method MUST
+then write the incoming `$data` into a new file
+`{partsFolder}/{$partId}.part.{$targetExtension}`.
+
+If, after the write, the parts folder contains at least `NUMBER_OF_PARTS`
+entries, the method MUST invoke `attemptCloseUpload(folderContents, target,
+numParts)` (REQ-004). The method MUST return `true` on a successful part write
+regardless of whether the close attempt occurred.
+
+The method MUST throw `NotFoundException` if either the resolved target file
+or parts folder is not of the expected node type (a `Folder` and a `File`
+respectively).
+
+#### Scenario: middle part is appended without reconciliation
+
+- **GIVEN** a 3-part upload with metadata cached under `upload_<uuid-2>`
+- **AND** only `1.part.bin` exists in the parts folder
+- **WHEN** `writePart(2, '<uuid-2>', '<bytes>')` is called
+- **THEN** `2.part.bin` is written into the parts folder
+- **AND** `attemptCloseUpload` is NOT called (only 2 < 3 parts present)
+- **AND** the method returns `true`
+
+#### Scenario: last part triggers reconciliation
+
+- **GIVEN** a 3-part upload with `1.part.bin` and `2.part.bin` already present
+- **WHEN** `writePart(3, '<uuid-3>', '<bytes>')` is called
+- **THEN** `3.part.bin` is written into the parts folder
+- **AND** `attemptCloseUpload` is invoked with all 3 part files
+- **AND** the method returns `true`
+
+#### Notes
+
+- IDOR surface: the method authorises on UUID knowledge only — anyone who learns
+  a `partUuid` can append parts to the corresponding upload. The controller is
+  the gatekeeper. Documented for defence-in-depth review.
+- `getFirstNodeById` ambiguity: if the same node id is reachable from multiple
+  paths under APP_USER, the first match wins; the recorded
+  `UPLOAD_TARGET_PATH` is not cross-checked against the resolved file's parent.
+
+---
+
+### REQ-004: In-memory part reconciliation into target file
+
+`attemptCloseUpload(array $folderContents, File $target, int $numParts): bool`
+MUST verify that the parts folder contains exactly the set `{1, 2, …, numParts}`
+of part files matching `^[0-9]+\.part\.{$targetExtension}$`. If the set is
+incomplete, the method MUST return `false` without mutating state.
+
+If the set is complete, the method MUST:
+
+1. Read each part's content via `File::getContent` in part-number order.
+2. Concatenate the contents into a single PHP string.
+3. Delete each part file via `File::delete`.
+4. Delete the parts folder if it is empty after part deletion.
+5. Write the concatenated content into `$target` via `File::putContent`.
+6. Return `true`.
+
+#### Scenario: reconciliation merges 3 parts into target
+
+- **GIVEN** a parts folder containing `1.part.bin`, `2.part.bin`, `3.part.bin` with contents `"AAA"`, `"BBB"`, `"CCC"`
+- **AND** `$target` is `/Uploads/big.bin`
+- **AND** `$numParts = 3`
+- **WHEN** `attemptCloseUpload(<contents>, $target, 3)` is called
+- **THEN** `/Uploads/big.bin` ends up with content `"AAABBBCCC"`
+- **AND** all three part files are deleted
+- **AND** `/Uploads/big.bin_parts/` is deleted
+- **AND** the method returns `true`
+
+#### Scenario: missing middle part returns false
+
+- **GIVEN** a parts folder containing only `1.part.bin` and `3.part.bin`
+- **AND** `$numParts = 3`
+- **WHEN** `attemptCloseUpload(<contents>, $target, 3)` is called
+- **THEN** the method returns `false`
+- **AND** the parts folder is NOT modified
+- **AND** `$target` is NOT written
+
+#### Notes
+
+- **Memory profile:** the concatenation buffer holds the full upload in PHP
+  memory. Large files (multi-GB) will OOM the worker. The class imports
+  `IObjectStoreMultiPartUpload` / `IChunkedFileWrite` but does not use them.
+  Tightening to a streaming reconciliation is a separate change; this REQ
+  documents the in-memory shape as the **observed** contract.
+- Concatenation order is enforced by `ksort($files)` plus the
+  `intval(extension-stripped)` regex match against `range(1, numParts)` —
+  string-sorted names happen to match numeric order for the small `1..N`
+  ranges used in practice.

--- a/openspec/changes/retrofit-2026-05-24-storage-uploads/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-storage-uploads/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] task-1: storage-uploads#REQ-001 — Multi-part upload initialisation with cache-tracked parts (retroactive annotation)
+- [x] task-2: storage-uploads#REQ-002 — Single-shot file write under the active user (retroactive annotation)
+- [x] task-3: storage-uploads#REQ-003 — Upload part append with auto-reconciliation when all parts present (retroactive annotation)
+- [x] task-4: storage-uploads#REQ-004 — In-memory part reconciliation into target file (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 4 methods under `storage-uploads` as 4 new REQs.

Ghost change: `retrofit-2026-05-24-storage-uploads` (drafted in `openspec/changes/`).

### What this PR does
- Drafts 4 REQs as a new capability spec (`retrofit: true`)
- Creates tasks.md with one task per REQ
- Annotates 4 methods with `@spec openspec/changes/retrofit-.../tasks.md#task-N`

### What this PR does NOT do
- No code behavior changes — only docblock `@spec` annotations
- Does not silently fix observed-but-buggy behaviour — notes/design surface it

### Security / soft-fail findings flagged (not fixed)
- **HIGH** — `writeFile()` references `$this->userSession` but the class never declares or injects `IUserSession`. The method raises `Error: Undefined property` at runtime — effectively dead code.
- **MEDIUM (DoS)** — `attemptCloseUpload` concatenates the full upload in a single PHP string before write; large files OOM the worker. Imports `IObjectStoreMultiPartUpload` / `IChunkedFileWrite` but never uses them.
- **MEDIUM (IDOR)** — `writePart` authorises on UUID knowledge only; anyone with a `partUuid` can append parts to a foreign upload. Controller is the only gatekeeper.
- `getFirstNodeById` ambiguity: target path recorded in cache but not cross-checked against resolved file's parent.
- `createUpload` resolves `userManager->get(APP_USER)` but never uses the result (dead variable).

### Review focus
- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- One REQ per observable behaviour

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `storage-uploads`

Refs ConductionNL/openconnector#936