### PR TITLE
retrofit: reverse-spec logs-and-statistics (5 REQs / 14 methods)

### DIFF
--- a/lib/Controller/LogsController.php
+++ b/lib/Controller/LogsController.php
@@ -94,6 +94,8 @@ class LogsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-1
      */
     public function index(
         ?int $limit=20,
@@ -170,6 +172,8 @@ class LogsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-1
      */
     public function show(string $id): JSONResponse
     {
@@ -193,6 +197,8 @@ class LogsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-1
      */
     public function destroy(string $id): JSONResponse
     {
@@ -215,6 +221,8 @@ class LogsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-2
      */
     public function statistics(): JSONResponse
     {
@@ -272,6 +280,8 @@ class LogsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-2
      */
     public function export(
         ?string $level=null,

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -74,6 +74,8 @@ class SettingsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-5
      */
     public function rebase(): JSONResponse
     {

--- a/lib/Controller/SourcesController.php
+++ b/lib/Controller/SourcesController.php
@@ -102,6 +102,8 @@ class SourcesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-3
      */
     public function logs(SearchService $searchService): JSONResponse
     {
@@ -268,6 +270,8 @@ class SourcesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-3
      */
     public function test(CallService $callService, string $id): JSONResponse
     {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -79,6 +79,8 @@ class SettingsService
      * @param string $createdColumn The column expression to add the interval to.
      *
      * @return string The SQL expression.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-5
      */
     private function expiresExpression(string $createdColumn): string
     {
@@ -100,6 +102,8 @@ class SettingsService
      * @param string $column          The column name to check.
      *
      * @return bool True when the column exists, false otherwise.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-5
      */
     private function columnExists(string $unprefixedTable, string $column): bool
     {
@@ -138,6 +142,8 @@ class SettingsService
      * @return array Array containing warning counts and total counts for all tables.
      *
      * @throws \RuntimeException If statistics retrieval fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-5
      */
     public function getStats(): array
     {
@@ -247,6 +253,8 @@ class SettingsService
      *
      * @return array The current retention settings configuration.
      * @throws \RuntimeException If settings retrieval fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-4
      */
     public function getSettings(): array
     {
@@ -309,6 +317,8 @@ class SettingsService
      *
      * @return array The updated settings configuration.
      * @throws \RuntimeException If settings update fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-4
      */
     public function updateSettings(array $data): array
     {
@@ -350,6 +360,8 @@ class SettingsService
      *
      * @return array Array containing the rebase operation results
      * @throws \RuntimeException If the rebase operation fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md#task-5
      */
     public function rebase(): array
     {

--- a/openspec/changes/retrofit-2026-05-24-logs-and-statistics/design.md
+++ b/openspec/changes/retrofit-2026-05-24-logs-and-statistics/design.md
@@ -1,0 +1,60 @@
+# Design — Retrofit logs-and-statistics
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+Three controllers + one service make up the openconnector logs / stats /
+retention surface:
+
+- `LogsController` — CRUD + stats + CSV export over synchronization logs
+  (OR-backed `synchronization_log` schema).
+- `SourcesController::logs` + `::test` — per-source call-log listing and
+  a "fire a test call" outbound dispatch.
+- `SettingsController::rebase` — admin action that bulk-updates the
+  `expires` column across every log table to the current retention
+  window.
+- `SettingsService` — backs the rebase action, provides
+  `getStats` / `getSettings` / `updateSettings` for the dashboard, and
+  defines `expiresExpression` + `columnExists` for DB-portable rebase
+  SQL (GH #822).
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `LogsController::index` / `::show` / `::destroy` / `::statistics` / `::export` | every method is `@NoAdminRequired` + `@NoCSRFRequired` with no per-object guard. Any authenticated user can list, read, delete, count, and export the FULL synchronization-log dataset across the instance. Triggers `hydra-gate-no-admin-idor`. | **HIGH — IDOR / data exfiltration** |
+| `SourcesController::logs` | same — `@NoAdminRequired`. Any user reads every source's call logs (including request URLs, status codes, response bodies). | **HIGH — info disclosure / IDOR** |
+| `SourcesController::test` | `@NoAdminRequired` — any user can fire an arbitrary outbound HTTP call by providing the source UUID + request params. Even though the URL itself is admin-configured, source UUIDs are guessable; the test action can be used for: (a) blind SSRF if any source points at internal infrastructure, (b) credential probing if sources carry stored auth, (c) outbound DoS via flood. | **HIGH — SSRF / IDOR** |
+| `SettingsController::rebase` | `@NoAdminRequired` + `@NoCSRFRequired` — any authed user can trigger a global `UPDATE` across every log table, rewriting `expires` for every log row instance-wide. Combined with an `updateSettings` call that drops the retention to `1ms` (also @NoAdminRequired — REQ-004) this lets a user effectively wipe every log on the instance. | **HIGH — privilege escalation / data destruction** |
+| `LogsController::destroy` | individual-log deletion with no authz beyond "is logged in." Logs are evidence of activity — users can delete logs that incriminate them. | **MEDIUM — audit trail tampering** |
+| `LogsController::statistics` | runs 5 separate `findAll(... level: X)` queries per call. With no caching, this is a soft DoS vector (admin dashboards usually invoke it on load). | low — performance |
+| `LogsController::export` | iterates all matching logs into one PHP string for CSV emission. No pagination, no streaming. Large datasets OOM the worker. Returns the entire CSV in the JSON `content` field — base64'd through transport. | medium — soft DoS |
+| `SettingsService::rebase` | the first two `UPDATE` branches (success-log retention at index 0, call-log retention at index 1) both target `openconnector_call_logs` writing to `callLogsUpdated` — they clobber each other's results in the response dict. The first key is overwritten by the second; observable bug. | medium — drift, log loss |
+| `SettingsService::rebase` | uses `*PREFIX*<table>` interpolation inside SQL UPDATE strings. The table names are hard-coded constants so this is not user-controlled — but the `WHERE expires IS NULL OR expires = ''` is a tautology shape that touches every NULL/empty row each call. Repeated `rebase` invocations are O(N) over the log table; a malicious user can DoS the DB by spamming. | medium — soft DoS via rebase loop |
+| `SettingsService::getSettings` | hard-codes `appVersion: '0.2.0'` — drift from `appinfo/info.xml`. Stale info-disclosure surface. | low — drift |
+| `SettingsService::getStats` | every per-table query has its own `try/catch(\Exception)` that defaults the count to `0` and logs `debug`. Missing tables → zero counts. Operators can't tell "fresh install" from "table broken." | low — silent skip |
+| `LogsController::export` `JSON_EXTRACT` reference | the SourcesController equivalent uses `JSON_EXTRACT(response, '$.responseTime')` which is MySQL-specific; would fail under Postgres. Pinned for portability follow-up. | low — DB portability |
+| `LogsController::index` `filters` | `level` / `message` / `synchronizationId` / `dateFrom` / `dateTo` are forwarded into OR's `filters` array verbatim. OR is the gatekeeper for safe interpolation but the SearchService / SQL layer downstream is what would matter for injection. Documented as observation; OR contract is trusted. | informational |
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `LogsController::index` + `::show` + `::destroy` |
+| REQ-002 | `LogsController::statistics` + `::export` |
+| REQ-003 | `SourcesController::logs` + `::test` |
+| REQ-004 | `SettingsService::getSettings` + `::updateSettings` |
+| REQ-005 | `SettingsService::getStats` + `::rebase` + private helpers `expiresExpression` + `columnExists`; `SettingsController::rebase` (the thin HTTP wrapper) is folded under the same REQ-005 |
+
+## What the spec deliberately does NOT cover
+
+- The OR log schemas themselves (`synchronization_log` / `call_log` / `job_log`)
+  — that's data-model territory.
+- The CallService that backs `SourcesController::test` — its outbound
+  HTTP behaviour is covered by the `http-call-engine` cluster (PR #942).
+- The CSV format — caller contract, not a behaviour worth pinning.
+
+## Validation
+
+After archive, `openspec validate logs-and-statistics --strict` MUST pass.

--- a/openspec/changes/retrofit-2026-05-24-logs-and-statistics/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-logs-and-statistics/proposal.md
@@ -1,0 +1,34 @@
+# Retrofit — logs-and-statistics
+
+Describes observed behavior of 14 methods under `logs-and-statistics` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Controller/LogsController.php::index()`
+- `lib/Controller/LogsController.php::show()`
+- `lib/Controller/LogsController.php::destroy()`
+- `lib/Controller/LogsController.php::statistics()`
+- `lib/Controller/LogsController.php::export()`
+- `lib/Controller/SourcesController.php::logs()`
+- `lib/Controller/SourcesController.php::test()`
+- `lib/Controller/SettingsController.php::rebase()`
+- `lib/Service/SettingsService.php::getStats()`
+- `lib/Service/SettingsService.php::getSettings()`
+- `lib/Service/SettingsService.php::updateSettings()`
+- `lib/Service/SettingsService.php::rebase()`
+- `lib/Service/SettingsService.php::expiresExpression()` (private helper of rebase)
+- `lib/Service/SettingsService.php::columnExists()` (private helper of rebase)
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section + design.md surface multiple HIGH-severity authorization findings (silent IDOR pattern across the logs / stats / rebase / source-test endpoints)
+- Cap REQs at 5: paired controllers + service helpers under shared REQs
+
+## Major security findings flagged
+
+- **HIGH (IDOR — multiple endpoints)** — `LogsController` (index/show/destroy/statistics/export), `SourcesController` (logs/test), `SettingsController::rebase` ALL carry `@NoAdminRequired` + `@NoCSRFRequired` with zero per-object guards. Any authed user can read/delete/export all logs and trigger global DB rewrite via `rebase`.
+- **HIGH (SSRF)** — `SourcesController::test` triggers an arbitrary outbound HTTP call to the source URL, controllable by any authed user.
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-logs-and-statistics/specs/logs-and-statistics/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-logs-and-statistics/specs/logs-and-statistics/spec.md
@@ -1,0 +1,322 @@
+---
+retrofit: true
+status: draft
+---
+
+# Logs and statistics
+
+## Purpose
+
+The HTTP surface and service layer for openconnector's log management,
+log statistics, and retention configuration. Listings, individual
+reads / deletes, level-aggregated stats, CSV exports, per-source call
+logs, source connectivity test calls, and the admin `rebase` action that
+recomputes `expires` columns across every log table.
+
+This spec retroactively documents the observed contract of every method
+in the cluster. Multiple HIGH-severity observed-but-suspicious
+authorization findings are documented in REQ Notes and design.md
+without being silently fixed.
+
+## ADDED Requirements
+
+### REQ-001: Synchronization log listing, retrieval and deletion
+
+`LogsController::index(?int $limit = 20, ?int $offset = 0, ?string
+$level = null, ?string $message = null, ?string $synchronizationId =
+null, ?string $dateFrom = null, ?string $dateTo = null): JSONResponse`
+MUST query OR for `register=openconnector, schema=synchronization_log`
+merged with the supplied filters, paginate with the given limit and
+offset, and return:
+
+```json
+{
+  "results": [<logs>],
+  "pagination": { "page": <currentPage>, "pages": <totalPages>, "results": <countOnPage>, "total": <total> }
+}
+```
+
+`LogsController::show(string $id): JSONResponse` MUST `find` by id
+under the same register/schema and return the log's `getObject()` array
+on success, or `404 { error: 'Log not found' }` on missing.
+
+`LogsController::destroy(string $id): JSONResponse` MUST resolve the
+log by id and call `deleteObject($log->getUuid())`. On success it MUST
+return `{ message: 'Log deleted successfully' }`; on missing,
+`404 { error: 'Log not found or could not be deleted' }`.
+
+All three carry `@NoAdminRequired` + `@NoCSRFRequired`.
+
+#### Scenario: list with level filter
+
+- **GIVEN** `?level=error&limit=10&offset=0`
+- **WHEN** `index(...)` is called
+- **THEN** OR is queried with `filters: { register, schema, level: 'error' }, limit: 10, offset: 0`
+- **AND** the response carries `pagination.page == 1`
+
+#### Scenario: show non-existent log
+
+- **WHEN** `show('does-not-exist')` is called
+- **THEN** the response status is 404
+- **AND** the body is `{ error: 'Log not found' }`
+
+#### Scenario: destroy removes the log
+
+- **GIVEN** a log with uuid `<id>` exists
+- **WHEN** `destroy('<id>')` is called
+- **THEN** `deleteObject('<id>')` is invoked on OR
+- **AND** the response is `{ message: 'Log deleted successfully' }`
+
+#### Notes
+
+- **HIGH (IDOR / OWASP A01:2021):** all three endpoints are
+  `@NoAdminRequired` + `@NoCSRFRequired` and accept arbitrary log
+  UUIDs. Any authed user can list / read / delete every log on the
+  instance. `destroy` further enables audit-trail tampering — users
+  can delete logs of their own activity.
+- The retrofit documents the surface but does not patch it. Hardening
+  is a focused change with admin-only annotations + per-object scope
+  checks.
+
+---
+
+### REQ-002: Synchronization log level statistics and CSV export
+
+`LogsController::statistics(): JSONResponse` MUST issue five separate
+OR `findAll` queries — one per level
+(`error` / `warning` / `info` / `success` / `debug`) — under the
+`synchronization_log` schema, compose the per-level counts, and return:
+
+```json
+{
+  "errorCount": N, "warningCount": N, "infoCount": N, "successCount": N, "debugCount": N,
+  "levelDistribution": { "error": N, "warning": N, "info": N, "success": N, "debug": N }
+}
+```
+
+On any `\Exception` the method MUST return `500 { error: 'Could not fetch statistics' }`.
+
+`LogsController::export(?string $level = null, ?string $message =
+null, ?string $synchronizationId = null, ?string $dateFrom = null,
+?string $dateTo = null): JSONResponse` MUST run the same filter
+composition as REQ-001 `index`, query OR WITHOUT pagination, and
+build a CSV string in-memory with the header
+`UUID,Level,Message,Synchronization ID,User ID,Session ID,Created,Expires`
+and one row per log. The response MUST be:
+
+```json
+{ "filename": "synchronization_logs_<Y-m-d_H-i-s>.csv", "content": "<csv>", "contentType": "text/csv" }
+```
+
+On any `\Exception`: `500 { error: 'Could not export logs' }`.
+
+Both endpoints carry `@NoAdminRequired` + `@NoCSRFRequired`.
+
+#### Scenario: statistics aggregates 5 levels
+
+- **WHEN** `statistics()` is called
+- **THEN** five OR `findAll` queries fire (one per level)
+- **AND** the response contains both per-level keys (`errorCount`, etc) and a `levelDistribution` map
+
+#### Scenario: export builds a single CSV string
+
+- **GIVEN** 3 logs match `level=error`
+- **WHEN** `export(level: 'error')` is called
+- **THEN** the response `content` is a CSV string with 1 header line + 3 data lines
+- **AND** message fields are double-quoted with internal `"` doubled (RFC4180-ish)
+
+#### Notes
+
+- **MEDIUM (soft DoS):** `export` materialises the entire matching
+  dataset in PHP memory and returns it in the JSON body. Large
+  datasets OOM the worker.
+- **HIGH (IDOR):** like REQ-001, both endpoints are `@NoAdminRequired`
+  — any user can extract every log on the instance via CSV.
+
+---
+
+### REQ-003: Per-source call log listing and outbound test call
+
+`SourcesController::logs(SearchService $searchService): JSONResponse`
+MUST list `call_log` objects from OR with pagination via `_page` /
+`_limit`, support special filter parameters (`date_from`, `date_to`,
+`endpoint`, `status_code`, `slow_requests`), and validate sort fields
+against the allow-list `['created', 'status_code', 'endpoint']` before
+forwarding to OR.
+
+`SourcesController::test(CallService $callService, string $id):
+JSONResponse` MUST resolve the source by `$id` (404 on missing) and
+then dispatch an outbound HTTP call via `CallService` using the
+request body's `query` / `headers` / `method` / `endpoint` / `type` /
+`body` fields. The response is the call result (status / headers /
+body) as JSON.
+
+Both endpoints carry `@NoAdminRequired` + `@NoCSRFRequired`.
+
+#### Scenario: logs with status_code range
+
+- **GIVEN** `?status_code=400,500`
+- **WHEN** `logs(...)` is called
+- **THEN** the search condition `status_code >= 400 AND status_code <= 500` is appended to `searchParams`
+
+#### Scenario: test fires a CallService call
+
+- **GIVEN** a source uuid `src-1` and a body `{ method: 'POST', endpoint: '/foo', body: 'x' }`
+- **WHEN** `test($callService, 'src-1')` is called
+- **THEN** `CallService` dispatches a POST to the source's resolved URL + `/foo`
+- **AND** the response carries the upstream response shape
+
+#### Notes
+
+- **HIGH (SSRF / IDOR):** `test` is `@NoAdminRequired` and accepts
+  any source UUID. Even though the URL is admin-configured, source
+  UUIDs are guessable and the test action can be used as a blind
+  SSRF probe (sources pointing at internal IPs), a credential probe
+  (sources with stored auth), or an outbound DoS vector. Triggers
+  `hydra-gate-no-admin-idor`.
+- **HIGH (info disclosure):** `logs` exposes every source's call
+  logs (URLs, status codes, response bodies) to every authed user.
+
+---
+
+### REQ-004: App-wide retention settings read and update
+
+`SettingsService::getSettings(): array` MUST return an array shaped:
+
+```php
+[
+  'version' => ['appName' => 'Open Connector', 'appVersion' => '0.2.0'],
+  'retention' => [
+    'successLogRetention'      => <int ms, default 3_600_000>,         // 1h
+    'callLogRetention'         => <int ms, default 2_592_000_000>,      // 30d
+    'eventMessageRetention'    => <int ms, default 604_800_000>,        // 7d
+    'jobLogRetention'          => <int ms, default 2_592_000_000>,      // 30d
+    'syncContractLogRetention' => <int ms, default 7_776_000_000>,      // 90d
+    'syncLogRetention'         => <int ms, default 2_592_000_000>,      // 30d
+  ],
+]
+```
+
+When the `openconnector / retention` IAppConfig key exists, the method
+MUST JSON-decode it and override the per-key defaults via `?? <default>`.
+
+`SettingsService::updateSettings(array $data): array` MUST accept a
+shape containing a `retention` key. When present, the method MUST
+JSON-encode the retention payload and write it to `openconnector /
+retention` via `setValueString`. The method MUST then return
+`getSettings()` (the freshly read state).
+
+Both methods throw `\RuntimeException` on `\Exception`, with the
+original message wrapped.
+
+#### Scenario: defaults applied when no config
+
+- **WHEN** `getSettings()` is called with no `retention` key in IAppConfig
+- **THEN** the response carries all 6 default retention values
+
+#### Scenario: update writes JSON and returns freshly read state
+
+- **GIVEN** `data = { retention: { callLogRetention: 86_400_000 } }`
+- **WHEN** `updateSettings($data)` is called
+- **THEN** `openconnector / retention` is set to a JSON string with the new value
+- **AND** the return is `getSettings()` reflecting the updated config
+
+#### Notes
+
+- **LOW (drift):** `appVersion: '0.2.0'` is hard-coded and drifts
+  from `appinfo/info.xml`. Documented as observed; fix is to source
+  from `IAppManager::getAppVersion`.
+
+---
+
+### REQ-005: App-wide stats and DB-vendor-aware retention rebase
+
+`SettingsService::getStats(): array` MUST return a fixed-shape array
+with three sections: `warnings` (counts of records that need
+attention — without-expiry / expired across 5 schemas), `totals`
+(15 `total<Table>` counts), `sizes` (10 size counters), plus a
+`lastUpdated` ISO-8601 timestamp.
+
+Per-table counts MUST be obtained via direct
+`SELECT COUNT(*) FROM <table>` queries (one per table). Per-table
+`\Exception` failures MUST default the count to `0` and log a `debug`
+entry. Any other top-level `\Exception` MUST be wrapped in
+`\RuntimeException`.
+
+`SettingsService::rebase(): array` MUST iterate over 6 retention
+buckets (success-log, call-log, event-message, job-log, sync-contract-log,
+sync-log) and for each non-zero retention value run an SQL `UPDATE`
+that sets `expires` on every row where the current value is `NULL` or
+empty (and for sync-contract / sync logs also where the value is
+`'0000-00-00 00:00:00'` or `created IS NOT NULL`). The
+`expires` expression MUST be DB-vendor-portable via
+`expiresExpression` (REQ-005 helpers).
+
+Per-bucket exceptions MUST be appended to `results.errors` and logged
+via `LoggerInterface::error`. The method MUST always return a result
+dict with `startTime`, `endTime`, `duration`, `success`,
+`retentionResults`, `errors`.
+
+The two private helpers:
+
+- `expiresExpression(string $createdColumn): string` MUST return a
+  parametrised SQL fragment that adds a microsecond interval. The
+  expression branches on the active `Doctrine\DBAL\Platforms`
+  vendor: PostgreSQL gets
+  `<col> + (? || ' microseconds')::interval`; everything else gets
+  `DATE_ADD(<col>, INTERVAL ? MICROSECOND)`.
+- `columnExists(string $unprefixedTable, string $column): bool` MUST
+  return `true` iff the named column exists on the named table. The
+  query branches on vendor: PostgreSQL uses
+  `information_schema.columns`; others use `SHOW COLUMNS FROM
+  \`*PREFIX*<table>\` LIKE <quoted-column>`. Any `\Throwable`
+  (e.g. legacy table dropped) MUST return `false`.
+
+`SettingsController::rebase(): JSONResponse` is a thin HTTP wrapper
+that calls `SettingsService::rebase()` and returns its result as JSON.
+On `\Exception` it returns `500 { error: 'Failed to perform rebase
+operation', message: <e->getMessage()> }`. Carries `@NoAdminRequired`
++ `@NoCSRFRequired`.
+
+#### Scenario: getStats aggregates 15 totals
+
+- **WHEN** `getStats()` is called
+- **THEN** 15 `SELECT COUNT(*)` queries fire, one per registered table
+- **AND** the response carries `totals.totalCallLogs`, `totals.totalJobs`, etc
+
+#### Scenario: rebase on PostgreSQL uses interval syntax
+
+- **GIVEN** the DB platform is `PostgreSQLPlatform`
+- **AND** `retention.callLogRetention = 86_400_000` (1 day in ms)
+- **WHEN** `rebase()` is called
+- **THEN** the call-logs UPDATE uses `expires = created + (? || ' microseconds')::interval` with `86_400_000_000` (microseconds) as the bound parameter
+
+#### Scenario: rebase on MySQL uses DATE_ADD
+
+- **GIVEN** the DB platform is MySQL (default branch)
+- **WHEN** `rebase()` runs the same retention
+- **THEN** the UPDATE uses `expires = DATE_ADD(created, INTERVAL ? MICROSECOND)`
+
+#### Scenario: missing legacy table is silently skipped
+
+- **GIVEN** the `event_messages.expires` column does NOT exist (legacy table dropped post #820)
+- **WHEN** `rebase()` reaches the event-messages bucket
+- **THEN** `columnExists` returns `false` (the `\Throwable` catch fires)
+- **AND** the result dict contains `retentionResults.eventMessagesUpdated = 'Column expires not found - skipped'`
+
+#### Notes
+
+- **HIGH (privilege escalation / data destruction):** the HTTP
+  wrapper `SettingsController::rebase` is `@NoAdminRequired` —
+  combined with REQ-004's `updateSettings` (also @NoAdminRequired)
+  any authed user can set retention to `1ms` and trigger `rebase`,
+  effectively wiping every log on the instance.
+- **MEDIUM (bucket clobber):** the first UPDATE branch (success-log
+  retention) writes to `*PREFIX*openconnector_call_logs` AND records
+  the row count under the key `callLogsUpdated`; the second branch
+  (call-log retention) does the same. The second clobbers the first
+  in the response dict. Two of the six rebase passes target the
+  same table with the same write key — observable bug.
+- **MEDIUM (DB portability):** the sources-controller log query
+  (REQ-003) uses MySQL-specific `JSON_EXTRACT(response,
+  '$.responseTime')` — would fail under Postgres.

--- a/openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-logs-and-statistics/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: logs-and-statistics#REQ-001 — Synchronization log listing, retrieval and deletion (retroactive annotation)
+- [x] task-2: logs-and-statistics#REQ-002 — Synchronization log level statistics and CSV export (retroactive annotation)
+- [x] task-3: logs-and-statistics#REQ-003 — Per-source call log listing and outbound test call (retroactive annotation)
+- [x] task-4: logs-and-statistics#REQ-004 — App-wide retention settings read and update (retroactive annotation)
+- [x] task-5: logs-and-statistics#REQ-005 — App-wide stats and DB-vendor-aware retention rebase (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 14 methods under `logs-and-statistics` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-logs-and-statistics` (drafted in `openspec/changes/`).

### What this PR does
- Drafts 5 REQs as a new capability spec (`retrofit: true`)
- Annotates 14 methods with `@spec` tags
- Paired methods under shared REQs to stay at cap: REQ-001 logs CRUD trio, REQ-002 stats+export, REQ-003 sources logs+test, REQ-004 settings read+update, REQ-005 stats+rebase+two helpers+HTTP wrapper

### Security findings flagged (not fixed)
- **HIGH IDOR (multiple endpoints)** — `LogsController` (index/show/destroy/statistics/export), `SourcesController::logs`, `SourcesController::test`, `SettingsController::rebase` ALL carry `@NoAdminRequired` + `@NoCSRFRequired`. Any authed user can read/delete/export all logs, fire outbound calls per any source UUID, and trigger global DB UPDATE across all log tables. Triggers `hydra-gate-no-admin-idor`.
- **HIGH SSRF** — `SourcesController::test` enables blind SSRF via any guessable source UUID (sources may point at internal infrastructure or carry stored auth).
- **HIGH privilege escalation / data destruction** — chaining `SettingsService::updateSettings` (retention -> 1 ms, also @NoAdminRequired) + `rebase` lets any authed user effectively wipe every log on the instance.
- **HIGH audit-trail tampering** — `LogsController::destroy` lets users delete logs that document their own activity.
- **MEDIUM observable bug** — `SettingsService::rebase` first two UPDATE branches both target `openconnector_call_logs` and clobber `callLogsUpdated` in the response dict.
- **MEDIUM soft DoS** — `LogsController::export` materialises the full dataset in PHP memory; `LogsController::statistics` runs 5 uncached `findAll`s per call.
- **MEDIUM DB portability** — `SourcesController::logs` uses MySQL-specific `JSON_EXTRACT` for slow-request filtering; fails under Postgres.
- **LOW drift** — `SettingsService::getSettings` hard-codes `appVersion: '0.2.0'`, drifts from `appinfo/info.xml`.

### Review focus
- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- Pairings are deliberate per the design.md REQ-map; do not split unless adding scenarios that motivate it

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `logs-and-statistics`

Refs ConductionNL/openconnector#936