### PR TITLE
retrofit: reverse-spec mapping-and-search (5 REQs / 24 methods)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Retrofit annotation commit (opsx-annotate, 2026-05-24)
 78b6624686d0c027295843e24b5c8e1a2ed3458b
+884adc749c8b76de06dd5d520f099164d979f917

--- a/lib/Controller/MappingsController.php
+++ b/lib/Controller/MappingsController.php
@@ -104,6 +104,8 @@ class MappingsController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-4
+     *
      * @example
      * Request:
      * {
@@ -246,6 +248,8 @@ class MappingsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-4
      */
     public function saveObject(): ?JSONResponse
     {
@@ -285,6 +289,8 @@ class MappingsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-4
      */
     public function getObjects(): JSONResponse
     {

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -122,6 +122,8 @@ class MappingService
      * @param string $replacement The encoded character.
      *
      * @return array The array with encoded array keys
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-1
      */
     public function encodeArrayKeys(array $array, string $toReplace, string $replacement): array
     {
@@ -152,6 +154,8 @@ class MappingService
      * @throws LoaderError|SyntaxError Twig exceptions.
      *
      * @psalm-param array<string, mixed> $context
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-1
      */
     public function renderTemplateString(string $template, array $context=[]): string
     {
@@ -171,6 +175,8 @@ class MappingService
      *
      * @return array The result (output) of the mapping process
      * @throws LoaderError|SyntaxError Twig Exceptions
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-1
      */
     public function executeMapping(\OCA\OpenRegister\Db\Mapping|ObjectEntity $mapping, array $input, bool $list=false): array
     {
@@ -206,6 +212,8 @@ class MappingService
      * @throws Exception When mapping fails
      *
      * @SuppressWarnings(PHPMD.ElseExpression)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-1
      */
     private function executeMappingLocal(\OCA\OpenRegister\Db\Mapping $mapping, array $input, bool $list=false): array
     {
@@ -335,6 +343,8 @@ class MappingService
      * @param string $cast     The type of cast we want to do.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-2
      */
     private function handleCast(Dot $dotArray, string $key, string $cast)
     {
@@ -512,6 +522,8 @@ class MappingService
      * @param array $array Array to check.
      *
      * @return bool True if array keys are null else false.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-2
      */
     private function areAllArrayKeysNull(array $array): bool
     {
@@ -543,6 +555,8 @@ class MappingService
      * @param string $coordinates A string containing coordinates.
      *
      * @return array An array of coordinates.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-2
      */
     public function coordinateStringToArray(string $coordinates): array
     {
@@ -579,6 +593,8 @@ class MappingService
      * @param string $mappingId The unique identifier of the mapping to retrieve.
      *
      * @return ObjectEntity The requested mapping entity.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-3
      */
     public function getMapping(string $mappingId): ObjectEntity
     {
@@ -595,6 +611,8 @@ class MappingService
      * This maintains proper encapsulation and separation of concerns.
      *
      * @return array<ObjectEntity> An array containing all mapping entities
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-3
      */
     public function getMappings(): array
     {

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -72,6 +72,8 @@ class SearchService
      * @param array $newAggregation      New aggregation entries to merge.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function mergeFacets(array $existingAggregation, array $newAggregation): array
     {
@@ -109,6 +111,8 @@ class SearchService
      * @param array|null $newAggregations      New aggregations to merge.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     private function mergeAggregations(?array $existingAggregations, ?array $newAggregations): array
     {
@@ -136,6 +140,8 @@ class SearchService
      * @param array $b Right side.
      *
      * @return integer
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function sortResultArray(array $a, array $b): int
     {
@@ -152,6 +158,8 @@ class SearchService
      * @param array $catalogi      Optional catalog filter array.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function search(array $parameters, array $elasticConfig, array $dbConfig, array $catalogi=[]): array
     {
@@ -277,6 +285,8 @@ class SearchService
      * @param string $value   The full $value of the query param, like this: ?$name=$value.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     private function recursiveRequestQueryKey(array &$vars, string $name, string $nameKey, string $value): void
     {
@@ -313,6 +323,8 @@ class SearchService
      * @param array $fieldsToSearch Database field names to filter/search on.
      *
      * @return array $filters
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function createMongoDBSearchFilter(array $filters, array $fieldsToSearch): array
     {
@@ -348,6 +360,8 @@ class SearchService
      * @param array $fieldsToSearch Fields to search on in sql.
      *
      * @return array $searchConditions
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function createMySQLSearchConditions(array $filters, array $fieldsToSearch): array
     {
@@ -368,6 +382,8 @@ class SearchService
      * @param array $filters Query parameters from request.
      *
      * @return array $filters
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function unsetSpecialQueryParams(array $filters): array
     {
@@ -387,6 +403,8 @@ class SearchService
      * @param array $filters Query parameters from request.
      *
      * @return array $searchParams
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function createMySQLSearchParams(array $filters): array
     {
@@ -405,6 +423,8 @@ class SearchService
      * @param array $filters Query parameters from request.
      *
      * @return array $sort
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function createSortForMySQL(array $filters): array
     {
@@ -433,6 +453,8 @@ class SearchService
      * @return array $sort
      *
      * @todo Not functional yet. Needs to be fixed (see PublicationsController->index).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function createSortForMongoDB(array $filters): array
     {
@@ -457,6 +479,8 @@ class SearchService
      * @param string $queryString The input query string from the request.
      *
      * @return array The resulting array of query parameters.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-5
      */
     public function parseQueryString(string $queryString=''): array
     {

--- a/openspec/changes/archive/retrofit-2026-05-25-mapping-and-search/design.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-mapping-and-search/design.md
@@ -1,0 +1,41 @@
+# Design — Retrofit mapping-and-search
+
+> **Retrofit change.** Tasks describe retroactive annotation, not new implementation work.
+> The code described here already exists and ships in production. No behavior changes.
+
+## Context
+
+`mapping-and-search` groups two adjacent concerns that share the payload-transformation
+domain:
+
+1. **Mapping** — `MappingService` (dot-array + Twig engine, now delegating to OpenRegister
+   per ADR-022) and `MappingsController` (UI test/save/list endpoints).
+2. **Search** — `SearchService`, a federated catalog search helper plus pure
+   filter/sort/facet compilation utilities.
+
+## Decisions
+
+- **One capability, five REQs.** The 24 units cluster cleanly into five observable
+  behaviors: mapping execution (REQ-001), value casting (REQ-002), the OR object shim
+  (REQ-003), the controller surface (REQ-004), and query/facet compilation (REQ-005).
+  Casting is split from execution because the cast vocabulary is large and independently
+  testable.
+- **Document, do not fix.** `SearchService::search()` references constructor-undefined
+  properties (`elasticService`, `directoryService`, `objectService`). The REQ records the
+  *intended* shape and the Notes section flags the runtime fatal. The pure helpers around
+  it are sound.
+- **Delegation noted, not re-specified.** `MappingService` is `@deprecated`; the canonical
+  engine lives in OpenRegister. REQ-001 specifies the local fallback as observed.
+
+## Annotation plan
+
+Each method gets `@spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-N`
+mapped per the REQ → task table:
+
+| REQ | task | methods |
+|---|---|---|
+| REQ-001 | task-1 | executeMapping, executeMappingLocal, renderTemplateString, encodeArrayKeys |
+| REQ-002 | task-2 | handleCast, areAllArrayKeysNull, coordinateStringToArray |
+| REQ-003 | task-3 | getMapping, getMappings |
+| REQ-004 | task-4 | MappingsController::test, saveObject, getObjects |
+| REQ-005 | task-5 | search, mergeFacets, mergeAggregations, sortResultArray, createMongoDBSearchFilter, createMySQLSearchConditions, unsetSpecialQueryParams, createMySQLSearchParams, createSortForMySQL, createSortForMongoDB, parseQueryString, recursiveRequestQueryKey |

--- a/openspec/changes/archive/retrofit-2026-05-25-mapping-and-search/proposal.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-mapping-and-search/proposal.md
@@ -1,0 +1,45 @@
+---
+kind: spec
+---
+
+# Retrofit — mapping-and-search
+
+Describes observed behavior of 24 methods under `mapping-and-search` as 5 new REQs. Code
+already exists — this change retroactively specifies it. New capability `mapping-and-search`.
+
+## Affected code units
+
+- lib/Service/MappingService.php::executeMapping()
+- lib/Service/MappingService.php::executeMappingLocal()
+- lib/Service/MappingService.php::renderTemplateString()
+- lib/Service/MappingService.php::encodeArrayKeys()
+- lib/Service/MappingService.php::handleCast()
+- lib/Service/MappingService.php::areAllArrayKeysNull()
+- lib/Service/MappingService.php::coordinateStringToArray()
+- lib/Service/MappingService.php::getMapping()
+- lib/Service/MappingService.php::getMappings()
+- lib/Controller/MappingsController.php::test()
+- lib/Controller/MappingsController.php::saveObject()
+- lib/Controller/MappingsController.php::getObjects()
+- lib/Service/SearchService.php::search()
+- lib/Service/SearchService.php::mergeFacets()
+- lib/Service/SearchService.php::mergeAggregations()
+- lib/Service/SearchService.php::sortResultArray()
+- lib/Service/SearchService.php::createMongoDBSearchFilter()
+- lib/Service/SearchService.php::createMySQLSearchConditions()
+- lib/Service/SearchService.php::unsetSpecialQueryParams()
+- lib/Service/SearchService.php::createMySQLSearchParams()
+- lib/Service/SearchService.php::createSortForMySQL()
+- lib/Service/SearchService.php::createSortForMongoDB()
+- lib/Service/SearchService.php::parseQueryString()
+- lib/Service/SearchService.php::recursiveRequestQueryKey()
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces observed-but-suspicious behavior: `SearchService::search()` calls
+  undefined properties (will fatal at runtime); mapping endpoints are `@NoAdminRequired`;
+  the `date` cast is a PHP `date()` passthrough
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/archive/retrofit-2026-05-25-mapping-and-search/specs/mapping-and-search/spec.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-mapping-and-search/specs/mapping-and-search/spec.md
@@ -1,0 +1,216 @@
+---
+retrofit: true
+status: implemented
+---
+
+# Mapping and Search Specification
+
+## Purpose
+
+OpenConnector transforms inbound/outbound payloads through configurable mappings and
+exposes a federated catalog search helper. The mapping engine has largely moved to
+OpenRegister (ADR-022) — `MappingService` now delegates to OpenRegister's
+`MappingService` when present and only falls back to its own dot-array + Twig engine
+when OpenRegister is unavailable. The search helper compiles request filters into
+MongoDB / MySQL query fragments and fans out to peer directory instances. This spec
+captures the observed behavior of the 24 mapping/search code units retroactively; the
+code already exists.
+
+## ADDED Requirements
+
+### REQ-001: Apply a mapping recipe to an input payload
+
+The system MUST transform an input array into an output array according to a mapping
+recipe. `executeMapping()` is the public entry point: it normalises an `ObjectEntity`
+into an OpenRegister `Mapping`, and — when OpenRegister's `MappingService` was resolved
+at construction — delegates the transformation to it; otherwise it runs the local
+`executeMappingLocal()` engine. The local engine builds a dot-notation array
+(optionally seeded with the input when `passThrough` is true), resolves each mapping
+key either by copying an existing dot-path value or by rendering the value as a Twig
+template (`renderTemplateString()`), applies `unset` directives, applies `cast`
+directives via `handleCast()`, and supports list mode (per-element mapping with extra
+`listInput`/`value` injection) and root-level output via the `#` key. Array keys
+containing `.` are encoded to `&#46;` during processing (`encodeArrayKeys()`) and
+decoded back afterward.
+
+#### Scenario: Twig-rendered field mapping
+
+- GIVEN a mapping recipe `{ "fullName": "{{ name }}" }` and input `{ "name": "John" }`
+- WHEN `executeMapping()` runs with OpenRegister unavailable
+- THEN the output is `{ "fullName": "John" }`
+
+#### Scenario: Direct dot-path copy takes precedence over Twig
+
+- GIVEN a recipe value that exactly matches an existing input dot-path
+- WHEN the local engine processes that key
+- THEN the input value is copied verbatim and the value is NOT rendered as a Twig template
+
+#### Scenario: List mode maps each element
+
+- GIVEN `list` is true and the input is an array of items
+- WHEN `executeMapping()` runs
+- THEN each item is mapped individually and returned as a list preserving keys
+
+#### Scenario: Twig render failure surfaces a contextual error
+
+- GIVEN a mapping value that throws during Twig rendering
+- WHEN the local engine renders it
+- THEN an `Exception` is thrown naming the mapping, the key, and the failing value
+
+### REQ-002: Cast a mapped value to a declared type
+
+The system MUST coerce a mapped value according to its `cast` directive. `handleCast()`
+supports scalar casts (`string`, `int`/`integer`, `float`, `bool`/`boolean` and their
+nullable `?bool` variants, `array`), encoding casts (`url`, `rawurl`, their decode
+variants, `html`/`htmlDecode`, `base64`/`base64Decode`, `json`/`jsonToArray`, `utf8`
+transliteration), domain casts (`date`, `coordinateStringToArray`, `moneyStringToInt`,
+`intToMoneyString`), and conditional casts (`nullStringToNull`, `keyCantBeValue`,
+`unsetIfValue==X`, `setNullIfValue==X`, `countValue:path`). A key deleted by a cast
+(e.g. `unsetIfValue`, `keyCantBeValue`) MUST NOT be re-set. `coordinateStringToArray()`
+parses a space-separated coordinate string into a point array. `areAllArrayKeysNull()`
+is the recursive predicate used by the `unsetIfValue`/`setNullIfValue` empty-array
+checks.
+
+#### Scenario: Boolean cast normalises truthy strings
+
+- GIVEN a value of `"yes"`, `"true"`, or `1` with a `bool` cast
+- WHEN `handleCast()` runs
+- THEN the value becomes boolean `true`; any other value becomes `false`
+
+#### Scenario: unsetIfValue removes a matching key
+
+- GIVEN a `unsetIfValue==X` cast and the mapped value equals `X`
+- WHEN `handleCast()` runs
+- THEN the key is deleted from the output and not re-set
+
+#### Scenario: Unknown cast leaves the value unchanged
+
+- GIVEN a `cast` directive that matches no known case
+- WHEN `handleCast()` runs
+- THEN the value passes through unmodified (default branch)
+
+### REQ-003: Resolve mappings through the OpenRegister object shim
+
+The system MUST expose mapping entities only through the service layer, never via direct
+storage access. `getMapping()` resolves a single mapping by id from the `openconnector`
+register / `mapping` schema via OpenRegister's `ObjectService::find()`. `getMappings()`
+lists every mapping via `ObjectService::findAll()` and unwraps the `results` envelope
+when present.
+
+#### Scenario: Resolve a single mapping by id
+
+- GIVEN a mapping id that exists in the `openconnector` register
+- WHEN `getMapping()` is called
+- THEN the corresponding `ObjectEntity` is returned
+
+#### Scenario: List mappings unwraps the results envelope
+
+- GIVEN OpenRegister returns `{ "results": [ ... ] }`
+- WHEN `getMappings()` is called
+- THEN the inner `results` array is returned
+
+### REQ-004: Test, persist, and list mappings via the controller
+
+The system MUST provide `@NoAdminRequired @NoCSRFRequired` endpoints for the mapping UI.
+`test()` requires `inputObject` and `mapping` in the request (throwing
+`InvalidArgumentException` otherwise), hydrates an `ObjectEntity` from the supplied
+mapping payload, runs `executeMapping()`, and — when a `schema` id and `validation` flag
+are supplied and OpenRegister is installed — validates the result against the schema,
+returning `{ resultObject, isValid, validationErrors }`. Mapping execution errors return
+HTTP 400; a missing schema returns 404; a missing OpenRegister returns 412. `saveObject()`
+persists the supplied `object` to the `openconnector` register / `mapping` schema
+(register and schema overridable), returning 412 when OpenRegister is absent and 400 when
+`object` is missing. `getObjects()` reports OpenRegister availability and lists available
+registers via `RegisterMapper::findAll()`.
+
+#### Scenario: Test endpoint rejects missing required fields
+
+- GIVEN a request without `inputObject` or without `mapping`
+- WHEN `test()` runs
+- THEN an `InvalidArgumentException` is thrown
+
+#### Scenario: Test endpoint validates against a schema when requested
+
+- GIVEN a valid `inputObject`, `mapping`, a resolvable `schema` id, and `validation` true
+- WHEN `test()` runs with OpenRegister installed
+- THEN the response includes the mapped `resultObject`, `isValid`, and any `validationErrors`
+
+#### Scenario: Persist requires OpenRegister and an object field
+
+- GIVEN OpenRegister is not installed, OR the `object` field is missing
+- WHEN `saveObject()` runs
+- THEN it returns HTTP 412 (no OpenRegister) or HTTP 400 (missing object) respectively
+
+### REQ-005: Compile request filters into search queries and merge facets
+
+The system MUST translate request query parameters into backend-specific query fragments
+and merge results from multiple sources. `parseQueryString()` (with
+`recursiveRequestQueryKey()`) parses a raw query string into a nested filter array,
+honouring bracketed keys (`a[b][]`). `createMongoDBSearchFilter()` builds a `$or` regex
+clause from `_search` across the supplied fields and rewrites `IS NULL`/`IS NOT NULL`
+sentinels into `$eq`/`$ne`. `createMySQLSearchConditions()`/`createMySQLSearchParams()`
+build `LOWER(field) LIKE :search` conditions and the bound parameter.
+`createSortForMySQL()`/`createSortForMongoDB()` translate the `_order` directive into
+`ASC`/`DESC` or `1`/`-1`. `unsetSpecialQueryParams()` strips every `_`-prefixed key.
+`search()` fans out to peer directory search endpoints, merges hits, re-sorts by
+descending `_score` (`sortResultArray()`), and merges facet aggregations
+(`mergeAggregations()` / `mergeFacets()`, summing counts by `_id`), returning a paginated
+envelope.
+
+#### Scenario: Free-text search compiles to a regex OR clause
+
+- GIVEN filters containing `_search` and a list of searchable fields
+- WHEN `createMongoDBSearchFilter()` runs
+- THEN a `$or` array of `{ field: { $regex, $options: 'i' } }` is produced and `_search` is removed
+
+#### Scenario: Special query params are stripped from filters
+
+- GIVEN filters containing `_limit`, `_page`, and a domain field
+- WHEN `unsetSpecialQueryParams()` runs
+- THEN every `_`-prefixed key is removed and the domain field remains
+
+#### Scenario: Facet counts are summed across sources
+
+- GIVEN two aggregation sets sharing a facet `_id`
+- WHEN `mergeFacets()` runs
+- THEN the merged entry's `count` is the sum of both sources' counts
+
+## Non-Functional Requirements
+
+- **Internationalization:** Controller error messages MUST be translatable via `IL10N` (ADR-007); Dutch and English are supported.
+
+## Acceptance Criteria
+
+- [x] Mapping delegation to OpenRegister with local fallback is exercised
+- [x] All documented cast directives behave as observed
+- [x] Mapping controller endpoints return the documented status codes
+- [x] Filter compilation and facet merging behave as observed
+
+## Notes
+
+- **Delegation/deprecation:** `MappingService` is marked `@deprecated` — the engine has
+  moved to OpenRegister (ADR-022). The local engine is a fallback only. New work should
+  target the OpenRegister mapping engine, not extend this fallback.
+- **Observed-but-suspicious — `SearchService::search()` references undefined properties.**
+  `search()` calls `$this->elasticService`, `$this->directoryService`, and
+  `$this->objectService`, none of which are injected by the constructor (only
+  `IURLGenerator` is). The class carries `@SuppressWarnings(PHPMD.UndefinedVariable)`.
+  As written, `search()` will fatal at runtime the moment `elasticConfig['location']` is
+  non-empty or the directory branch is reached. This REQ documents the *intended* behavior
+  observed from the code shape; the method appears to be dead/broken plumbing carried over
+  from a federated-catalog feature. Flagged for follow-up — do not treat REQ-005's
+  `search()` scenarios as a guarantee of a working runtime path until the missing
+  dependencies are wired. The pure helper methods (filter/sort/facet compilation) are
+  sound and independently testable.
+- **Security — mapping endpoints accept arbitrary user payloads.** `test()` and
+  `saveObject()` are `@NoAdminRequired`; any authenticated user can execute an arbitrary
+  Twig mapping against arbitrary input (`test()`) or persist a mapping object
+  (`saveObject()`). Twig rendering of user-supplied templates is sandboxed by the mapping
+  Twig environment's extension set, but the surface is worth a dedicated review: confirm
+  no `MappingExtension`/`AuthenticationExtension` function exposes SSRF, file read, or
+  credential access to an unprivileged caller. Not an IDOR (no arbitrary stored-object id
+  is dereferenced), but the authorization posture (any authed user) should be confirmed
+  against ADR-023 action-level authorization.
+- **`date` cast is a passthrough of PHP `date()`** — `case 'date': $value = date($value)`
+  treats the mapped *value* as a PHP date format string, not a date to reformat. Observed
+  behavior; likely surprising to mapping authors. Documented as-is.

--- a/openspec/changes/archive/retrofit-2026-05-25-mapping-and-search/tasks.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-mapping-and-search/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: mapping-and-search#REQ-001 — Apply a mapping recipe to an input payload (retroactive annotation)
+- [x] task-2: mapping-and-search#REQ-002 — Cast a mapped value to a declared type (retroactive annotation)
+- [x] task-3: mapping-and-search#REQ-003 — Resolve mappings through the OpenRegister object shim (retroactive annotation)
+- [x] task-4: mapping-and-search#REQ-004 — Test, persist, and list mappings via the controller (retroactive annotation)
+- [x] task-5: mapping-and-search#REQ-005 — Compile request filters into search queries and merge facets (retroactive annotation)

--- a/openspec/specs/mapping-and-search/spec.md
+++ b/openspec/specs/mapping-and-search/spec.md
@@ -1,0 +1,216 @@
+---
+retrofit: true
+status: implemented
+---
+
+# Mapping and Search Specification
+
+## Purpose
+
+OpenConnector transforms inbound/outbound payloads through configurable mappings and
+exposes a federated catalog search helper. The mapping engine has largely moved to
+OpenRegister (ADR-022) — `MappingService` now delegates to OpenRegister's
+`MappingService` when present and only falls back to its own dot-array + Twig engine
+when OpenRegister is unavailable. The search helper compiles request filters into
+MongoDB / MySQL query fragments and fans out to peer directory instances. This spec
+captures the observed behavior of the 24 mapping/search code units retroactively; the
+code already exists.
+
+## ADDED Requirements
+
+### REQ-001: Apply a mapping recipe to an input payload
+
+The system MUST transform an input array into an output array according to a mapping
+recipe. `executeMapping()` is the public entry point: it normalises an `ObjectEntity`
+into an OpenRegister `Mapping`, and — when OpenRegister's `MappingService` was resolved
+at construction — delegates the transformation to it; otherwise it runs the local
+`executeMappingLocal()` engine. The local engine builds a dot-notation array
+(optionally seeded with the input when `passThrough` is true), resolves each mapping
+key either by copying an existing dot-path value or by rendering the value as a Twig
+template (`renderTemplateString()`), applies `unset` directives, applies `cast`
+directives via `handleCast()`, and supports list mode (per-element mapping with extra
+`listInput`/`value` injection) and root-level output via the `#` key. Array keys
+containing `.` are encoded to `&#46;` during processing (`encodeArrayKeys()`) and
+decoded back afterward.
+
+#### Scenario: Twig-rendered field mapping
+
+- GIVEN a mapping recipe `{ "fullName": "{{ name }}" }` and input `{ "name": "John" }`
+- WHEN `executeMapping()` runs with OpenRegister unavailable
+- THEN the output is `{ "fullName": "John" }`
+
+#### Scenario: Direct dot-path copy takes precedence over Twig
+
+- GIVEN a recipe value that exactly matches an existing input dot-path
+- WHEN the local engine processes that key
+- THEN the input value is copied verbatim and the value is NOT rendered as a Twig template
+
+#### Scenario: List mode maps each element
+
+- GIVEN `list` is true and the input is an array of items
+- WHEN `executeMapping()` runs
+- THEN each item is mapped individually and returned as a list preserving keys
+
+#### Scenario: Twig render failure surfaces a contextual error
+
+- GIVEN a mapping value that throws during Twig rendering
+- WHEN the local engine renders it
+- THEN an `Exception` is thrown naming the mapping, the key, and the failing value
+
+### REQ-002: Cast a mapped value to a declared type
+
+The system MUST coerce a mapped value according to its `cast` directive. `handleCast()`
+supports scalar casts (`string`, `int`/`integer`, `float`, `bool`/`boolean` and their
+nullable `?bool` variants, `array`), encoding casts (`url`, `rawurl`, their decode
+variants, `html`/`htmlDecode`, `base64`/`base64Decode`, `json`/`jsonToArray`, `utf8`
+transliteration), domain casts (`date`, `coordinateStringToArray`, `moneyStringToInt`,
+`intToMoneyString`), and conditional casts (`nullStringToNull`, `keyCantBeValue`,
+`unsetIfValue==X`, `setNullIfValue==X`, `countValue:path`). A key deleted by a cast
+(e.g. `unsetIfValue`, `keyCantBeValue`) MUST NOT be re-set. `coordinateStringToArray()`
+parses a space-separated coordinate string into a point array. `areAllArrayKeysNull()`
+is the recursive predicate used by the `unsetIfValue`/`setNullIfValue` empty-array
+checks.
+
+#### Scenario: Boolean cast normalises truthy strings
+
+- GIVEN a value of `"yes"`, `"true"`, or `1` with a `bool` cast
+- WHEN `handleCast()` runs
+- THEN the value becomes boolean `true`; any other value becomes `false`
+
+#### Scenario: unsetIfValue removes a matching key
+
+- GIVEN a `unsetIfValue==X` cast and the mapped value equals `X`
+- WHEN `handleCast()` runs
+- THEN the key is deleted from the output and not re-set
+
+#### Scenario: Unknown cast leaves the value unchanged
+
+- GIVEN a `cast` directive that matches no known case
+- WHEN `handleCast()` runs
+- THEN the value passes through unmodified (default branch)
+
+### REQ-003: Resolve mappings through the OpenRegister object shim
+
+The system MUST expose mapping entities only through the service layer, never via direct
+storage access. `getMapping()` resolves a single mapping by id from the `openconnector`
+register / `mapping` schema via OpenRegister's `ObjectService::find()`. `getMappings()`
+lists every mapping via `ObjectService::findAll()` and unwraps the `results` envelope
+when present.
+
+#### Scenario: Resolve a single mapping by id
+
+- GIVEN a mapping id that exists in the `openconnector` register
+- WHEN `getMapping()` is called
+- THEN the corresponding `ObjectEntity` is returned
+
+#### Scenario: List mappings unwraps the results envelope
+
+- GIVEN OpenRegister returns `{ "results": [ ... ] }`
+- WHEN `getMappings()` is called
+- THEN the inner `results` array is returned
+
+### REQ-004: Test, persist, and list mappings via the controller
+
+The system MUST provide `@NoAdminRequired @NoCSRFRequired` endpoints for the mapping UI.
+`test()` requires `inputObject` and `mapping` in the request (throwing
+`InvalidArgumentException` otherwise), hydrates an `ObjectEntity` from the supplied
+mapping payload, runs `executeMapping()`, and — when a `schema` id and `validation` flag
+are supplied and OpenRegister is installed — validates the result against the schema,
+returning `{ resultObject, isValid, validationErrors }`. Mapping execution errors return
+HTTP 400; a missing schema returns 404; a missing OpenRegister returns 412. `saveObject()`
+persists the supplied `object` to the `openconnector` register / `mapping` schema
+(register and schema overridable), returning 412 when OpenRegister is absent and 400 when
+`object` is missing. `getObjects()` reports OpenRegister availability and lists available
+registers via `RegisterMapper::findAll()`.
+
+#### Scenario: Test endpoint rejects missing required fields
+
+- GIVEN a request without `inputObject` or without `mapping`
+- WHEN `test()` runs
+- THEN an `InvalidArgumentException` is thrown
+
+#### Scenario: Test endpoint validates against a schema when requested
+
+- GIVEN a valid `inputObject`, `mapping`, a resolvable `schema` id, and `validation` true
+- WHEN `test()` runs with OpenRegister installed
+- THEN the response includes the mapped `resultObject`, `isValid`, and any `validationErrors`
+
+#### Scenario: Persist requires OpenRegister and an object field
+
+- GIVEN OpenRegister is not installed, OR the `object` field is missing
+- WHEN `saveObject()` runs
+- THEN it returns HTTP 412 (no OpenRegister) or HTTP 400 (missing object) respectively
+
+### REQ-005: Compile request filters into search queries and merge facets
+
+The system MUST translate request query parameters into backend-specific query fragments
+and merge results from multiple sources. `parseQueryString()` (with
+`recursiveRequestQueryKey()`) parses a raw query string into a nested filter array,
+honouring bracketed keys (`a[b][]`). `createMongoDBSearchFilter()` builds a `$or` regex
+clause from `_search` across the supplied fields and rewrites `IS NULL`/`IS NOT NULL`
+sentinels into `$eq`/`$ne`. `createMySQLSearchConditions()`/`createMySQLSearchParams()`
+build `LOWER(field) LIKE :search` conditions and the bound parameter.
+`createSortForMySQL()`/`createSortForMongoDB()` translate the `_order` directive into
+`ASC`/`DESC` or `1`/`-1`. `unsetSpecialQueryParams()` strips every `_`-prefixed key.
+`search()` fans out to peer directory search endpoints, merges hits, re-sorts by
+descending `_score` (`sortResultArray()`), and merges facet aggregations
+(`mergeAggregations()` / `mergeFacets()`, summing counts by `_id`), returning a paginated
+envelope.
+
+#### Scenario: Free-text search compiles to a regex OR clause
+
+- GIVEN filters containing `_search` and a list of searchable fields
+- WHEN `createMongoDBSearchFilter()` runs
+- THEN a `$or` array of `{ field: { $regex, $options: 'i' } }` is produced and `_search` is removed
+
+#### Scenario: Special query params are stripped from filters
+
+- GIVEN filters containing `_limit`, `_page`, and a domain field
+- WHEN `unsetSpecialQueryParams()` runs
+- THEN every `_`-prefixed key is removed and the domain field remains
+
+#### Scenario: Facet counts are summed across sources
+
+- GIVEN two aggregation sets sharing a facet `_id`
+- WHEN `mergeFacets()` runs
+- THEN the merged entry's `count` is the sum of both sources' counts
+
+## Non-Functional Requirements
+
+- **Internationalization:** Controller error messages MUST be translatable via `IL10N` (ADR-007); Dutch and English are supported.
+
+## Acceptance Criteria
+
+- [x] Mapping delegation to OpenRegister with local fallback is exercised
+- [x] All documented cast directives behave as observed
+- [x] Mapping controller endpoints return the documented status codes
+- [x] Filter compilation and facet merging behave as observed
+
+## Notes
+
+- **Delegation/deprecation:** `MappingService` is marked `@deprecated` — the engine has
+  moved to OpenRegister (ADR-022). The local engine is a fallback only. New work should
+  target the OpenRegister mapping engine, not extend this fallback.
+- **Observed-but-suspicious — `SearchService::search()` references undefined properties.**
+  `search()` calls `$this->elasticService`, `$this->directoryService`, and
+  `$this->objectService`, none of which are injected by the constructor (only
+  `IURLGenerator` is). The class carries `@SuppressWarnings(PHPMD.UndefinedVariable)`.
+  As written, `search()` will fatal at runtime the moment `elasticConfig['location']` is
+  non-empty or the directory branch is reached. This REQ documents the *intended* behavior
+  observed from the code shape; the method appears to be dead/broken plumbing carried over
+  from a federated-catalog feature. Flagged for follow-up — do not treat REQ-005's
+  `search()` scenarios as a guarantee of a working runtime path until the missing
+  dependencies are wired. The pure helper methods (filter/sort/facet compilation) are
+  sound and independently testable.
+- **Security — mapping endpoints accept arbitrary user payloads.** `test()` and
+  `saveObject()` are `@NoAdminRequired`; any authenticated user can execute an arbitrary
+  Twig mapping against arbitrary input (`test()`) or persist a mapping object
+  (`saveObject()`). Twig rendering of user-supplied templates is sandboxed by the mapping
+  Twig environment's extension set, but the surface is worth a dedicated review: confirm
+  no `MappingExtension`/`AuthenticationExtension` function exposes SSRF, file read, or
+  credential access to an unprivileged caller. Not an IDOR (no arbitrary stored-object id
+  is dereferenced), but the authorization posture (any authed user) should be confirmed
+  against ADR-023 action-level authorization.
+- **`date` cast is a passthrough of PHP `date()`** — `case 'date': $value = date($value)`
+  treats the mapped *value* as a PHP date format string, not a date to reformat. Observed
+  behavior; likely surprising to mapping authors. Documented as-is.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 24 methods under `mapping-and-search` as 5 new REQs.

Ghost change: `retrofit-2026-05-25-mapping-and-search` (archived). Refs #936.

### What this PR does
- Drafts 5 REQs as a new capability spec (`openspec/specs/mapping-and-search/spec.md`, `retrofit: true`)
- Creates tasks.md with one task per REQ
- Annotates 24 methods with `@spec openspec/changes/retrofit-2026-05-25-mapping-and-search/tasks.md#task-N` across `MappingService`, `MappingsController`, `SearchService`
- Archives the change (merges spec delta into main specs)

### What this PR does NOT do
- No code behavior changes — docblock `@spec` annotations only
- Does not silently fix observed-but-buggy behavior — Notes flag it

### Security / correctness findings flagged in spec notes
- 🔴 **`SearchService::search()` references constructor-undefined properties** (`elasticService`, `directoryService`, `objectService`) — the federated path fatals at runtime; class carries `@SuppressWarnings(PHPMD.UndefinedVariable)`. REQ-005 documents intended shape; the pure filter/sort/facet helpers are sound.
- 🟡 **Mapping endpoints are `@NoAdminRequired`** — any authenticated user can execute an arbitrary Twig mapping (`test()`) or persist a mapping object (`saveObject()`). Not an IDOR (no arbitrary stored id dereferenced) but the authorization posture should be confirmed against ADR-023.
- 🟡 **`date` cast is a PHP `date()` passthrough** — treats the mapped value as a format string.

### Review focus
- REQ language matches observed behavior (not aspirational)
- Scenarios are testable
- One REQ per distinct observable behavior

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `mapping-and-search`