### PR TITLE
retrofit: reverse-spec xml-response (5 REQs / 7 methods)

### DIFF
--- a/lib/Http/XMLResponse.php
+++ b/lib/Http/XMLResponse.php
@@ -96,6 +96,8 @@ class XMLResponse extends Response
      *
      * @return       array<string, mixed> The data for rendering.
      * @psalm-return array<string, mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-xml-response/tasks.md#task-1
      */
     protected function getData(): array
     {
@@ -111,6 +113,8 @@ class XMLResponse extends Response
      * @return $this
      *
      * @psalm-param callable(array<string, mixed>): string $callback
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-xml-response/tasks.md#task-1
      */
     public function setRenderCallback(callable $callback): self
     {
@@ -123,6 +127,8 @@ class XMLResponse extends Response
      * Returns the rendered XML.
      *
      * @return string The rendered XML.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-xml-response/tasks.md#task-2
      */
     public function render(): string
     {
@@ -152,6 +158,8 @@ class XMLResponse extends Response
      *
      * @psalm-param  array<string, mixed> $data
      * @psalm-return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-xml-response/tasks.md#task-3
      */
     public function arrayToXml(array $data, ?string $rootTag=null): string
     {
@@ -207,6 +215,8 @@ class XMLResponse extends Response
      * @psalm-param DOMDocument $dom
      * @psalm-param DOMElement $element
      * @psalm-param array<string, mixed> $data
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-xml-response/tasks.md#task-4
      */
     private function buildXmlElement(DOMDocument $dom, DOMElement $element, array $data): void
     {
@@ -269,6 +279,8 @@ class XMLResponse extends Response
      * @psalm-param DOMElement $parentElement
      * @psalm-param string $tagName
      * @psalm-param array<string, mixed>|string|object $data
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-xml-response/tasks.md#task-5
      */
     private function createChildElement(DOMDocument $dom, DOMElement $parentElement, string $tagName, $data): void
     {
@@ -309,6 +321,8 @@ class XMLResponse extends Response
      * @psalm-param  DOMDocument $dom
      * @psalm-param  string $text
      * @psalm-return \DOMNode
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-xml-response/tasks.md#task-5
      */
     private function createSafeTextNode(DOMDocument $dom, string $text): \DOMNode
     {

--- a/openspec/changes/retrofit-2026-05-24-xml-response/design.md
+++ b/openspec/changes/retrofit-2026-05-24-xml-response/design.md
@@ -1,0 +1,65 @@
+# Design — Retrofit xml-response
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+`lib/Http/XMLResponse.php` is a Nextcloud `OCP\AppFramework\Http\Response`
+subclass that serialises array payloads to XML and sets
+`Content-Type: application/xml; charset=utf-8` (plus an attachment
+`Content-Disposition` if the request path ends in `.xml`). The serialisation
+is a recursive walk via `DOMDocument`:
+
+- `arrayToXml($data, $rootTag = null)` is the public entry point. It picks a
+  root tag (either explicit, `@root` from data, or `'root'`), creates the
+  root element, walks the data via `buildXmlElement`, and post-processes the
+  serialised string (decimal `&#13;` → hex `&#xD;`, self-closing-tag space).
+- `buildXmlElement($dom, $element, $data)` handles `@attributes`, `#text`,
+  indexed-array fan-out, and recurses for associative arrays via
+  `createChildElement`.
+- `createChildElement($dom, $parent, $tagName, $data)` either recurses (array)
+  or coerces to string and appends a safe text node. Objects without
+  `__toString` (and `IQueryBuilder` instances explicitly) are replaced with
+  `'[Object of class Foo]'`.
+- `createSafeTextNode($dom, $text)` decodes HTML entities **twice** before
+  creating the text node.
+
+This class is consumed by the endpoint runtime (cluster `endpoint-runtime`)
+when an endpoint configures XML output, and by any controller that returns an
+`XMLResponse` directly.
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `createSafeTextNode` | calls `html_entity_decode` **twice** — explicitly to "handle cases like `&amp;#039;` into `'`". This unwinds attacker-controlled entity escapes: if the upstream caller passes `&amp;lt;script&amp;gt;` (already-escaped HTML for `&lt;script&gt;`), the double-decode unwraps it to literal `<script>` which is then placed as a DOM text node (DOM will re-escape on serialisation, so the on-the-wire XML is safe, BUT any consumer that uses the rendered XML inside an HTML context after a second decode pass would see executable script). The name "createSafe…" oversells the safety property. | medium — sanitiser anti-pattern, depends on downstream consumer |
+| `setRenderCallback` | replaces `render()` with arbitrary callable; the callable receives `$this->getData()` (the unwrapped `['value' => $this->data]`) and is trusted to produce XML. Bypasses every safety property of the DOM path including the `&#13;` normalisation. No documented contract that the callback must produce valid XML or escape input — caller responsibility. | medium — unbounded escape hatch |
+| `arrayToXml::preg_replace` | post-serialisation regex `\/<([^>]*)\/>\/` rewrites `<foo/>` to `<foo />` (cosmetic). `[^>]*` is fine for well-formed DOM output, but is a fragile contract if `$dom->saveXML()` ever produces a tag with embedded `>` inside an attribute value (it shouldn't, but this is the assumption being baked into the class). | low — cosmetic, no security impact |
+| `createChildElement::IQueryBuilder` | hard-coded `instanceof IQueryBuilder` special-case to skip `__toString` (which would emit a parametrised SQL fragment). Suggests prior incident — the rest of the class is generic about object handling but this one type gets a fence. | informational — code smell of a past bug |
+| `buildXmlElement::is_numeric` | tag names that look like numbers are rewritten to `item<N>` to keep XML well-formed (XML tags can't start with a digit). Tag names with other invalid characters (`:`, `<`, spaces) are NOT sanitised — `DOMDocument::createElement` will throw `DOMException`. | low — partial sanitisation |
+| `__construct::str_ends_with('.xml')` | the attachment-header guard relies on a `?string $path` argument that the controller must supply. If forgotten, large XML payloads render in-browser instead of downloading. Not a security issue, just an ergonomics surface. | informational |
+
+There is **no XML parsing** in this class — it only emits XML, so the
+classic XXE / billion-laughs surface does not apply here. (Inbound XML
+parsing is in the rule-pipeline cluster, deferred to a separate retrofit.)
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `getData` + `setRenderCallback` (paired: accessor + override) |
+| REQ-002 | `render` |
+| REQ-003 | `arrayToXml` |
+| REQ-004 | `buildXmlElement` |
+| REQ-005 | `createChildElement` + `createSafeTextNode` (paired: child creation always ends in a safe text node) |
+
+## What the spec deliberately does NOT cover
+
+- Constructor wiring — the constructor's header/content-type logic is REQ-implicit
+  but the wiring itself is plumbing.
+- The XML schema or shape of the payloads consumed by clients — that's the
+  caller's contract.
+
+## Validation
+
+After archive, `openspec validate xml-response --strict` MUST pass.

--- a/openspec/changes/retrofit-2026-05-24-xml-response/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-xml-response/proposal.md
@@ -1,0 +1,21 @@
+# Retrofit — xml-response
+
+Describes observed behavior of 7 methods under `xml-response` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Http/XMLResponse.php::getData()`
+- `lib/Http/XMLResponse.php::setRenderCallback()`
+- `lib/Http/XMLResponse.php::render()`
+- `lib/Http/XMLResponse.php::arrayToXml()`
+- `lib/Http/XMLResponse.php::buildXmlElement()` (private helper of arrayToXml)
+- `lib/Http/XMLResponse.php::createChildElement()` (private helper of buildXmlElement)
+- `lib/Http/XMLResponse.php::createSafeTextNode()` (private helper of createChildElement)
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section + design.md surface observed-but-suspicious behaviour: double `html_entity_decode` in `createSafeTextNode` (potential entity-unwrap on attacker-controlled text); IQueryBuilder special-case looks like ad-hoc patching; render-callback bypasses the safe path entirely
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-xml-response/specs/xml-response/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-xml-response/specs/xml-response/spec.md
@@ -1,0 +1,229 @@
+---
+retrofit: true
+status: draft
+---
+
+# XML response
+
+## Purpose
+
+Nextcloud `Response` subclass that serialises an array (or single string)
+payload into XML and writes the appropriate `Content-Type` /
+`Content-Disposition` headers. Supports an `@root` data convention for
+naming the document element, an `@attributes` convention for XML
+attributes, a `#text` convention for inline text, indexed-array fan-out
+for sibling elements, and a render-callback override for non-DOM XML
+emission.
+
+This spec retroactively documents the observed contract of every public
+method plus the three private helpers that make the DOM walk work.
+
+## ADDED Requirements
+
+### REQ-001: Data accessor and render-callback override
+
+`getData(): array` MUST return `['value' => $this->data]` (the constructor
+wraps a string payload as `['content' => $string]` before storage). This is
+the shape passed to both the default `render()` path and any callable
+installed via `setRenderCallback`.
+
+`setRenderCallback(callable $callback): self` MUST store the callable and
+return `$this` for fluent chaining. The callable signature is
+`fn(array $data): string` where `$data` is the `getData()` shape.
+
+The callback, if set, MUST replace the entire default DOM serialisation
+path — `render()` invokes it and returns its result verbatim.
+
+#### Scenario: getData wraps the stored payload
+
+- **GIVEN** an XMLResponse constructed with `['foo' => 'bar']`
+- **WHEN** `getData()` is called
+- **THEN** the result is `['value' => ['foo' => 'bar']]`
+
+#### Scenario: setRenderCallback returns self for chaining
+
+- **WHEN** `setRenderCallback(fn($d) => '<a/>')` is called
+- **THEN** the return value is the same XMLResponse instance
+
+#### Notes
+
+- The render-callback is a **complete bypass** of the safe DOM path
+  including the CR-normalisation and entity-escaping. Caller is solely
+  responsible for producing well-formed XML. Documented as observed
+  contract; documented in design.md as a security-adjacent escape
+  hatch.
+
+---
+
+### REQ-002: Top-level render with @root unwrap
+
+`render(): string` MUST first dispatch to the render-callback if one is
+installed. Otherwise, it MUST inspect the wrapped data
+(`getData()['value']`). If the wrapped data has an `@root` key, the
+method MUST call `arrayToXml($data)` and trust `arrayToXml` to use the
+`@root` value as the document element name. Otherwise, the method MUST
+wrap the data in `['value' => $data]` and call `arrayToXml(..., rootTag:
+'response')`.
+
+The return value is the rendered XML string. The method MUST NOT throw.
+
+#### Scenario: @root convention drives the document element name
+
+- **GIVEN** a payload `['@root' => 'envelope', 'body' => 'hello']`
+- **WHEN** `render()` is called (no callback set)
+- **THEN** the output XML begins `<envelope>` and contains `<body>hello</body>`
+
+#### Scenario: no @root falls back to <response><value>...</value></response>
+
+- **GIVEN** a payload `['foo' => 'bar']` with no `@root`
+- **WHEN** `render()` is called
+- **THEN** the output begins `<response>` and contains `<value><foo>bar</foo></value>`
+
+---
+
+### REQ-003: Array-to-XML serialisation with DOMDocument
+
+`arrayToXml(array $data, ?string $rootTag = null): string` MUST construct a
+`DOMDocument('1.0', 'UTF-8')` with `formatOutput = true`, create a root
+element from the first non-null of: `$rootTag` argument, `$data['@root']`,
+the literal `'root'`. The method MUST strip `@root` from `$data` after
+extraction so it does not surface as a child element.
+
+The method MUST recurse into the data via `buildXmlElement` (REQ-004),
+serialise via `DOMDocument::saveXML()`, then post-process:
+
+1. Replace all `&#13;` (decimal carriage-return entity) with `&#xD;`
+   (hexadecimal form) — for downstream parsers that only recognise the
+   hex form.
+2. Run a regex `<([^>]*)\/>` → `<$1 />` to add a space before the
+   self-closing slash.
+
+If element creation fails or `saveXML()` returns `false`, the method MUST
+return an empty string.
+
+#### Scenario: explicit rootTag overrides @root
+
+- **GIVEN** data `['@root' => 'ignored', 'a' => 1]` and rootTag `'used'`
+- **WHEN** `arrayToXml($data, 'used')` is called
+- **THEN** the output document element is `<used>` not `<ignored>`
+
+#### Scenario: CR normalisation rewrites &#13; to &#xD;
+
+- **GIVEN** data containing a string with `\r` characters
+- **WHEN** `arrayToXml(...)` is called
+- **THEN** the output contains `&#xD;` but no `&#13;`
+
+#### Notes
+
+- The post-serialisation regex is fragile against attribute values that
+  contain a `>` character (DOM should never produce such, but the
+  assumption is baked in). Documented in design.md.
+
+---
+
+### REQ-004: Recursive DOM walk for arrays with @attributes and #text
+
+`buildXmlElement(DOMDocument $dom, DOMElement $element, array $data): void`
+MUST process `$data` in this order:
+
+1. **`@attributes`**: if present and an array, iterate and call
+   `$element->setAttribute((string) $key, (string) $value)` for each
+   entry, then unset the key.
+2. **`#text`**: if present, append a safe text node (REQ-005) with the
+   string cast of `$data['#text']`, then unset the key.
+3. **Remaining keys**: iterate. For each key:
+   - Strip a leading `@` via `ltrim($key, '@')`.
+   - If the key is numeric, rewrite to `"item$key"` to keep XML well-formed.
+   - If the value is an indexed array of arrays (first element is an array),
+     fan out one child element per item with the same tag name.
+   - If the value is an associative array, create one child element via
+     `createChildElement` (REQ-005) and recurse.
+   - Otherwise (scalar / object), create a child element via
+     `createChildElement` with the scalar / object data.
+
+The method MUST NOT throw on invalid input — element-creation failures are
+swallowed by the helpers.
+
+#### Scenario: @attributes become element attributes
+
+- **GIVEN** data `['@attributes' => ['id' => 1, 'href' => '/foo'], 'name' => 'bar']`
+- **WHEN** the walk runs on a `<thing>` element
+- **THEN** the output is `<thing id="1" href="/foo"><name>bar</name></thing>`
+
+#### Scenario: indexed array of arrays fans out sibling elements
+
+- **GIVEN** data `['item' => [['n' => 1], ['n' => 2], ['n' => 3]]]`
+- **WHEN** the walk runs
+- **THEN** the output contains `<item><n>1</n></item><item><n>2</n></item><item><n>3</n></item>`
+
+#### Scenario: numeric key is rewritten to itemN
+
+- **GIVEN** data `['0' => 'first', '1' => 'second']`
+- **WHEN** the walk runs
+- **THEN** the output contains `<item0>first</item0><item1>second</item1>`
+
+#### Notes
+
+- Keys with other XML-invalid characters (`:`, `<`, spaces) are NOT
+  sanitised — they will trigger a `DOMException` in
+  `DOMDocument::createElement`. Documented in design.md.
+
+---
+
+### REQ-005: Child-element creation with object-to-string fallback and safe text node
+
+`createChildElement(DOMDocument $dom, DOMElement $parent, string $tagName,
+$data): void` MUST attempt to create a `<$tagName>` element. If creation
+fails it MUST return without mutation. Otherwise it MUST append the new
+element to `$parent` and then:
+
+- If `$data` is an array, recurse via `buildXmlElement` (REQ-004).
+- If `$data` is an object that implements `__toString` AND is NOT an
+  `IQueryBuilder` instance, coerce to string.
+- If `$data` is any other object (no `__toString` or `IQueryBuilder`),
+  replace with the literal `'[Object of class ' . get_class($data) . ']'`.
+- Append a safe text node with the resulting string via
+  `createSafeTextNode`.
+
+`createSafeTextNode(DOMDocument $dom, string $text): \DOMNode` MUST decode
+HTML entities **twice** via `html_entity_decode($text, ENT_QUOTES |
+ENT_HTML5, 'UTF-8')` (first pass) then `html_entity_decode($decoded, ...)`
+(second pass) before returning `$dom->createTextNode($decoded)`. The
+DOM-side text-node creation will re-escape `<`, `>`, `&` on serialisation
+to ensure well-formed XML output.
+
+#### Scenario: array data recurses
+
+- **GIVEN** child data `['inner' => 'value']`
+- **WHEN** `createChildElement($dom, $parent, 'outer', $data)` runs
+- **THEN** the output contains `<outer><inner>value</inner></outer>`
+
+#### Scenario: object without __toString becomes placeholder
+
+- **GIVEN** child data `new \stdClass()` (no `__toString`)
+- **WHEN** `createChildElement(...)` runs
+- **THEN** the appended text is `[Object of class stdClass]`
+
+#### Scenario: IQueryBuilder is always replaced with placeholder
+
+- **GIVEN** child data is an `IQueryBuilder` instance (which DOES implement `__toString`)
+- **WHEN** `createChildElement(...)` runs
+- **THEN** the appended text is `[Object of class <IQueryBuilder impl>]` NOT the SQL fragment
+
+#### Scenario: double-entity-decode unwraps escaped HTML
+
+- **GIVEN** text `'&amp;lt;b&amp;gt;hi&amp;lt;/b&amp;gt;'`
+- **WHEN** `createSafeTextNode(...)` runs
+- **THEN** the underlying text-node value is `'<b>hi</b>'` (DOM serialisation re-escapes to `&lt;b&gt;hi&lt;/b&gt;`)
+
+#### Notes
+
+- The double-decode behaviour is **observed**, not aspirational. The
+  `createSafe…` naming oversells the safety property — see design.md.
+  The on-the-wire XML remains well-formed because DOM-side serialisation
+  re-escapes, but a downstream consumer that decodes XML and reuses the
+  text in an HTML context could see attacker-controlled markup.
+- The `IQueryBuilder` carve-out exists because a `QueryBuilder::__toString`
+  emits a parametrised SQL fragment with placeholders — embedding that in
+  the response would be a data-leak. The carve-out is hard-coded; other
+  sensitive `__toString`-bearing types would slip through.

--- a/openspec/changes/retrofit-2026-05-24-xml-response/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-xml-response/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: xml-response#REQ-001 — Data accessor and render-callback override (retroactive annotation)
+- [x] task-2: xml-response#REQ-002 — Top-level render with @root unwrap (retroactive annotation)
+- [x] task-3: xml-response#REQ-003 — Array-to-XML serialisation with DOMDocument (retroactive annotation)
+- [x] task-4: xml-response#REQ-004 — Recursive DOM walk for arrays with @attributes and #text (retroactive annotation)
+- [x] task-5: xml-response#REQ-005 — Child-element creation with object-to-string fallback and safe text node (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 7 methods under `xml-response` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-xml-response` (drafted in `openspec/changes/`).

### What this PR does
- Drafts 5 REQs as a new capability spec (`retrofit: true`)
- Creates tasks.md (REQ-001 and REQ-005 each pair two related methods)
- Annotates 7 methods with `@spec openspec/changes/retrofit-.../tasks.md#task-N`

### What this PR does NOT do
- No code behavior changes — only docblock `@spec` annotations
- Does not silently fix observed-but-suspicious behaviour — notes/design surface it

### Security / soft-fail findings flagged (not fixed)
- **MEDIUM** — `createSafeTextNode` double-decodes HTML entities; the `createSafe...` name oversells the safety. On-the-wire XML is fine (DOM re-escapes), but downstream consumers that decode the XML and reuse text in an HTML context could see attacker-controlled markup.
- **MEDIUM** — `setRenderCallback` is an unbounded bypass of every safety property of the DOM path (CR normalisation, entity escaping). Caller becomes solely responsible for well-formed XML.
- **LOW** — Hard-coded `IQueryBuilder` carve-out suggests a prior SQL-leak incident; other sensitive `__toString` types would still slip through.
- **LOW** — Partial sanitisation: numeric tag names rewritten to `itemN`, but tag names with `:` / `<` / spaces trigger `DOMException`.
- No XXE/billion-laughs surface — class only EMITS XML, never parses inbound.

### Review focus
- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- One REQ per observable behaviour (REQ-001 and REQ-005 deliberately pair related methods)

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `xml-response`

Refs ConductionNL/openconnector#936