### PR TITLE
retrofit: reverse-spec organisation-bridge (5 REQs / 6 methods)

### DIFF
--- a/lib/Service/OrganisationBridgeService.php
+++ b/lib/Service/OrganisationBridgeService.php
@@ -64,6 +64,8 @@ class OrganisationBridgeService
      *
      * @psalm-return   \OCA\OpenRegister\Service\OrganisationService|null
      * @phpstan-return \OCA\OpenRegister\Service\OrganisationService|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-organisation-bridge/tasks.md#task-1
      */
     public function getOrganisationService(): ?\OCA\OpenRegister\Service\OrganisationService
     {
@@ -94,6 +96,8 @@ class OrganisationBridgeService
      *
      * @psalm-return   bool
      * @phpstan-return bool
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-organisation-bridge/tasks.md#task-2
      */
     public function isOrganisationServiceAvailable(): bool
     {
@@ -110,6 +114,8 @@ class OrganisationBridgeService
      *
      * @psalm-return   array
      * @phpstan-return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-organisation-bridge/tasks.md#task-3
      */
     public function getUserOrganisationStats(): array
     {
@@ -155,6 +161,8 @@ class OrganisationBridgeService
      * @param string $organisationUuid The organization UUID to set as active.
      *
      * @return array Result with success status and message.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-organisation-bridge/tasks.md#task-4
      */
     public function setActiveOrganisation(string $organisationUuid): array
     {
@@ -205,6 +213,8 @@ class OrganisationBridgeService
      *
      * @psalm-return   array|null
      * @phpstan-return array|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-organisation-bridge/tasks.md#task-5
      */
     public function getActiveOrganisation(): ?array
     {
@@ -239,6 +249,8 @@ class OrganisationBridgeService
      *
      * @psalm-return   array
      * @phpstan-return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-organisation-bridge/tasks.md#task-5
      */
     public function getUserOrganisations(): array
     {

--- a/openspec/changes/retrofit-2026-05-24-organisation-bridge/design.md
+++ b/openspec/changes/retrofit-2026-05-24-organisation-bridge/design.md
@@ -1,0 +1,60 @@
+# Design — Retrofit organisation-bridge
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+`lib/Service/OrganisationBridgeService.php` is openconnector's adapter to
+OpenRegister's `OrganisationService`. It avoids a hard dependency on
+openregister by reflecting on `IAppManager` + the DI container and returning
+`null` / empty shapes when OR is not installed or fails to resolve.
+
+The service is consumed by the user-management code path (cluster
+`user-management-and-login`) and the frontend organisation switcher (cluster
+`frontend-vue-spa`). It is **not** a security perimeter on its own — the
+calling controller is supposed to gate access. The shapes it returns, however,
+have an authorization-adjacent property worth flagging (see below).
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `getOrganisationService` | classic unsafe-auth-resolver: `catch (ContainerExceptionInterface\|NotFoundExceptionInterface) { logger->warning; return null; }`. Every consumer guards the call site with `if ($org !== null)` and silently degrades — the call "I cannot tell who you are" looks identical to "you have no org affiliation". Triggers the `hydra-gate-unsafe-auth-resolver` gate. | **HIGH — OWASP A01:2021 / CWE-863 silent-fail-open authorization shape** |
+| `setActiveOrganisation` no membership re-check | the bridge forwards `$organisationUuid` verbatim to `OrganisationService::setActiveOrganisation` and returns the result. Authz that the current user actually belongs to the target org is delegated to OR's implementation — bridge has no defence in depth. | medium — relies on OR contract |
+| `getUserOrganisationStats` shape divergence | unavailable path returns `{ total: 0, active: null, results: [], available: false }`, error path returns the same shape plus `error: 'Failed to retrieve organization data'`. Callers that only switch on `available` will treat an OR-side error identical to "OR not installed" — silently downgrades to empty stats. | medium — silent data-quality regression |
+| `setActiveOrganisation` error message leak | `catch (\Exception $e) { return [..., 'message' => $e->getMessage()] }` echoes the OR exception text back to the API consumer (which is ultimately the browser). Could surface internal DB error fragments. | low — info-disclosure surface |
+| `getUserOrganisations` empty-on-error | both unavailable AND OR-side error return `[]` indistinguishably. The frontend cannot tell "you have zero orgs" from "OR is broken". | low — UX ambiguity |
+| `getActiveOrganisation` empty-on-anything | unavailable, no active org, OR exception — all three return `null`. Same indistinguishability problem. | low — UX ambiguity |
+
+The repeated "swallow exception, return falsy" pattern is the spine of this
+class. Whether to harden it (raise on OR-side exceptions; distinguish
+"unavailable" from "errored"; reduce the surface to a single
+`OrganisationContext` value object) is a design call worth its own change —
+this retrofit pins the existing shape so any future hardening has a baseline.
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `getOrganisationService` |
+| REQ-002 | `isOrganisationServiceAvailable` |
+| REQ-003 | `getUserOrganisationStats` |
+| REQ-004 | `setActiveOrganisation` |
+| REQ-005 | `getActiveOrganisation` + `getUserOrganisations` (folded — same shape, same fail-paths) |
+
+`isOrganisationServiceAvailable` gets its own REQ-002 because consumers
+explicitly switch on it; it is not just sugar over `getOrganisationService()
+!== null`.
+
+## What the spec deliberately does NOT cover
+
+- Constructor wiring (`__construct(IAppManager, ContainerInterface, LoggerInterface)`)
+  — DI plumbing.
+- OR's `OrganisationService` contract — that lives in openregister's spec; this
+  retrofit pins only the openconnector-side adapter shape.
+- The HTTP controllers that consume these methods — covered by
+  `user-management-and-login`.
+
+## Validation
+
+After archive, `openspec validate organisation-bridge --strict` MUST pass.

--- a/openspec/changes/retrofit-2026-05-24-organisation-bridge/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-organisation-bridge/proposal.md
@@ -1,0 +1,20 @@
+# Retrofit — organisation-bridge
+
+Describes observed behavior of 6 methods under `organisation-bridge` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Service/OrganisationBridgeService.php::getOrganisationService()`
+- `lib/Service/OrganisationBridgeService.php::isOrganisationServiceAvailable()`
+- `lib/Service/OrganisationBridgeService.php::getUserOrganisationStats()`
+- `lib/Service/OrganisationBridgeService.php::setActiveOrganisation()`
+- `lib/Service/OrganisationBridgeService.php::getActiveOrganisation()`
+- `lib/Service/OrganisationBridgeService.php::getUserOrganisations()`
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section + design.md surface the unsafe-auth-resolver `catch → return null` pattern that triggers the `hydra-gate-unsafe-auth-resolver` gate — this is an authorization-side surface (OWASP A01:2021 / CWE-863) and is documented as observed-but-suspicious, not fixed in this change
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-organisation-bridge/specs/organisation-bridge/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-organisation-bridge/specs/organisation-bridge/spec.md
@@ -1,0 +1,242 @@
+---
+retrofit: true
+status: draft
+---
+
+# Organisation bridge
+
+## Purpose
+
+Adapter that lets openconnector consume OpenRegister's organisation features
+without taking a hard dependency on openregister. Reflects on `IAppManager` +
+the server DI container at every call to decide whether to forward to OR's
+`OrganisationService` or return an unavailable-shape default.
+
+This spec retroactively documents the observed contract of every public method.
+
+## ADDED Requirements
+
+### REQ-001: Soft-fail lazy accessor for OR OrganisationService
+
+`getOrganisationService(): ?\OCA\OpenRegister\Service\OrganisationService` MUST
+first check that `'openregister'` is in `IAppManager::getInstalledApps()`. If not,
+the method MUST return `null` without touching the DI container.
+
+If openregister is installed, the method MUST attempt to resolve
+`OCA\OpenRegister\Service\OrganisationService` from the container. On
+`ContainerExceptionInterface` or `NotFoundExceptionInterface`, the method MUST
+log a `LoggerInterface::warning('OpenRegister OrganisationService not
+available', ['exception' => ...])` and return `null`.
+
+On successful resolution the method MUST return the service instance.
+
+#### Scenario: openregister not installed returns null silently
+
+- **GIVEN** `IAppManager::getInstalledApps()` does NOT include `'openregister'`
+- **WHEN** `getOrganisationService()` is called
+- **THEN** the method returns `null`
+- **AND** the DI container is NOT queried
+- **AND** no log entry is emitted
+
+#### Scenario: container resolution failure returns null with warning
+
+- **GIVEN** openregister is installed
+- **AND** `$container->get('OCA\OpenRegister\Service\OrganisationService')` throws `NotFoundExceptionInterface`
+- **WHEN** `getOrganisationService()` is called
+- **THEN** the method returns `null`
+- **AND** a `LoggerInterface::warning` is emitted with `exception => <message>`
+
+#### Notes
+
+- **HIGH (OWASP A01:2021 / CWE-863):** The `catch → return null` shape is the
+  unsafe-auth-resolver pattern (`hydra-gate-unsafe-auth-resolver`). Every
+  consumer guards with `if ($org !== null) { ... }`. The "OR is briefly
+  unavailable" path looks identical to "this user has no org affiliation",
+  which can degrade an authorization decision into "checks skipped." The
+  bridge is not itself an auth gate, but the org context it surfaces feeds
+  authz decisions downstream; this REQ documents the observed shape so any
+  hardening lands as a separate change rather than an implicit fix.
+
+---
+
+### REQ-002: OR-availability predicate and unavailable-shape returns
+
+`isOrganisationServiceAvailable(): bool` MUST return `true` iff
+`getOrganisationService()` returns a non-null value. Consumers switch on this
+predicate to decide between forwarding to OR and returning their own
+unavailable-shape default.
+
+The predicate MUST NOT cache the result — every call re-evaluates
+`getOrganisationService()`.
+
+#### Scenario: OR present returns true
+
+- **GIVEN** openregister is installed and `OrganisationService` resolves cleanly
+- **WHEN** `isOrganisationServiceAvailable()` is called
+- **THEN** the method returns `true`
+
+#### Scenario: OR missing returns false
+
+- **GIVEN** openregister is not installed
+- **WHEN** `isOrganisationServiceAvailable()` is called
+- **THEN** the method returns `false`
+
+#### Notes
+
+- No memoisation — the bridge re-checks on every call. Cheap because the
+  `IAppManager::getInstalledApps()` short-circuit fires first when OR is
+  absent. When OR is present, a container `get` is invoked per call, which is
+  amortised by the container's own caching.
+
+---
+
+### REQ-003: User organisation statistics with availability fallback
+
+`getUserOrganisationStats(): array` MUST forward to
+`OrganisationService::getUserOrganisationStats()` when the OR service is
+available and return that result merged with `['available' => true]`.
+
+When OR is not available, the method MUST return the static fallback:
+
+```php
+['total' => 0, 'active' => null, 'results' => [], 'available' => false]
+```
+
+When OR is available but its `getUserOrganisationStats` throws `\Exception`, the
+method MUST log `LoggerInterface::error('Failed to get user organization stats',
+['exception' => ...])` and return the same fallback shape PLUS
+`'error' => 'Failed to retrieve organization data'`.
+
+#### Scenario: happy path forwards OR stats with available flag
+
+- **GIVEN** OR returns `{ total: 3, active: 'org-1', results: [<orgs>] }`
+- **WHEN** `getUserOrganisationStats()` is called
+- **THEN** the method returns `{ total: 3, active: 'org-1', results: [<orgs>], available: true }`
+
+#### Scenario: OR unavailable returns empty-shape
+
+- **WHEN** OR is not installed
+- **AND** `getUserOrganisationStats()` is called
+- **THEN** the method returns `{ total: 0, active: null, results: [], available: false }`
+- **AND** the `error` key is NOT present
+
+#### Scenario: OR-side exception returns empty-shape with error key
+
+- **GIVEN** OR is installed but `getUserOrganisationStats()` throws
+- **WHEN** the method is called
+- **THEN** the method returns `{ total: 0, active: null, results: [], available: false, error: 'Failed to retrieve organization data' }`
+- **AND** a `LoggerInterface::error` is emitted
+
+#### Notes
+
+- Consumers that only switch on `available` will treat the OR-side error path
+  identically to "OR not installed". The `error` key is the only
+  distinguishing signal — see design.md for the data-quality regression.
+
+---
+
+### REQ-004: Set active organisation for the current user
+
+`setActiveOrganisation(string $organisationUuid): array` MUST forward to
+`OrganisationService::setActiveOrganisation(organisationUuid: $organisationUuid)`
+when OR is available, and return:
+
+```php
+[
+  'success'   => <bool from OR>,
+  'message'   => 'Active organization updated successfully' | 'Failed to update active organization',
+  'available' => true,
+]
+```
+
+When OR is not available, the method MUST return:
+
+```php
+['success' => false, 'message' => 'Organization service not available', 'available' => false]
+```
+
+When OR is available but `setActiveOrganisation` throws `\Exception`, the method
+MUST log `LoggerInterface::error('Failed to set active organization',
+['organisationUuid' => ..., 'exception' => ...])` and return:
+
+```php
+['success' => false, 'message' => <exception message>, 'available' => true]
+```
+
+#### Scenario: success forwards true result
+
+- **GIVEN** OR returns `true` for the UUID
+- **WHEN** `setActiveOrganisation('org-1')` is called
+- **THEN** the method returns `{ success: true, message: 'Active organization updated successfully', available: true }`
+
+#### Scenario: OR rejects with false
+
+- **GIVEN** OR returns `false` for the UUID
+- **WHEN** `setActiveOrganisation('org-1')` is called
+- **THEN** the method returns `{ success: false, message: 'Failed to update active organization', available: true }`
+
+#### Scenario: OR throws — exception message echoed back
+
+- **GIVEN** OR throws `\Exception('user not member of org')`
+- **WHEN** `setActiveOrganisation('org-1')` is called
+- **THEN** the method returns `{ success: false, message: 'user not member of org', available: true }`
+- **AND** the error is logged with the UUID
+
+#### Notes
+
+- **Info-disclosure low:** the exception message is forwarded verbatim to the
+  API consumer. Internal DB error fragments could leak. Hardening would
+  replace the message with a static "Failed to update active organization"
+  string on the exception path too.
+- **No defence-in-depth membership check:** the bridge does not verify the
+  current user actually belongs to `$organisationUuid` — it trusts OR's
+  implementation.
+
+---
+
+### REQ-005: Read active and list user organisations as jsonSerialize arrays
+
+`getActiveOrganisation(): ?array` MUST forward to
+`OrganisationService::getActiveOrganisation()` and return the
+`jsonSerialize()` result of the returned entity. The method MUST return `null`
+on any of: OR not available, OR returns `null`, or OR throws `\Exception` (the
+latter logged via `LoggerInterface::error('Failed to get active organization',
+['exception' => ...])`).
+
+`getUserOrganisations(): array` MUST forward to
+`OrganisationService::getUserOrganisations()` and return
+`array_map(fn($org) => $org->jsonSerialize(), $organisations)`. The method MUST
+return `[]` on any of: OR not available, OR throws `\Exception` (the latter
+logged via `LoggerInterface::error('Failed to get user organizations', ...)`).
+
+#### Scenario: getActiveOrganisation forwards entity as JSON
+
+- **GIVEN** OR returns an organisation entity with `jsonSerialize() === { uuid: 'org-1', name: 'Acme' }`
+- **WHEN** `getActiveOrganisation()` is called
+- **THEN** the method returns `{ uuid: 'org-1', name: 'Acme' }`
+
+#### Scenario: getActiveOrganisation returns null for OR no-active
+
+- **GIVEN** OR returns `null` (user has no active org)
+- **WHEN** `getActiveOrganisation()` is called
+- **THEN** the method returns `null`
+
+#### Scenario: getUserOrganisations maps entities through jsonSerialize
+
+- **GIVEN** OR returns `[org-1-entity, org-2-entity]`
+- **WHEN** `getUserOrganisations()` is called
+- **THEN** the method returns `[{org-1 json}, {org-2 json}]`
+
+#### Scenario: OR-side exception returns null/empty without distinguishing
+
+- **GIVEN** OR is available but its method throws
+- **WHEN** the bridge method is called
+- **THEN** `getActiveOrganisation()` returns `null` / `getUserOrganisations()` returns `[]`
+- **AND** the exception is logged via `LoggerInterface::error`
+- **AND** the caller cannot distinguish "no orgs" / "no active org" from "OR errored"
+
+#### Notes
+
+- The "null on anything" / "empty array on anything" shape collapses three
+  distinct cases (unavailable, no data, errored) into one return value. The
+  UX consequence is documented in design.md; this REQ pins the observed shape.

--- a/openspec/changes/retrofit-2026-05-24-organisation-bridge/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-organisation-bridge/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: organisation-bridge#REQ-001 — Soft-fail lazy accessor for OR OrganisationService (retroactive annotation)
+- [x] task-2: organisation-bridge#REQ-002 — OR-availability predicate and unavailable-shape returns (retroactive annotation)
+- [x] task-3: organisation-bridge#REQ-003 — User organisation statistics with availability fallback (retroactive annotation)
+- [x] task-4: organisation-bridge#REQ-004 — Set active organisation for the current user (retroactive annotation)
+- [x] task-5: organisation-bridge#REQ-005 — Read active and list user organisations as jsonSerialize arrays (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 6 methods under `organisation-bridge` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-organisation-bridge` (drafted in `openspec/changes/`).

### What this PR does
- Drafts 5 REQs as a new capability spec (`retrofit: true`)
- Creates tasks.md with one task per REQ (REQ-005 covers two methods with identical shape)
- Annotates 6 methods with `@spec openspec/changes/retrofit-.../tasks.md#task-N`

### What this PR does NOT do
- No code behavior changes — only docblock `@spec` annotations
- Does not silently fix observed-but-suspicious behaviour — notes/design surface it

### Security findings flagged (not fixed)
- **HIGH (OWASP A01:2021 / CWE-863)** — `getOrganisationService` is the classic unsafe-auth-resolver pattern (catch -> return null + warning). Triggers `hydra-gate-unsafe-auth-resolver`. Consumers cannot distinguish "OR briefly unavailable" from "user has no org affiliation"; downstream authz decisions silently degrade.
- **MEDIUM** — `setActiveOrganisation` has no defence-in-depth membership re-check; trusts OR.
- **MEDIUM** — `getUserOrganisationStats` collapses "OR not installed" + "OR errored" + "user has no orgs" into a near-identical empty shape; only the `error` key distinguishes the errored path.
- **LOW** — `setActiveOrganisation` echoes OR's `$e->getMessage()` verbatim back to the API consumer (potential info disclosure).
- **LOW** — `getActiveOrganisation` / `getUserOrganisations` collapse all failure modes into `null` / `[]`.

### Review focus
- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- One REQ per observable behaviour (REQ-005 deliberately folds two near-identical methods)

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `organisation-bridge`

Refs ConductionNL/openconnector#936