### PR TITLE
retrofit: reverse-spec software-catalogus-events (5 REQs / 23 methods)

### DIFF
--- a/lib/EventListener/SoftwareCatalogEventListener.php
+++ b/lib/EventListener/SoftwareCatalogEventListener.php
@@ -99,6 +99,8 @@ class SoftwareCatalogEventListener implements IEventListener
      * @param ObjectCreatedEvent $event The creation event.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-4
      */
     private function handleObjectCreated(ObjectCreatedEvent $event): void
     {
@@ -147,6 +149,8 @@ class SoftwareCatalogEventListener implements IEventListener
      * @param ObjectUpdatedEvent $event The update event.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-4
      */
     private function handleObjectUpdated(ObjectUpdatedEvent $event): void
     {
@@ -178,6 +182,8 @@ class SoftwareCatalogEventListener implements IEventListener
      * @param ObjectDeletedEvent $event The deletion event.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-4
      */
     private function handleObjectDeleted(ObjectDeletedEvent $event): void
     {

--- a/lib/Service/SoftwareCatalogueService.php
+++ b/lib/Service/SoftwareCatalogueService.php
@@ -89,6 +89,8 @@ class SoftwareCatalogueService
      *
      * @throws \Psr\Container\ContainerExceptionInterface Container failure.
      * @throws \Psr\Container\NotFoundExceptionInterface  Container miss.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-1
      */
     public function extendModel(int|string $modelId): PromiseInterface
     {
@@ -163,6 +165,8 @@ class SoftwareCatalogueService
      * @throws DoesNotExistException If the view or model does not exist in the object store.
      *
      * @psalm-return PromiseInterface<void>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-1
      */
     public function extendView(array $viewPromise, array $modelPromise): PromiseInterface
     {
@@ -276,6 +280,8 @@ class SoftwareCatalogueService
      * @return PromiseInterface A promise that resolves with the extended node.
      *
      * @psalm-return PromiseInterface<array>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-2
      */
     private function extendNode(array $node): PromiseInterface
     {
@@ -342,6 +348,8 @@ class SoftwareCatalogueService
      * @param array $connection The connection to extend.
      *
      * @return PromiseInterface The resulting promise.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-2
      */
     private function extendConnection(array $connection): PromiseInterface
     {
@@ -394,6 +402,8 @@ class SoftwareCatalogueService
      * @param array $node The node to find an element for.
      *
      * @return array|null The matching element or null if not found.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-3
      */
     private function findElementForNode(array $node): ?array
     {
@@ -421,6 +431,8 @@ class SoftwareCatalogueService
      * @param array $connection The connection to find a relationship for.
      *
      * @return array|null The matching relationship or null if not found.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-3
      */
     private function findRelationForConnection(array $connection): ?array
     {
@@ -448,6 +460,8 @@ class SoftwareCatalogueService
      * @param array $element The element to find relations for.
      *
      * @return array Array of relations.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-3
      */
     private function findRelationsForElement(array $element): array
     {
@@ -476,6 +490,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the operation fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-4
      */
     public function handleNewOrganization(ObjectEntity $organization): void
     {
@@ -498,6 +514,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the operation fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-4
      */
     public function handleNewContact(ObjectEntity $contact): void
     {
@@ -517,6 +535,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the operation fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-4
      */
     public function handleContactUpdate(ObjectEntity $contact): void
     {
@@ -536,6 +556,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the operation fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-4
      */
     public function handleContactDeletion(ObjectEntity $contact): void
     {
@@ -555,6 +577,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the email sending fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-5
      */
     private function sendWelcomeEmail(ObjectEntity $organization): void
     {
@@ -571,6 +595,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the notification sending fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-5
      */
     private function sendVngNotification(ObjectEntity $organization): void
     {
@@ -587,6 +613,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the security group creation fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-5
      */
     private function createSecurityGroup(ObjectEntity $organization): void
     {
@@ -603,6 +631,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the user creation/enabling fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-5
      */
     private function createOrEnableUser(ObjectEntity $contact): void
     {
@@ -619,6 +649,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the user update fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-5
      */
     private function updateUser(ObjectEntity $contact): void
     {
@@ -635,6 +667,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the user disabling fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-5
      */
     private function disableUser(ObjectEntity $contact): void
     {
@@ -651,6 +685,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the email sending fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-5
      */
     private function sendContactWelcomeEmail(ObjectEntity $contact): void
     {
@@ -667,6 +703,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the email sending fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-5
      */
     private function sendContactUpdateEmail(ObjectEntity $contact): void
     {
@@ -683,6 +721,8 @@ class SoftwareCatalogueService
      * @return void
      *
      * @throws \Exception If the email sending fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md#task-5
      */
     private function sendContactDeletionEmail(ObjectEntity $contact): void
     {

--- a/openspec/changes/retrofit-2026-05-24-software-catalogus-events/design.md
+++ b/openspec/changes/retrofit-2026-05-24-software-catalogus-events/design.md
@@ -1,0 +1,65 @@
+# Design — Retrofit software-catalogus-events
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+Two distinct concerns wired through a single service + event listener:
+
+1. **ArchiMate model graph extension** (`SoftwareCatalogueService::extend*`,
+   `find*`). Reads an OR-stored ArchiMate-style model + views + nodes +
+   connections, walks the graph in parallel via ReactPHP promises, and
+   writes back per-view "extended" objects under the `extendview` schema.
+2. **Lifecycle event handling** (`SoftwareCatalogEventListener` + the
+   `handle*` orchestrators in `SoftwareCatalogueService`). The listener
+   subscribes to OR `ObjectCreated` / `ObjectUpdated` / `ObjectDeleted`
+   events, filters by schema id (`ORGANIZATION_SCHEMA_ID` /
+   `CONTACT_SCHEMA_ID` constants on the listener), and dispatches to the
+   matching `handleNew*` / `handleContactUpdate` / `handleContactDeletion`
+   orchestrators on the service. Each orchestrator then calls 2–3
+   provisioning helpers in fixed order.
+
+## Observed-but-suspicious behaviour (flagged, not fixed)
+
+| Site | Issue | Severity |
+|---|---|---|
+| `sendWelcomeEmail` / `sendVngNotification` / `createSecurityGroup` / `createOrEnableUser` / `updateUser` / `disableUser` / `sendContactWelcomeEmail` / `sendContactUpdateEmail` / `sendContactDeletionEmail` | every one of these 9 helpers is a stub. Body is `// TODO: Implement <X> logic.` + a single `$this->logger->info('<message>', ['organization' => $organization])` (or `['contact' => $contact]`). No email is sent, no group is created, no user is provisioned. The methods are wired up — the event listener calls the orchestrators, the orchestrators call these — so the pipeline LOOKS green at every layer. Operators reading info-level logs would see "Sending welcome email to organization" without realising NO email actually goes out. Triggers `hydra-gate-stub-scan`. | **HIGH — silent no-op provisioning** |
+| `extendModel` / `extendView` `$deferred->promise()->catch(fn ($error) {})` | each method registers an empty catch handler on its own deferred promise, so any rejection upstream is silently swallowed at the boundary. The `then`'s `onRejected` callback DOES reject the deferred, but the empty `catch` then no-ops on the resulting rejected promise. Net: model-extension errors are invisible to the caller. | medium — silent failure |
+| `extendModel` `array_map(function ($view) ... { $this->extendView(...); })` (line 130) | the inner callback NEVER `return`s the call to `extendView`. So `$promises` is a list of `null`s. `all($promises)` resolves immediately on `null`s — the actual extendView promises are leaked and run as side effects with no aggregation. Observable bug. | **HIGH — extendModel never actually awaits views** |
+| `extendNode` SUFFIX mutation | unconditionally appends `self::SUFFIX` to `node.identifier` if not already present. The SUFFIX is set on the class constant; no defensive check that the identifier is a string (could be `null` for malformed nodes — `str_ends_with(null, ...)` would TypeError pre-PHP 8.1 / be cast to `""` in 8.1+). | low — input-trust |
+| `extendNode` recursive promises | recurses via `extendNode` for every `$node['nodes']` subtree. No depth limit — adversarial input could OOM via deeply nested nodes (though OR objects are typically schema-bounded). | low — soft-DoS theoretical |
+| `extendView` `array_filter(... === 'Relationship')` | partitions results by string equality on the `type` field. Case-sensitive, unbounded type vocabulary. Drift in OR's schema (e.g. switching to `relationship` lowercase) silently empties one of the two arrays. | low — drift surface |
+| `extendView` `saveObject(..., uuid: $id)` | when `$id` is `null` (first-time extension) the save creates a new object; otherwise it overwrites. The override path has NO conflict / versioning check — a parallel extension run on the same view will clobber a peer's write. | medium — last-write-wins |
+| `EventListener::handleObjectUpdated` | only acts on `CONTACT_SCHEMA_ID`; organisations have NO update handler (only create — `handleNewOrganization`). So renaming or otherwise editing an organisation triggers no NC group rename, no notification. | medium — gap |
+| `EventListener::handleObjectDeleted` | same: organisations have NO delete handler — only contacts get `handleContactDeletion`. An organisation can be removed in SC while its provisioned (placeholder) NC group remains forever. | medium — gap (becomes worse once stubs are filled) |
+| `EventListener::handle` exception wrapping | catches `\Exception` per dispatch but NOT `\Throwable` — fatal errors (TypeError, OutOfMemoryError) propagate up. The OR event dispatcher's tolerance for that depends on its own catch shape. | low — wrong-class catch |
+| `handleNewOrganization` / `handleNewContact` etc. orchestrator order | the orchestrators call helpers in a fixed serial sequence with no transaction. If `createSecurityGroup` ever shipped and threw between `sendWelcomeEmail` (sent) and `sendVngNotification` (not yet sent), the org would be partially provisioned with no rollback. Documented as observed even though all helpers are stubs today. | low — pre-implementation hazard |
+
+## REQ → method map
+
+| REQ | Methods |
+|---|---|
+| REQ-001 | `extendModel` + `extendView` |
+| REQ-002 | `extendNode` + `extendConnection` (paired — both apply SUFFIX-normalisation and look up via REQ-003 helpers) |
+| REQ-003 | `findElementForNode` + `findRelationForConnection` + `findRelationsForElement` |
+| REQ-004 | `EventListener::handleObjectCreated` + `::handleObjectUpdated` + `::handleObjectDeleted` + `handleNewOrganization` + `handleNewContact` + `handleContactUpdate` + `handleContactDeletion` (all 7 dispatch / orchestrator methods folded — they share the same dispatch-by-schema-id + try/catch shape) |
+| REQ-005 | All 9 stub provisioning helpers (`sendWelcomeEmail`, `sendVngNotification`, `createSecurityGroup`, `createOrEnableUser`, `updateUser`, `disableUser`, `sendContactWelcomeEmail`, `sendContactUpdateEmail`, `sendContactDeletionEmail`) |
+
+REQ-005 is a single REQ deliberately — these 9 methods share the same
+observable behaviour (a log-only no-op) and their contracts collapse
+into "this method emits a log line and does nothing else". Splitting
+them would mean 9 near-identical REQs.
+
+## What the spec deliberately does NOT cover
+
+- The OR `extendview` / `model` / `view` / `element` / `relationship`
+  schemas — that's data-model territory.
+- The OR event-dispatcher wiring (`addServiceListener`) — covered by
+  the events-cloudevents cluster (PR #943).
+- The ArchiMate semantics (what "extending" means in the modelling
+  sense) — that's domain documentation.
+
+## Validation
+
+After archive, `openspec validate software-catalogus-events --strict`
+MUST pass.

--- a/openspec/changes/retrofit-2026-05-24-software-catalogus-events/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-software-catalogus-events/proposal.md
@@ -1,0 +1,37 @@
+# Retrofit — software-catalogus-events
+
+Describes observed behavior of 23 methods under `software-catalogus-events` as 5 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/EventListener/SoftwareCatalogEventListener.php::handleObjectCreated()`
+- `lib/EventListener/SoftwareCatalogEventListener.php::handleObjectUpdated()`
+- `lib/EventListener/SoftwareCatalogEventListener.php::handleObjectDeleted()`
+- `lib/Service/SoftwareCatalogueService.php::extendModel()`
+- `lib/Service/SoftwareCatalogueService.php::extendView()`
+- `lib/Service/SoftwareCatalogueService.php::extendNode()`
+- `lib/Service/SoftwareCatalogueService.php::extendConnection()`
+- `lib/Service/SoftwareCatalogueService.php::findElementForNode()`
+- `lib/Service/SoftwareCatalogueService.php::findRelationForConnection()`
+- `lib/Service/SoftwareCatalogueService.php::findRelationsForElement()`
+- `lib/Service/SoftwareCatalogueService.php::handleNewOrganization()`
+- `lib/Service/SoftwareCatalogueService.php::handleNewContact()`
+- `lib/Service/SoftwareCatalogueService.php::handleContactUpdate()`
+- `lib/Service/SoftwareCatalogueService.php::handleContactDeletion()`
+- `lib/Service/SoftwareCatalogueService.php::sendWelcomeEmail()` (stub)
+- `lib/Service/SoftwareCatalogueService.php::sendVngNotification()` (stub)
+- `lib/Service/SoftwareCatalogueService.php::createSecurityGroup()` (stub)
+- `lib/Service/SoftwareCatalogueService.php::createOrEnableUser()` (stub)
+- `lib/Service/SoftwareCatalogueService.php::updateUser()` (stub)
+- `lib/Service/SoftwareCatalogueService.php::disableUser()` (stub)
+- `lib/Service/SoftwareCatalogueService.php::sendContactWelcomeEmail()` (stub)
+- `lib/Service/SoftwareCatalogueService.php::sendContactUpdateEmail()` (stub)
+- `lib/Service/SoftwareCatalogueService.php::sendContactDeletionEmail()` (stub)
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Cap at 5 REQs by splitting the cluster along its two concerns: ArchiMate model graph extension (REQ-001..003), lifecycle event handling (REQ-004), provisioning stubs (REQ-005). The stubs share a "log-only no-op" contract that's worth a single REQ — their orchestrators (REQ-004) call them in fixed order.
+- design.md flags the **stub-scan finding**: 9 of 23 methods are `// TODO: Implement` bodies whose only behaviour is `LoggerInterface::info`. Wired through the EventListener, every organisation / contact created in the SC produces a log line but NO welcome email, NO VNG notification, NO security group, NO NC user. The pipeline LOOKS like it's running.
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-software-catalogus-events/specs/software-catalogus-events/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-software-catalogus-events/specs/software-catalogus-events/spec.md
@@ -1,0 +1,295 @@
+---
+retrofit: true
+status: draft
+---
+
+# Software catalogus events
+
+## Purpose
+
+Two concerns wired into the openconnector software-catalogus integration:
+ArchiMate-style model graph extension (read OR model + views, walk nodes
++ connections via ReactPHP promises, write per-view "extended" objects)
+and lifecycle-event provisioning (subscribe to OR
+ObjectCreated/Updated/Deleted, dispatch to per-schema orchestrators
+that should provision NC groups + users + emails).
+
+This spec retroactively documents the observed contract — including
+the fact that 9 of the 23 methods are documented log-only stubs whose
+"observable behaviour" is a single `LoggerInterface::info` call.
+
+## ADDED Requirements
+
+### REQ-001: ReactPHP promise-based ArchiMate model graph extension
+
+`extendModel(int|string $modelId): PromiseInterface` MUST resolve the
+OR `vng-gemma` model object via `ObjectService::getOpenRegisters()->find(...)`,
+load all existing `extendview` objects into `$this->existingViews`,
+then for each `view` in the model's `views` array call
+`extendView($view, $model)` (REQ-001 cont) and aggregate via ReactPHP
+`all(...)`. The returned `PromiseInterface` resolves when all view
+extensions complete.
+
+`extendView(array $viewPromise, array $modelPromise): PromiseInterface`
+MUST stash the model's `elements` + `relationships` into instance
+state (`$this->elements`, `$this->relations`), extend each `node` via
+`extendNode` (REQ-002) and each `connection` via `extendConnection`
+(REQ-002) in parallel, partition results by `type === 'Relationship'`
+into the view's `nodes` and `connections` arrays, and save the
+resulting view via `ObjectService::getOpenRegisters()->saveObject(...,
+uuid: <existing-uuid-or-null>)`.
+
+Both methods MUST reject the returned deferred on
+`OpenRegister service is not available` if `getOpenRegisters()` returns
+`null`.
+
+#### Scenario: extendModel walks all views
+
+- **GIVEN** a model with 3 views
+- **WHEN** `extendModel($id)` is called
+- **THEN** `extendView` is invoked 3 times (one per view, in parallel)
+- **AND** the returned promise resolves after all 3 view extensions complete
+
+#### Scenario: OR unavailable rejects the promise
+
+- **GIVEN** `ObjectService::getOpenRegisters()` returns `null`
+- **WHEN** `extendModel(...)` is called
+- **THEN** the returned promise is REJECTED with `\Exception('OpenRegister service is not available')`
+
+#### Notes
+
+- **HIGH (observable bug — `extendModel` never awaits views):** the
+  inner array_map callback in `extendModel`
+  `function ($view) use ($model) { $this->extendView(viewPromise: $view, modelPromise: $model); }`
+  has NO `return` statement — so `$promises` is a list of `null`s,
+  `all($promises)` resolves immediately, and the actual `extendView`
+  promises run as fire-and-forget side effects. The caller's
+  `then()` fires before any view is actually extended. Documented as
+  observed; fix is a `return $this->extendView(...)`.
+- **MEDIUM (silent failure):** both methods register
+  `$deferred->promise()->catch(fn ($error) {})` — any rejection at
+  the deferred boundary is swallowed.
+- **MEDIUM (last-write-wins):** `saveObject(..., uuid: $id)` has no
+  conflict-detection; parallel extension runs on the same view race.
+- `$this->elements` / `$this->relations` / `$this->existingViews`
+  are mutable instance state set by extendView/extendModel —
+  reusing the service instance across concurrent extends would race.
+
+---
+
+### REQ-002: Node and connection extension with identifier-suffix normalisation
+
+`extendNode(array $node): PromiseInterface` MUST:
+
+1. Append `self::SUFFIX` to `node.identifier` if not already present.
+2. Call `findElementForNode($node)` (REQ-003). If `null`, log a warning
+   and resolve with the unchanged node.
+3. Call `findRelationsForElement($element)` (REQ-003).
+4. Attach the matched element to the node as `$node['element']`.
+5. If `$node['nodes']` is a non-empty array, recurse via `extendNode`
+   on each child in parallel and replace `$node['nodes']` with the
+   extended array.
+6. Resolve with the extended node.
+
+On `\Exception`, log via `LoggerInterface::error` and reject.
+
+`extendConnection(array $connection): PromiseInterface` MUST:
+
+1. Append `self::SUFFIX` to `connection.identifier` if not already present.
+2. Call `findRelationForConnection($connection)` (REQ-003). If `null`,
+   log a warning and resolve with the unchanged connection.
+3. Attach the matched relationship to the connection as
+   `$connection['relationship']`.
+4. Append `self::SUFFIX` to `source` and `target` if not already
+   present.
+5. Resolve with the extended connection.
+
+#### Scenario: extendNode attaches a matching element
+
+- **GIVEN** a node `{ identifier: 'x', elementRef: 'el-1' }` and `$this->elements` contains an element with `identifier: 'el-1'`
+- **WHEN** `extendNode($node)` is called
+- **THEN** the resolved node carries `element` matching `el-1`
+- **AND** the node's identifier is `'x' . self::SUFFIX`
+
+#### Scenario: extendConnection appends SUFFIX to source/target
+
+- **GIVEN** a connection `{ identifier: 'c1', source: 's1', target: 't1' }`
+- **WHEN** `extendConnection($conn)` is called
+- **THEN** the resolved connection carries `source: 's1' . SUFFIX`, `target: 't1' . SUFFIX`
+
+#### Notes
+
+- **LOW (input trust):** `str_ends_with($node['identifier'], ...)`
+  TypeErrors on non-string identifier in PHP 8.0; casts to `""` in
+  8.1+. The methods do not validate input types.
+- **LOW (soft-DoS theoretical):** `extendNode` recurses on
+  `$node['nodes']` with no depth limit. Schema-bounded in practice
+  but worth noting.
+
+---
+
+### REQ-003: Element and relation lookup helpers
+
+`findElementForNode(array $node): ?array` MUST return `null` if
+`$node['elementRef']` is unset. Otherwise the method MUST search
+`$this->elements` (set by `extendView`) for an element whose
+`identifier` strictly equals `$node['elementRef']` and return the
+matching element array, or `null` if none.
+
+`findRelationForConnection(array $connection): ?array` MUST mirror
+the same shape for `$connection['relationshipRef']` against
+`$this->relations`, returning the matching relationship or `null`.
+
+`findRelationsForElement(array $element): array` MUST return all
+entries in `$this->relations` where `source` OR `target` equals
+`$element['identifier']`, returning a (possibly empty) array of
+matching relations.
+
+#### Scenario: findElementForNode misses cleanly
+
+- **GIVEN** `$this->elements` contains no element with `identifier === 'missing'`
+- **WHEN** `findElementForNode(['elementRef' => 'missing'])` is called
+- **THEN** the return is `null`
+
+#### Scenario: findRelationsForElement returns matches
+
+- **GIVEN** `$this->relations` contains 2 relations referencing element `e1` (one as source, one as target) and 1 relation referencing `e2`
+- **WHEN** `findRelationsForElement(['identifier' => 'e1'])` is called
+- **THEN** the return contains exactly the 2 e1-related entries
+
+#### Notes
+
+- These helpers depend on `$this->elements` / `$this->relations`
+  being set — they MUST only be invoked from inside an `extendView`
+  call (or its descendants). Calling directly with stale state
+  silently returns wrong matches.
+
+---
+
+### REQ-004: OR lifecycle event dispatch to provisioning orchestrators
+
+`SoftwareCatalogEventListener::handleObjectCreated(ObjectCreatedEvent
+$event): void` MUST inspect the event's `getObject()` result. If the
+object's `getSchema()` equals `self::ORGANIZATION_SCHEMA_ID`, the
+method MUST call `SoftwareCatalogueService::handleNewOrganization($object)`.
+If it equals `self::CONTACT_SCHEMA_ID`, the method MUST call
+`handleNewContact($object)`.
+
+`handleObjectUpdated(ObjectUpdatedEvent $event): void` MUST inspect
+`$event->getNewObject()` and dispatch to
+`handleContactUpdate($object)` if the schema id matches
+`CONTACT_SCHEMA_ID`. Organisations have NO update handler.
+
+`handleObjectDeleted(ObjectDeletedEvent $event): void` MUST inspect
+`$event->getObject()` and dispatch to `handleContactDeletion($object)`
+if schema id matches `CONTACT_SCHEMA_ID`. Organisations have NO
+delete handler.
+
+All three event-listener methods MUST catch `\Exception` per
+dispatch, log via `LoggerInterface::error('Failed to handle ...: ',
+['exception' => $e, 'object' => $object])`, and return — never
+rethrow.
+
+The four orchestrators on `SoftwareCatalogueService` MUST call their
+helpers in fixed serial order:
+
+- `handleNewOrganization($organization)` → `sendWelcomeEmail` +
+  `sendVngNotification` + `createSecurityGroup` (REQ-005).
+- `handleNewContact($contact)` → `createOrEnableUser` +
+  `sendContactWelcomeEmail` (REQ-005).
+- `handleContactUpdate($contact)` → `updateUser` +
+  `sendContactUpdateEmail` (REQ-005).
+- `handleContactDeletion($contact)` → `disableUser` +
+  `sendContactDeletionEmail` (REQ-005).
+
+The orchestrators do not catch exceptions themselves — exceptions
+propagate to the listener's per-dispatch catch.
+
+#### Scenario: new organisation routes to handleNewOrganization
+
+- **GIVEN** an `ObjectCreatedEvent` whose object's schema id matches `ORGANIZATION_SCHEMA_ID`
+- **WHEN** `SoftwareCatalogEventListener::handle($event)` runs (dispatches to `handleObjectCreated`)
+- **THEN** `SoftwareCatalogueService::handleNewOrganization($object)` is called
+
+#### Scenario: organisation update is ignored
+
+- **GIVEN** an `ObjectUpdatedEvent` whose schema id matches `ORGANIZATION_SCHEMA_ID`
+- **WHEN** the event is dispatched
+- **THEN** NO orchestrator is invoked (there is no organisation-update handler)
+
+#### Scenario: orchestrator exception is logged and swallowed at the listener
+
+- **GIVEN** `handleNewOrganization` throws (e.g. an OR transient failure)
+- **WHEN** the event listener dispatches the event
+- **THEN** the `\Exception` is caught, an error is logged with the object payload, and the listener returns normally
+
+#### Notes
+
+- **MEDIUM (gap):** organisations have no update / delete handler.
+  Renaming or removing an organisation in SC triggers no NC-side
+  reaction.
+- **LOW (wrong-class catch):** `handle*` methods catch `\Exception`
+  but not `\Throwable` — fatal errors propagate up. OR's event
+  dispatcher's tolerance varies.
+- **LOW (no transaction):** the orchestrators run helpers serially
+  with no rollback. Once the stubs are filled (REQ-005), a partial
+  failure can leave the org / contact half-provisioned.
+
+---
+
+### REQ-005: Stub provisioning helpers — log-only no-ops
+
+Nine helper methods MUST emit a single `LoggerInterface::info` line
+documenting the call and otherwise do nothing:
+
+| Method | Log message | Context |
+|---|---|---|
+| `sendWelcomeEmail($organization)` | `'Sending welcome email to organization'` | `['organization' => $organization]` |
+| `sendVngNotification($organization)` | `'Sending VNG notification about new organization'` | `['organization' => $organization]` |
+| `createSecurityGroup($organization)` | `'Creating security group for organization'` | `['organization' => $organization]` |
+| `createOrEnableUser($contact)` | `'Creating or enabling user for contact'` | `['contact' => $contact]` |
+| `updateUser($contact)` | `'Updating user for contact'` | `['contact' => $contact]` |
+| `disableUser($contact)` | `'Disabling user for contact'` | `['contact' => $contact]` |
+| `sendContactWelcomeEmail($contact)` | `'Sending welcome email to contact'` | `['contact' => $contact]` |
+| `sendContactUpdateEmail($contact)` | `'Sending update email to contact'` | `['contact' => $contact]` |
+| `sendContactDeletionEmail($contact)` | `'Sending deletion email to contact'` | `['contact' => $contact]` |
+
+Each method MUST be `private` and return `void`. The body is `// TODO:
+Implement <X> logic.` plus the log call. No external side effects —
+no email is sent, no NC group is created, no NC user is created /
+updated / disabled, no VNG endpoint is called.
+
+#### Scenario: sendWelcomeEmail emits a log line and returns
+
+- **WHEN** `sendWelcomeEmail($org)` is called
+- **THEN** `LoggerInterface::info('Sending welcome email to organization', ['organization' => $org])` is emitted
+- **AND** no SMTP / IMailer / IUserManager / IGroupManager interaction occurs
+- **AND** the method returns `void`
+
+#### Scenario: orchestrator handleNewContact calls 2 stubs in order
+
+- **GIVEN** `$contact` is an ObjectEntity
+- **WHEN** `handleNewContact($contact)` is called
+- **THEN** `createOrEnableUser($contact)` is called
+- **AND** then `sendContactWelcomeEmail($contact)` is called
+- **AND** the two info log lines are emitted in that order
+- **AND** no actual user is created, no actual email is sent
+
+#### Notes
+
+- **HIGH (silent no-op provisioning) — `hydra-gate-stub-scan`:**
+  these 9 methods are TODOs. The orchestrators (REQ-004) call them
+  in a clear path that looks production-grade — the EventListener
+  catches errors, the orchestrators dispatch by schema id, the
+  helpers log every call. To an operator looking at logs the
+  pipeline LOOKS green. In reality every organisation / contact
+  lifecycle event is a no-op. Multiple memory notes apply:
+  - The fleet "mail being phased out for n8n" note suggests this is
+    deliberate during the transition. If so the methods should be
+    removed and the orchestrators should call n8n webhooks directly
+    — silently logging without telling operators "this is a stub"
+    is the worst-of-all-worlds shape.
+- The retrofit pins the stub shape as the observed contract so any
+  future implementation lands as a behavioural change with explicit
+  REQ + scenario updates. Filling in the stubs without a REQ
+  update would silently change the observable contract.

--- a/openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-software-catalogus-events/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: software-catalogus-events#REQ-001 — ReactPHP promise-based ArchiMate model graph extension (retroactive annotation)
+- [x] task-2: software-catalogus-events#REQ-002 — Node and connection extension with identifier-suffix normalisation (retroactive annotation)
+- [x] task-3: software-catalogus-events#REQ-003 — Element and relation lookup helpers (retroactive annotation)
+- [x] task-4: software-catalogus-events#REQ-004 — OR lifecycle event dispatch to provisioning orchestrators (retroactive annotation)
+- [x] task-5: software-catalogus-events#REQ-005 — Stub provisioning helpers — log-only no-ops (retroactive annotation, observed-but-unimplemented)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 23 methods under `software-catalogus-events` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-software-catalogus-events` (drafted in `openspec/changes/`).

### What this PR does
- Drafts 5 REQs as a new capability spec (`retrofit: true`)
- Annotates 23 methods with `@spec` tags
- Folds methods aggressively to stay at cap: REQ-002 pairs node+connection extension, REQ-004 folds 7 dispatch/orchestrator methods, REQ-005 folds 9 stub helpers under one log-only no-op REQ

### Major findings flagged (not fixed)
- **HIGH stub-scan finding (`hydra-gate-stub-scan`)** — 9 of 23 methods are `// TODO: Implement <X> logic.` bodies whose only behaviour is a `LoggerInterface::info(...)` call. The pipeline LOOKS green at every layer (EventListener catches errors, orchestrators dispatch by schema id, helpers log every call) but NO email is sent, NO NC group is created, NO user is provisioned. Operators reading info-level logs would see "Sending welcome email to organization" and think the system is working.
- **HIGH observable bug** — `extendModel`'s inner `array_map` callback (line 130) never `return`s the `$this->extendView(...)` call; `$promises` is a list of `null`s; `all($promises)` resolves immediately. The actual extendView promises run as fire-and-forget side effects. extendModel's then() fires before any view is actually extended.
- **MEDIUM silent failure** — both `extendModel` and `extendView` register `$deferred->promise()->catch(fn ($error) {})` at the boundary, swallowing any upstream rejection.
- **MEDIUM gap** — `EventListener` has no organisation update / delete handler. Renaming or removing organisations in SC triggers no NC-side reaction (becomes a worse drift surface once the stubs are filled).
- **MEDIUM last-write-wins** — `extendView::saveObject(..., uuid: $id)` has no conflict-detection; parallel extension runs on the same view race.
- **LOW input trust + soft-DoS theoretical** — `extendNode` recurses without depth limit and assumes `identifier` is a string.

### Review focus
- REQ-005 is a single REQ deliberately — 9 near-identical log-only no-op stubs would otherwise inflate to 9 REQs. The retrofit pins the stub shape so any future implementation lands as a behavioural change with explicit REQ + scenario updates.
- REQ-001 Notes flag the `extendModel` aggregation bug — this is an observable contract drift (the method's name promises "wait for all views" but it doesn't). Document, don't fix.

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `software-catalogus-events`

Refs ConductionNL/openconnector#936