### PR TITLE
retrofit: reverse-spec job-scheduling (5 REQs / 13 methods)

### DIFF
--- a/lib/Controller/JobsController.php
+++ b/lib/Controller/JobsController.php
@@ -105,6 +105,8 @@ class JobsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-1
      */
     public function logs(SearchService $searchService): JSONResponse
     {
@@ -218,6 +220,8 @@ class JobsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-2
      */
     public function run(string $id): JSONResponse
     {
@@ -271,6 +275,8 @@ class JobsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-2
      */
     public function test(string $id): JSONResponse
     {

--- a/lib/Cron/JobTask.php
+++ b/lib/Cron/JobTask.php
@@ -82,6 +82,8 @@ class JobTask extends TimedJob
      *
      * @psalm-param   array{jobId?: int, forceRun?: bool} $argument
      * @phpstan-param mixed $argument
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-3
      */
     public function run(mixed $argument): void
     {

--- a/lib/Cron/LogCleanUpTask.php
+++ b/lib/Cron/LogCleanUpTask.php
@@ -72,6 +72,8 @@ class LogCleanUpTask extends TimedJob
      * @param string $schema The schema slug to clean up.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-5
      */
     private function cleanupSchema(string $schema): void
     {
@@ -109,6 +111,8 @@ class LogCleanUpTask extends TimedJob
      *
      * @psalm-param   mixed $argument
      * @phpstan-param mixed $argument
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-5
      */
     public function run(mixed $argument): void
     {

--- a/lib/Service/JobService.php
+++ b/lib/Service/JobService.php
@@ -131,6 +131,8 @@ class JobService
      * @throws \DateMalformedStringException On invalid datetime composition.
      *
      * @TODO: At a later point in time this should be changed to using the most specific source for expiration
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-4
      */
     private function calculateExpires(...$retentions): ?\DateTime
     {
@@ -161,6 +163,8 @@ class JobService
      * @phpstan-param  string $message
      * @phpstan-param  int $maxLength
      * @phpstan-return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-4
      */
     private function truncateMessage(string $message, int $maxLength=10000): string
     {
@@ -191,6 +195,8 @@ class JobService
      * @psalm-return   ObjectEntity
      * @phpstan-param  ObjectEntity $job
      * @phpstan-return ObjectEntity
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-4
      */
     public function scheduleJob(ObjectEntity $job): ObjectEntity
     {
@@ -258,6 +264,8 @@ class JobService
      * @psalm-return   int|null
      * @phpstan-param  class-string<IJob>|IJob $job
      * @phpstan-return int|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-4
      */
     public function getJobListId(IJob|string $job): int|null
     {
@@ -308,6 +316,8 @@ class JobService
      * @psalm-return   ObjectEntity|null
      * @phpstan-param  ObjectEntity $job
      * @phpstan-return ObjectEntity|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-4
      */
     public function executeJob(ObjectEntity $job, bool $forceRun=false): ?ObjectEntity
     {
@@ -458,6 +468,8 @@ class JobService
      *
      * @return ObjectEntity The saved job_log ObjectEntity.
      * @throws \OCP\DB\Exception
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-4
      */
     private function saveJobLog(ObjectEntity $job, array $jobData, array $logData): ObjectEntity
     {
@@ -503,6 +515,8 @@ class JobService
      *
      * @psalm-return   array<ObjectEntity>
      * @phpstan-return ObjectEntity[]
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md#task-4
      */
     public function run(): array
     {

--- a/openspec/changes/retrofit-2026-05-24-job-scheduling/design.md
+++ b/openspec/changes/retrofit-2026-05-24-job-scheduling/design.md
@@ -1,0 +1,64 @@
+# Design — Retrofit job-scheduling
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+OpenConnector exposes a job-scheduling subsystem with three layers:
+
+1. **`JobService`** (`lib/Service/JobService.php`) — the business-logic core.
+   `scheduleJob` registers an OR `job` object with NC's `IJobList`,
+   `executeJob` runs one job and persists a `job_log` entry, `run()` is the
+   batch dispatcher that walks all enabled, due jobs.
+2. **`JobTask`** (`lib/Cron/JobTask.php`) — a NC `TimedJob` that runs every
+   5 minutes and delegates to `JobService::run()`. Wired by `JobService::scheduleJob`.
+3. **`LogCleanUpTask`** (`lib/Cron/LogCleanUpTask.php`) — a NC `TimedJob`
+   that runs every minute (sic, see notes) and deletes expired log objects
+   across four log schemas.
+4. **`JobsController`** (`lib/Controller/JobsController.php`) — HTTP entry
+   point for `GET /jobs/logs`, `POST /jobs/{id}/run`, `POST /jobs/{id}/test`.
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `JobsController::run` / `::test` | both methods carry `@NoAdminRequired` + `@NoCSRFRequired` and accept arbitrary job UUIDs. No per-object authorization guard. Any authenticated NC user can trigger arbitrary background job execution, including jobs configured with `userId` to run as a privileged user. Triggers `hydra-gate-no-admin-idor` (ADR-005 Rule 3 / OWASP A01:2021). | **HIGH — IDOR / privilege escalation** |
+| `JobsController::logs` | also `@NoAdminRequired` + `@NoCSRFRequired`. Job logs may contain stack traces and result messages that leak information about internal services and configurations. No `userId` filter on the OR query — every authed user sees every job's logs. | **MEDIUM — info disclosure** |
+| `JobTask::run` | ignores its `$argument` parameter (which can carry a specific `jobId` from the queue) and ALWAYS calls `jobService->run()` (process all due jobs). This means: every queued JobTask instance triggers a full sweep, regardless of which specific job was scheduled. Highly redundant; turns an O(N) queue into O(N²) sweeps. | medium — performance / correctness drift |
+| `LogCleanUpTask` | `setInterval(60)` (every minute, with a `@todo change to hour`) plus `setAllowParallelRuns(true)` and the `setTimeSensitivity(IJob::TIME_INSENSITIVE)` flag — these combine into "run every minute, allow concurrent sweeps." On a busy instance with slow OR queries, multiple cleanup sweeps stack. | medium — soft DoS via cron-storm |
+| `LogCleanUpTask::cleanupSchema` | `catch (\Exception $e) {}` per object — single-object delete failures are swallowed with no logging. A persistent malformed log object will be retried every minute forever with no operator visibility. | medium — silent failure mode |
+| `JobService::scheduleJob` | the disable-path (`isEnabled === false` OR `jobListId !== null`) clears `jobListId` but the comment says `// @todo fix this (call to protected method) // $this->jobList->removeById(...)` — **the actual NC job entry is never removed.** A disabled job stays scheduled in NC's `oc_jobs` table even though the openconnector-side record claims it's disabled. The next `JobTask` sweep will still run it. | **HIGH — disable doesn't actually disable** |
+| `JobService::scheduleJob` | the "already scheduled, don't update" guard prevents re-scheduling — there is NO way through this service to change a job's schedule once it's set. Comment says `// @todo we should`. | medium — incomplete UX |
+| `JobService::executeJob` | sets a user session via `$userSession->setUser($user)` BUT never resets it on completion. Subsequent code on the same PHP worker process inherits the job's user. In cron context this is fine (worker exits); in HTTP context (via JobsController::run from a browser) it's a session-clobber. | **HIGH — session-clobber via HTTP run** |
+| `JobService::executeJob` | the rate-limit branch uses `DateTime::createFromFormat('U', $result['nextRun'], $nextRun->getTimezone())` — `'U'` is a Unix timestamp; timezone is ignored for `'U'` and `$result['nextRun']` from the action is trusted to be a valid integer string. Malformed input from the action makes the next-run calculation NaN; PHP's `DateTime->modify` then no-ops silently. | low — input-trust |
+| `JobService::executeJob` | retention math: `$logRetention * 1000` happens at every save; the per-job `logRetention` field is in seconds, the JobService internal in milliseconds. Consistent within file but easy to misuse if another consumer reads `logRetention` directly. | low — unit hazard |
+| `JobService::getJobListId` | "get the most recent job of this class" via `ORDER BY id DESC LIMIT 1`. If two schedules of the same `JobTask` class race, both win the same id — they share state. The comment cites NC's API limitation; the pattern is best-effort. | low — known NC API gap |
+| `JobService::run::findAll filter` | `'isEnabled' => true` is filter-by-equality, but the OR object stores arbitrary JSON — if the field is missing or null on legacy records, they are silently excluded. | low — silent-skip |
+| `JobsController::logs` `searchConditions` / `searchParams` arrays | built and then NEVER USED (no `where`/`whereRaw` call before the OR query). Dead code: the date_from / date_to / status / slow_executions filters from the docstring don't actually work. | medium — silently broken filter |
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `JobsController::logs` |
+| REQ-002 | `JobsController::run` + `JobsController::test` (both invoke `executeJob` with different `forceRun` semantics) |
+| REQ-003 | `JobTask::run` |
+| REQ-004 | `JobService::scheduleJob` + `JobService::executeJob` + `JobService::run` + private helpers `saveJobLog`, `truncateMessage`, `calculateExpires`, `getJobListId` |
+| REQ-005 | `LogCleanUpTask::run` + `LogCleanUpTask::cleanupSchema` |
+
+REQ-004 deliberately folds the JobService methods together — they are a single
+unit (scheduleJob and run both call executeJob, and the four private helpers
+are only reachable from executeJob/saveJobLog).
+
+## What the spec deliberately does NOT cover
+
+- The OR `job` and `job_log` schemas — that's data-model territory.
+- The actual job-action class implementations (`jobClass`) — each is its own
+  capability (e.g. sync-related action classes belong to the
+  synchronization-engine cluster, deferred).
+- `JobsController::page` — the index template route, covered by
+  `frontend-vue-spa`.
+
+## Validation
+
+After archive, `openspec validate job-scheduling --strict` MUST pass.

--- a/openspec/changes/retrofit-2026-05-24-job-scheduling/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-job-scheduling/proposal.md
@@ -1,0 +1,32 @@
+# Retrofit — job-scheduling
+
+Describes observed behavior of 13 methods under `job-scheduling` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Controller/JobsController.php::logs()`
+- `lib/Controller/JobsController.php::run()`
+- `lib/Controller/JobsController.php::test()`
+- `lib/Cron/JobTask.php::run()`
+- `lib/Cron/LogCleanUpTask.php::run()`
+- `lib/Cron/LogCleanUpTask.php::cleanupSchema()`
+- `lib/Service/JobService.php::scheduleJob()`
+- `lib/Service/JobService.php::executeJob()`
+- `lib/Service/JobService.php::getJobListId()`
+- `lib/Service/JobService.php::saveJobLog()`
+- `lib/Service/JobService.php::truncateMessage()`
+- `lib/Service/JobService.php::calculateExpires()`
+- `lib/Service/JobService.php::run()`
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section + design.md surface observed-but-suspicious behaviour
+- Cap REQs at 5: fold private helpers (`saveJobLog`, `truncateMessage`, `calculateExpires`, `getJobListId`) under the REQs of their callers
+
+## Major security finding flagged
+
+- **HIGH (IDOR — OWASP A01:2021 / ADR-005 Rule 3)** — `JobsController::run()` and `JobsController::test()` carry `@NoAdminRequired` / `@NoCSRFRequired` and accept any job UUID. Any authenticated NC user can trigger arbitrary background job execution (including jobs configured to run as a privileged user). The controller has no per-object authorization guard. Triggers `hydra-gate-no-admin-idor`.
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-job-scheduling/specs/job-scheduling/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-job-scheduling/specs/job-scheduling/spec.md
@@ -1,0 +1,322 @@
+---
+retrofit: true
+status: draft
+---
+
+# Job scheduling
+
+## Purpose
+
+Openconnector's job-scheduling subsystem: an HTTP controller for listing
+job logs and triggering one-shot job runs, a NC `TimedJob` cron that
+dispatches the configured jobs every 5 minutes, a separate cleanup cron
+that removes expired log objects across four log schemas, and a service
+layer that holds the business logic for scheduling, executing, and
+log-persisting.
+
+This spec retroactively documents the observed contract of every method
+in the cluster. Multiple HIGH-severity observed-but-suspicious behaviours
+are documented in REQ Notes and design.md without being silently fixed.
+
+## ADDED Requirements
+
+### REQ-001: Job log listing with pagination and filter parameters
+
+`JobsController::logs(SearchService $searchService): JSONResponse` MUST
+return job-log records from OR (`register: 'openconnector', schema:
+'job_log'`) under `@NoAdminRequired` / `@NoCSRFRequired`.
+
+The endpoint MUST accept pagination via `_page` (default 1) and `_limit`
+(default 20) query parameters, compute `offset = (page - 1) * limit`, and
+strip them plus any other `_`-prefixed special params before passing to OR.
+
+The response shape MUST be:
+
+```json
+{ "results": [<jobLogs>], "page": N, "pages": N, "results_count": N, "total": N }
+```
+
+On any `\Exception`, the method MUST return `500` with body
+`{ "error": "Failed to retrieve logs: <message>" }` (using the localised
+string).
+
+#### Scenario: pagination computes page and offset from query params
+
+- **GIVEN** `?_page=3&_limit=5`
+- **WHEN** `logs(...)` is called
+- **THEN** OR is queried with `limit=5, offset=10`
+- **AND** the response carries `page=3`
+
+#### Scenario: exception path returns 500 with localised error
+
+- **GIVEN** OR throws `\Exception('db down')`
+- **WHEN** `logs(...)` is called
+- **THEN** the response status is 500
+- **AND** the body is `{ "error": "Failed to retrieve logs: db down" }`
+
+#### Notes
+
+- **MEDIUM (info disclosure):** `@NoAdminRequired` lets every authed user
+  list every job's logs — there is no `userId` filter. Job logs carry
+  stack traces and result messages that can leak service internals.
+- **MEDIUM (silently broken filter):** the docstring promises `date_from`,
+  `date_to`, `status`, `slow_executions` filtering. The code builds
+  `$searchConditions` / `$searchParams` arrays for these but never passes
+  them to the OR query — the filters are dead. Pinning this as the
+  observed behaviour so a follow-up fix is intentional, not a "did we
+  break something?" surprise.
+
+---
+
+### REQ-002: Manual job execution endpoints with forceRun semantics
+
+`JobsController::run(string $id): JSONResponse` MUST resolve the OR
+`job` object for `$id` (returning `404` with `{ error: 'Job not found' }`
+on `DoesNotExistException`), then call `JobService::executeJob(job: $job,
+forceRun: <parsed>)`. The `forceRun` flag MUST be parsed from the request
+body's `forceRun` field via `FILTER_VALIDATE_BOOLEAN`; absent → `false`.
+
+`JobsController::test(string $id): JSONResponse` MUST follow the same
+shape but ALWAYS pass `forceRun: true`.
+
+Both methods MUST return the executed `job_log` as a JSON-serialised
+object, or `null` (the literal JSON `null`) if `executeJob` returned
+`null` (job not yet due and no force). On any other `Exception`, the
+response is `500` with body `{ "error": "Failed to execute job: <message>" }`.
+
+Both methods carry `@NoAdminRequired` and `@NoCSRFRequired`.
+
+#### Scenario: run defaults to non-force execution
+
+- **GIVEN** a job that is not yet due and no `forceRun` in the body
+- **WHEN** `run('<uuid>')` is called
+- **THEN** `JobService::executeJob` is invoked with `forceRun: false`
+- **AND** the response body is literal `null`
+
+#### Scenario: test always forces
+
+- **GIVEN** a disabled job
+- **WHEN** `test('<uuid>')` is called
+- **THEN** `JobService::executeJob` is invoked with `forceRun: true`
+- **AND** the job runs anyway
+
+#### Scenario: missing job returns 404
+
+- **WHEN** `run('does-not-exist')` is called
+- **THEN** the response status is 404
+- **AND** the body is `{ "error": "Job not found" }`
+
+#### Notes
+
+- **HIGH (IDOR / ADR-005 Rule 3 / OWASP A01:2021):** both endpoints are
+  `@NoAdminRequired` / `@NoCSRFRequired` and accept arbitrary job UUIDs
+  with no per-object authorization guard. Any authenticated user can
+  trigger arbitrary background jobs — including jobs configured with a
+  privileged `userId` (see REQ-004 session-clobber note for the
+  privilege-escalation chain). This triggers `hydra-gate-no-admin-idor`.
+- The retrofit deliberately documents this attack surface but does not
+  silently add a guard — that lands as a focused security change with
+  test coverage and an admin-config decision (per-job ACL? admin-only?
+  same as OR's object permissions?).
+
+---
+
+### REQ-003: Background job dispatch via NC TimedJob
+
+`JobTask::run(mixed $argument): void` (extends `NC TimedJob`) MUST
+delegate execution to `JobService::run()` and MUST NOT inspect the
+`$argument` parameter. The task is registered with:
+
+- `setInterval(300)` — 5-minute cadence
+- `setTimeSensitivity(IJob::TIME_SENSITIVE)` — honour the cron schedule
+- `setAllowParallelRuns(false)` — at most one instance at a time
+
+#### Scenario: every cron invocation calls JobService::run unconditionally
+
+- **GIVEN** a JobTask instance scheduled with arguments `{ jobId: 'abc', forceRun: true }`
+- **WHEN** NC's cron invokes `JobTask::run($argument)`
+- **THEN** the method calls `JobService::run()` with no arguments
+- **AND** the `jobId` in `$argument` is NOT used to scope execution
+
+#### Notes
+
+- **MEDIUM (correctness / performance drift):** the method ignores
+  `$argument` and always sweeps all due jobs. This makes
+  `IJobList::scheduleAfter(...args)` calls (REQ-004 §scheduleJob)
+  effectively no-ops for per-job targeting — every cron tick processes
+  every due job, regardless of which one was queued. Net: O(N) queue
+  becomes O(N²) execution as more jobs are scheduled. Documented as
+  observed; tightening to honour `$argument['jobId']` is a separate
+  change.
+
+---
+
+### REQ-004: Job scheduling registration and execution with retention-bounded logs
+
+`JobService::scheduleJob(ObjectEntity $job): ObjectEntity` MUST inspect
+the job's `isEnabled` flag and existing `jobListId`. If `isEnabled ===
+false` OR `jobListId !== null`, the method MUST clear `jobListId` to
+`null`, save the job via `objectService->saveObject`, and return. (See
+Notes on the disable bug below.)
+
+Otherwise the method MUST add a new `JobTask` entry to `IJobList` —
+either via `scheduleAfter` (when `scheduleAfter` field is set) or
+`add(...)` — using `arguments = $jobData['arguments'] ++ ['jobId' =>
+$job->getUuid()]`. It then MUST resolve the new entry's id via
+`getJobListId(JobTask::class)`, write it back as `jobListId`, save, and
+return the saved entity.
+
+`JobService::executeJob(ObjectEntity $job, bool $forceRun = false):
+?ObjectEntity` MUST:
+
+1. Short-circuit (return a WARNING log) if `isEnabled === false` and
+   `!$forceRun`.
+2. Short-circuit (return `null`, no log) if `nextRun` is in the future
+   and `!$forceRun`.
+3. If `userId` is set on the job and no user is in the session, set the
+   session user to that `userId` (no reset after).
+4. Resolve `jobClass` from the DI container and invoke `->run($arguments)`.
+5. Compute execution time in milliseconds.
+6. If `isSingleRun` and `!$forceRun`, set `isEnabled = false`.
+7. Update `lastRun = now()`; compute `nextRun = now + interval seconds`,
+   honouring a rate-limit override in `$result['nextRun']` (Unix
+   timestamp), rounding to the next minute when the seconds component
+   is non-zero. Set the time to top-of-minute.
+8. Save the job back to OR.
+9. Compute the success / error retention via `calculateExpires` (max of
+   per-job + global retention, `null` if either is `0`).
+10. Compose `logData` (level/message/executionTime/expires/stackTrace)
+    from the action's result and save via `saveJobLog`.
+
+`JobService::run(): array` MUST query OR for `register=openconnector,
+schema=job, isEnabled=true`, filter out jobs whose `nextRun` is in the
+future, and call `executeJob` on each, collecting non-null logs into
+the return array.
+
+`JobService::getJobListId(IJob|string $job): ?int` MUST query the
+`oc_jobs` table for the most recent row matching the given class
+(`ORDER BY id DESC LIMIT 1`) and return the id, or `null` if no match.
+
+`JobService::saveJobLog(...)` (private) MUST compose the log object
+(jobId, jobClass, jobListId, arguments, lastRun, nextRun, created) ++
+`$logData`, default `expires` based on log level (`INFO`: +1h, `WARNING`
+/ `ERROR`: +3d, default: +30d) if not set, and save to OR.
+
+`JobService::truncateMessage(string $message, int $maxLength = 10000):
+string` MUST return `$message` unchanged if it fits, otherwise truncate
+to `maxLength - 50` chars + the marker `'... [Message truncated -
+original length: <N> characters]'`.
+
+`JobService::calculateExpires(...int $retentions): ?DateTime` MUST
+return `null` if any retention is `0` (indefinite retention), otherwise
+return `new DateTime('now +' . max($retentions) . 'milliseconds')`.
+
+#### Scenario: scheduleJob registers a new JobTask entry
+
+- **GIVEN** a job with `isEnabled: true`, `jobListId: null`, no `scheduleAfter`
+- **WHEN** `scheduleJob($job)` is called
+- **THEN** `IJobList::add(JobTask::class, arguments + {jobId: <uuid>})` is invoked
+- **AND** the saved job has the new `jobListId` populated
+
+#### Scenario: executeJob honours nextRun unless forced
+
+- **GIVEN** a job with `nextRun = now + 1 hour`, `isEnabled: true`
+- **WHEN** `executeJob($job, forceRun: false)` is called
+- **THEN** the method returns `null` (no log)
+- **AND** the job action is NOT invoked
+
+#### Scenario: forceRun bypasses both isEnabled and nextRun
+
+- **GIVEN** a job with `isEnabled: false`, `nextRun: now + 1h`
+- **WHEN** `executeJob($job, forceRun: true)` is called
+- **THEN** the action is invoked
+- **AND** a SUCCESS / matching-level log is saved
+
+#### Scenario: rate-limit nextRun is honoured if later than the interval-based one
+
+- **GIVEN** action returns `{ nextRun: <unix-timestamp 30 min from now>, level: 'SUCCESS' }`
+- **AND** the job's interval would have produced nextRun 10 min from now
+- **WHEN** `executeJob` runs
+- **THEN** the saved `nextRun` is the rate-limit timestamp (rounded to next minute)
+
+#### Scenario: truncateMessage truncates with marker
+
+- **GIVEN** a message of 50_000 characters
+- **WHEN** `truncateMessage($msg, 10000)` is called
+- **THEN** the return is 9_950 chars of original + the truncation marker
+- **AND** the marker reports original length 50000
+
+#### Scenario: calculateExpires returns null on indefinite
+
+- **WHEN** `calculateExpires(3600000, 0)` is called
+- **THEN** the result is `null`
+
+#### Notes
+
+- **HIGH (disable doesn't actually disable):** `scheduleJob`'s disable
+  path clears the openconnector-side `jobListId` but leaves the
+  underlying NC `oc_jobs` row in place (the commented-out
+  `removeById` call). The next `JobTask::run` sweep walks OR for
+  `isEnabled = true`, so the disabled job will be skipped — but a
+  separate `JobTask` row also persists, which could re-run on its own
+  cron schedule if its arguments happen to contain a stale `jobId`.
+  Documented as observed; the fix is to switch to a public NC API or
+  upstream a `IJobList::removeById` method.
+- **HIGH (session-clobber):** `executeJob` calls
+  `$userSession->setUser($user)` and never resets. In cron context the
+  worker exits; in HTTP context (REQ-002 `run`/`test`) the same PHP
+  worker continues processing the request with the job's user
+  identity. Combined with the IDOR in REQ-002 this is a privilege
+  escalation: any authed user can trigger a job that runs as an admin
+  user and the rest of the controller flow inherits that session.
+- **LOW (unit hazard):** per-job `logRetention` is in seconds; service
+  internals are in milliseconds — the `* 1000` happens at every save.
+  Consistent here but easy to misuse downstream.
+- **LOW (NC API gap):** `getJobListId` is best-effort `ORDER BY id DESC
+  LIMIT 1` because NC's `IJobList` does not surface a way to read the
+  id of a just-added job. Documented for visibility.
+
+---
+
+### REQ-005: Periodic expired-log cleanup across log schemas
+
+`LogCleanUpTask::run(mixed $argument): void` MUST delete expired objects
+from each of these OR schemas, in order: `call_log`, `job_log`,
+`synchronization_contract_log`, `synchronization_log`.
+
+`LogCleanUpTask::cleanupSchema(string $schema): void` (private) MUST
+query OR with `register=openconnector, schema=$schema, expires[lt] = now`
+and call `deleteObject($object->getUuid())` for each result. Per-object
+delete failures MUST be silently swallowed (`catch (\Exception) {}`) so
+that one bad row does not abort the sweep.
+
+The task is registered with:
+
+- `setInterval(60)` — every minute (with a `@todo change to hour` comment)
+- `setTimeSensitivity(IJob::TIME_INSENSITIVE)`
+- `setAllowParallelRuns(true)` — concurrent sweeps allowed
+
+#### Scenario: each schema is cleaned in order
+
+- **WHEN** `run()` is invoked
+- **THEN** `cleanupSchema('call_log')` is called first
+- **AND** then `cleanupSchema('job_log')`
+- **AND** then `cleanupSchema('synchronization_contract_log')`
+- **AND** then `cleanupSchema('synchronization_log')`
+
+#### Scenario: cleanupSchema soft-fails per object
+
+- **GIVEN** OR returns 3 expired objects and `deleteObject` throws on the second
+- **WHEN** `cleanupSchema('call_log')` runs
+- **THEN** `deleteObject` is called on all 3 UUIDs (the exception is swallowed)
+- **AND** no log entry is emitted
+
+#### Notes
+
+- **MEDIUM (cron-storm):** `setInterval(60)` + `setAllowParallelRuns(true)`
+  means concurrent sweeps stack on a busy instance with slow OR queries.
+  The `@todo change to hour` comment indicates the author knew this.
+- **MEDIUM (silent failure):** per-object delete exceptions are
+  swallowed with no logging — a persistent malformed log object will
+  be retried every minute forever with zero operator visibility.
+  Documented as observed.

--- a/openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-job-scheduling/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: job-scheduling#REQ-001 — Job log listing with pagination and filter parameters (retroactive annotation)
+- [x] task-2: job-scheduling#REQ-002 — Manual job execution endpoints with forceRun semantics (retroactive annotation)
+- [x] task-3: job-scheduling#REQ-003 — Background job dispatch via NC TimedJob (retroactive annotation)
+- [x] task-4: job-scheduling#REQ-004 — Job scheduling registration and execution with retention-bounded logs (retroactive annotation)
+- [x] task-5: job-scheduling#REQ-005 — Periodic expired-log cleanup across log schemas (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 13 methods under `job-scheduling` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-job-scheduling` (drafted in `openspec/changes/`).

### What this PR does
- Drafts 5 REQs as a new capability spec (`retrofit: true`)
- Annotates 13 methods with `@spec openspec/changes/retrofit-.../tasks.md#task-N`
- REQ-002 pairs `JobsController::run` + `::test`; REQ-004 folds 7 JobService methods under one observable schedule+execute+log capability; REQ-005 pairs the two LogCleanUpTask methods.

### What this PR does NOT do
- No code behavior changes — only docblock `@spec` annotations
- Does not silently fix observed-but-suspicious behaviour — notes/design surface it

### Security findings flagged (not fixed)
- **HIGH (IDOR / ADR-005 Rule 3 / OWASP A01:2021)** — `JobsController::run()` + `::test()` carry `@NoAdminRequired` + `@NoCSRFRequired` with no per-object authorization guard. Any authenticated NC user can trigger arbitrary background jobs by UUID. Triggers `hydra-gate-no-admin-idor`.
- **HIGH (privilege escalation chain)** — `JobService::executeJob` calls `$userSession->setUser($user)` but never resets. In HTTP context (via the IDOR above) the rest of the controller flow inherits the job's user identity — typically more privileged.
- **HIGH (disable doesn't disable)** — `JobService::scheduleJob`'s disable path clears the openconnector-side `jobListId` but leaves the NC `oc_jobs` row in place. The `removeById` call is commented out.
- **MEDIUM (info disclosure)** — `JobsController::logs` is `@NoAdminRequired` — every authed user can list every job's logs (stack traces included), no `userId` filter.
- **MEDIUM (cron-storm)** — `LogCleanUpTask` runs every minute with `setAllowParallelRuns(true)`; sweeps stack on busy instances.
- **MEDIUM (silently broken filter)** — `JobsController::logs` builds `searchConditions` / `searchParams` arrays for the documented `date_from` / `date_to` / `status` / `slow_executions` filters then never passes them to OR — the filters are dead.
- **MEDIUM (correctness drift)** — `JobTask::run` ignores its `$argument` parameter (which can carry a specific `jobId` from the queue) and always sweeps every due job, regardless of which one was queued.
- **MEDIUM (silent failure)** — `LogCleanUpTask::cleanupSchema` catches per-object delete exceptions with no logging — a persistent malformed log object is retried every minute forever invisibly.

### Review focus
- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- One REQ per observable behaviour; the JobService fold (REQ-004) is deliberate to avoid REQ inflation

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `job-scheduling`

Refs ConductionNL/openconnector#936