### PR TITLE
retrofit: reverse-spec rule-pipeline (5 REQs / 31 methods)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Retrofit annotation commit (opsx-annotate, 2026-05-24)
 78b6624686d0c027295843e24b5c8e1a2ed3458b
+
+# Retrofit annotation commit (reverse-spec rule-pipeline, 2026-05-25)
+d27c6ef22f885f835143f95296ef94a424ab1aba

--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -1193,6 +1193,8 @@ class EndpointService
      * @param array        $data The current rule data envelope (body/headers/parameters).
      *
      * @return array The updated $data with the saved object merged into the body.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-2
      */
     private function processSaveObjectRule(ObjectEntity $rule, array $data): array
     {
@@ -1222,6 +1224,8 @@ class EndpointService
      * @param FlowToken|null $flowToken Optional flow token threaded through the rule chain.
      *
      * @return array|JSONResponse Returns modified data or error response if rule fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-1
      */
     private function processRules(
         ObjectEntity $endpoint,
@@ -1357,6 +1361,8 @@ class EndpointService
      * @throws MultipleObjectsReturnedException
      * @throws NotFoundExceptionInterface
      * @throws \OCP\DB\Exception
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-2
      */
     private function processOverrideRule(ObjectEntity $rule, array $data, string $objectId): array
     {
@@ -1401,6 +1407,8 @@ class EndpointService
      * @param array        $data The data of the request
      *
      * @return array|JSONResponse the unchanged $data array if authentication succeeds, or a JSONResponse containing an error on authentication.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-3
      */
     private function processAuthenticationRule(ObjectEntity $rule, array $data): array|JSONResponse
     {
@@ -1489,6 +1497,8 @@ class EndpointService
      * @param array        $data Optional rule data containing JSON-logic result for inclusion.
      *
      * @return JSONResponse Response containing error details and HTTP status code.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-3
      */
     private function processErrorRule(ObjectEntity $rule, array $data=[]): JSONResponse
     {
@@ -1518,6 +1528,8 @@ class EndpointService
      * @param array        $data    The current rule data envelope (body/headers/parameters).
      *
      * @return array The updated $data with mapped body merged in.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-2
      */
     private function processMapping(ObjectEntity $rule, ObjectEntity $mapping, array $data): array
     {
@@ -1551,6 +1563,8 @@ class EndpointService
      * @throws MultipleObjectsReturnedException When multiple mapping objects are returned unexpectedly
      * @throws LoaderError When there is an error loading the mapping
      * @throws SyntaxError When there is a syntax error in the mapping configuration
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-2
      */
     private function processMappingRule(ObjectEntity $rule, array $data): array
     {
@@ -1571,6 +1585,8 @@ class EndpointService
      * @return array The data array with the extended parameters in the 'extendedParameters' key.
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-2
      */
     private function processExtendInputRule(ObjectEntity $rule, array $data): array
     {
@@ -1630,6 +1646,8 @@ class EndpointService
      *
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-2
      */
     private function processAuditTrailRule(ObjectEntity $rule, ObjectEntity $endpoint, array $data, string $objectId): array|Response
     {
@@ -1669,6 +1687,8 @@ class EndpointService
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      * @throws \OCP\Files\NotFoundException
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-2
      */
     private function processLockingRule(ObjectEntity $rule, array $data, string $objectId): array
     {
@@ -1700,6 +1720,8 @@ class EndpointService
      * @param array        $data The data to process
      *
      * @return array The updated data array.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function processCustomRule(ObjectEntity $rule, array $data): array|JSONResponse
     {
@@ -1718,6 +1740,8 @@ class EndpointService
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      * @throws Exception
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-4
      */
     private function processWriteFileRule(ObjectEntity $rule, array $data, string $objectId): array
     {
@@ -1813,6 +1837,8 @@ class EndpointService
      * @param FlowToken    $flowToken The current flow token threaded through the synchronization.
      *
      * @return array The data after synchronization processing.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-4
      */
     private function processSyncRule(ObjectEntity $rule, array $data, FlowToken $flowToken): array
     {
@@ -1979,6 +2005,8 @@ class EndpointService
      * @throws \OCA\OpenRegister\Exception\ValidationException
      * @throws \OCP\Files\InvalidPathException
      * @throws \OCP\Files\NotFoundException
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-4
      */
     private function processFilePartRule(ObjectEntity $rule, array $data, ObjectEntity $endpoint, ?string $objectId=null): array|JSONResponse
     {
@@ -2094,6 +2122,8 @@ class EndpointService
      * @throws SyntaxError
      * @throws \OCP\Files\InvalidPathException
      * @throws \OCP\Files\NotFoundException
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-4
      */
     private function processFilePartUploadRule(ObjectEntity $rule, array $data, IRequest $request, ?string $objectId=null): array
     {
@@ -2142,6 +2172,8 @@ class EndpointService
      * @param array        $data The input data to be processed by the JavaScript rule
      *
      * @return array The processed data after executing the JavaScript rule
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-4
      */
     private function processJavaScriptRule(ObjectEntity $rule, array $data): array
     {
@@ -2164,6 +2196,8 @@ class EndpointService
      * @throws DoesNotExistException
      * @throws NotFoundExceptionInterface
      * @throws \OCP\Files\NotFoundException
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-4
      */
     private function processDownloadRule(ObjectEntity $rule, array $data, string $objectId): Response
     {
@@ -2238,6 +2272,8 @@ class EndpointService
      * @return bool True if conditions are met, false otherwise.
      *
      * @throws Exception
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-1
      */
     private function checkRuleConditions(ObjectEntity $rule, array $data, mixed &$logicResult): bool
     {
@@ -2256,6 +2292,8 @@ class EndpointService
      * @param array     $ruleData  The processed rule data to update the request with.
      *
      * @return FlowToken The updated flow token with the amended request.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-1
      */
     private function updateRequestWithRuleData(FlowToken $flowToken, array $ruleData): FlowToken
     {

--- a/lib/Service/RuleService.php
+++ b/lib/Service/RuleService.php
@@ -18,6 +18,8 @@
  * @version GIT: <git_id>
  *
  * @link https://www.OpenConnector.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
  */
 
 namespace OCA\OpenConnector\Service;
@@ -195,6 +197,8 @@ class RuleService
      * @param array        $data The data to process.
      *
      * @return array|JSONResponse The updated data array (or a JSONResponse if the rule short-circuits).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     public function processCustomRule(ObjectEntity $rule, array $data): array|JSONResponse
     {
@@ -218,6 +222,8 @@ class RuleService
      * @param array        $data The data to process
      *
      * @return array The updated data array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function processSoftwareCatalogusRule(ObjectEntity $rule, array $data): array
     {
@@ -382,6 +388,8 @@ class RuleService
      * @param array $propertyDefinitions The list of propertyDefinitions.
      *
      * @return string The id of the 'Publiceren' property.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function getPublishPropertyId(array $propertyDefinitions): string
     {
@@ -407,6 +415,8 @@ class RuleService
      * @param array $data The data structure to update
      *
      * @return array The updated data
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function processPropertyDefinitionsAndMetadata(array $data): array
     {
@@ -474,6 +484,8 @@ class RuleService
      * @param array $data The data structure to update
      *
      * @return array An array with [$applicationFolderKey, $relationsFolderKey, $applicationFolderCount, $relationsFolderCount]
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function setupOrganizationalFolders(array &$data): array
     {
@@ -540,6 +552,8 @@ class RuleService
      * @param array  $views                  The set of catalogue views to extend with new connections (passed by reference).
      *
      * @return array The updated data.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function processVoorzieningenData(
         array $data,
@@ -665,6 +679,8 @@ class RuleService
      * @param string $targetId   The target element id.
      *
      * @return array The connection array shape consumed by the catalogue exporter.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function createConnection(string $relationId, string $sourceId, string $targetId)
     {
@@ -707,6 +723,8 @@ class RuleService
      * @param array       $connections        Connections accumulator (passed by reference).
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function processNodes(
         array &$nodes,
@@ -849,6 +867,8 @@ class RuleService
      * @param string $relationType The type of relation.
      *
      * @return string The relation ID.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function createRelation(
         array &$data,
@@ -899,6 +919,8 @@ class RuleService
      * @param array        $data The rule data envelope.
      *
      * @return array|JSONResponse A JSON-response with the outcome, or the data on no-op paths.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function processCustomConnectionsRule(ObjectEntity $rule, array $data): array|JSONResponse
     {
@@ -931,6 +953,8 @@ class RuleService
      * @throws \Psr\Container\NotFoundExceptionInterface
      * @throws \Twig\Error\LoaderError
      * @throws \Twig\Error\SyntaxError
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     private function getExternalObject(string $url, array $configuration, string|int $schemaId): array
     {
@@ -989,6 +1013,8 @@ class RuleService
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md#task-5
      */
     public function extendExternalUrl(ObjectEntity $rule, array $data): array|JSONResponse
     {

--- a/openspec/changes/retrofit-2026-05-25-rule-pipeline/design.md
+++ b/openspec/changes/retrofit-2026-05-25-rule-pipeline/design.md
@@ -1,0 +1,41 @@
+# Design — retrofit-2026-05-25-rule-pipeline
+
+> **Retrofit change.** Tasks describe retroactive annotation of existing code,
+> not new implementation work. No code behaviour changes — only `@spec`
+> annotations are added to the affected methods, and the spec delta is merged
+> into `openspec/specs/rule-pipeline/spec.md` on archive.
+
+## Context
+
+The `rule-pipeline` cluster (Bucket 2b, 31 methods, no capability owner) is the
+endpoint rule engine. It spans `EndpointService.php` (rule-evaluation methods)
+and `RuleService.php` (custom software-catalogus + external-extension rules).
+ADR-002 establishes that this engine is openconnector-local with no OpenRegister
+equivalent — it will not be generalised into OR — so it warrants its own
+capability spec rather than an OR abstraction reference.
+
+The cluster shares `EndpointService.php` with the `endpoint-runtime` cluster.
+Rule-evaluation methods are annotated here; endpoint dispatch / caching methods
+are annotated by the sibling `endpoint-runtime` retrofit.
+
+## Decisions
+
+- **`--cluster`, not `--extend`.** No existing capability owns this behaviour
+  (the only main spec is `prometheus-metrics`). A new `rule-pipeline` capability
+  is the correct home.
+- **5 REQs fold 31 methods.** Grouped by observable behaviour: pipeline driver
+  (001), data-mutation rules (002), auth/error rules (003), file/sync/download
+  rules (004), custom catalogue rules (005). One REQ per coherent behaviour
+  cluster rather than one per method.
+- **Observed, not aspirational.** Stubs (`processJavaScriptRule`), silent
+  failures (`processWriteFileRule` swallowed write errors), and demo-shaped
+  constants (software-catalogus UUID pools) are documented in Notes, not fixed.
+
+## Risks / follow-ups
+
+These are surfaced in the spec Notes for human triage — they are NOT addressed
+by this annotation-only change:
+- Silent per-file write failure in `processWriteFileRule`.
+- Authentication rule does not record the authenticated principal.
+- `extendExternalUrl` write side-effect (auto-creating Source rows).
+- Hard-coded test data in the software-catalogus rule.

--- a/openspec/changes/retrofit-2026-05-25-rule-pipeline/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-rule-pipeline/proposal.md
@@ -1,0 +1,44 @@
+# Retrofit — rule-pipeline
+
+Describes the observed behaviour of 31 methods under the `rule-pipeline`
+cluster as 5 new REQs. Code already exists — this change retroactively
+specifies it. Source: `openspec/coverage-report.md` generated 2026-05-24,
+Bucket 2b cluster `rule-pipeline` (no capability owner).
+
+## Motivation
+
+The endpoint rule engine is core platform behaviour with no spec coverage. Per
+ADR-002 it is an openconnector-local concept (no OpenRegister equivalent), so it
+needs a foundational capability spec under `openspec/specs/`. This is the first
+of two shared-`EndpointService` clusters; the endpoint dispatch / caching half
+is covered separately by the `endpoint-runtime` cluster.
+
+## Affected code units
+
+`lib/Service/EndpointService.php` (rule-evaluation methods):
+- `processRules()`, `checkRuleConditions()`, `updateRequestWithRuleData()` — REQ-RULE-001
+- `processSaveObjectRule()`, `processMapping()`, `processMappingRule()`, `processExtendInputRule()`, `processOverrideRule()`, `processLockingRule()` — REQ-RULE-002
+- `processAuthenticationRule()`, `processErrorRule()` — REQ-RULE-003
+- `processWriteFileRule()`, `processSyncRule()`, `processFilePartRule()`, `processFilePartUploadRule()`, `processJavaScriptRule()`, `processDownloadRule()` — REQ-RULE-004
+- `processCustomRule()` — REQ-RULE-005
+
+`lib/Service/RuleService.php` (custom-rule + external-extension methods):
+- `processCustomRule()`, `processSoftwareCatalogusRule()`, `getPublishPropertyId()`, `processPropertyDefinitionsAndMetadata()`, `setupOrganizationalFolders()`, `processVoorzieningenData()`, `createConnection()`, `processNodes()`, `createRelation()`, `processCustomConnectionsRule()`, `getExternalObject()`, `extendExternalUrl()` — REQ-RULE-005
+
+(`getRuleById()` is a generic rule lookup used by the dispatch path and is
+annotated under the sibling `endpoint-runtime` cluster, per the coverage
+report's cluster assignment.)
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes.
+- Draft REQs that match behaviour (not aspirational).
+- Notes sections surface observed-but-suspicious behaviour:
+  - `processWriteFileRule` swallows per-file write exceptions silently (REQ-RULE-004).
+  - `processJavaScriptRule` is a dispatchable no-op stub (REQ-RULE-004).
+  - Authentication rule does not propagate the authenticated principal downstream (REQ-RULE-003).
+  - `extendExternalUrl` auto-creates enabled Source rows as a side-effect of a read rule (REQ-RULE-005).
+  - Software-catalogus rule carries hard-coded UUID pools / property ids / a test model name (REQ-RULE-005).
+  - `getRuleById` silently drops unresolvable rule ids (REQ-RULE-001).
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-rule-pipeline/specs/rule-pipeline/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-rule-pipeline/specs/rule-pipeline/spec.md
@@ -1,0 +1,219 @@
+---
+retrofit: true
+---
+
+# Endpoint Rule Pipeline
+
+## Purpose
+
+OpenConnector endpoints can carry an ordered list of rules that run before and
+after the request reaches its target (a register/schema or an external source).
+Rules implement endpoint-level business logic — authentication enforcement,
+data mapping, object persistence, file handling, synchronisation triggers,
+audit-trail reads, locking, custom transforms, and configured error responses.
+This capability describes the **observed behaviour** of the rule-processing
+engine (`EndpointService` rule methods + `RuleService` custom rules) as it
+exists today. It is a retrofit spec: the code already exists, and these REQs
+document it rather than prescribe new work. Per ADR-002 the rule engine is an
+openconnector-local concept with no OpenRegister equivalent.
+
+## Requirements
+
+### REQ-RULE-001: Ordered Rule Pipeline Execution
+
+The system MUST resolve an endpoint's configured rules into rule entities,
+sort them by their numeric `order` field (ascending, default 0), and process
+each rule in turn for the requested timing phase. For each rule the system MUST
+first evaluate the rule's JSON-Logic `conditions` and its `timing` ("before"
+or "after"); a rule whose conditions do not pass OR whose timing does not match
+the current phase MUST be skipped (logged at info level) without mutating the
+data envelope. When a rule's processing returns a `JSONResponse` or
+`DataDownloadResponse`, pipeline execution MUST short-circuit and that response
+MUST be returned immediately. Any exception thrown while applying a rule MUST be
+caught and surfaced as an HTTP 500 `JSONResponse` whose body carries the
+endpoint name, rule name, rule type, and error message.
+
+**Scenarios:**
+
+1. **GIVEN** an endpoint with three rules of `order` 30, 10, 20 **WHEN** the
+   pipeline runs **THEN** the rules execute in the sequence 10, 20, 30.
+
+2. **GIVEN** a rule whose JSON-Logic `conditions` evaluate to false **WHEN** the
+   pipeline reaches it **THEN** the rule is skipped, an info log records the
+   skip, and the data envelope is unchanged.
+
+3. **GIVEN** a rule with `timing` "after" **WHEN** the pipeline runs the "before"
+   phase **THEN** that rule is skipped during the before phase.
+
+4. **GIVEN** a rule whose processing throws an exception **WHEN** the pipeline
+   applies it **THEN** the response is HTTP 500 with a body containing the
+   endpoint name, rule name, rule type, and the exception message, and no
+   further rules run.
+
+5. **GIVEN** a rule that returns a `JSONResponse` (e.g. an error or override
+   rule) **WHEN** the pipeline applies it **THEN** that response is returned
+   immediately and subsequent rules are not processed.
+
+**Notes:**
+- `getRuleById()` resolves rules via OpenRegister `find(register: 'openconnector', schema: 'rule')` and returns `null` on lookup failure (logged), so an unresolvable rule id is silently dropped from the chain rather than failing the request. Documented as observed behaviour; flagged for future tightening.
+- Rule entities are re-fetched and re-sorted on every request; there is no caching of the resolved rule chain.
+
+### REQ-RULE-002: Data-Mutation Rules
+
+The system MUST provide rules that mutate the request/response data envelope
+against an OpenRegister object or schema. `save_object` MUST persist
+`data['body']` to a configured register/schema (optionally pre-mapping it) via
+OpenRegister `ObjectService::saveObject`. `mapping` MUST transform the body
+through a configured mapping object — iterating per-result when the body is a
+GET result set with `mapResults` enabled, otherwise mapping the whole body.
+`extend_input` MUST resolve UUID-valued request parameters to full OpenRegister
+objects and attach them under `extendedParameters` / `body._extendedInput`.
+`override` (timing "after" only) MUST re-persist a previously written object
+with the flow-token body. `locking` MUST lock or unlock the target object via
+OpenRegister `lockObject` / `unlockObject`.
+
+**Scenarios:**
+
+1. **GIVEN** a `save_object` rule with a configured register, schema, and
+   optional mapping **WHEN** the rule runs **THEN** the body is (optionally
+   mapped and) persisted via OpenRegister and the saved object replaces
+   `data['body']`.
+
+2. **GIVEN** a `mapping` rule and a GET body containing a `results` array with
+   `mapResults` not disabled **WHEN** the rule runs **THEN** the mapping is
+   applied to each result element individually.
+
+3. **GIVEN** an `extend_input` rule whose configured parameter holds a valid
+   UUID **WHEN** the rule runs **THEN** the referenced OpenRegister object is
+   fetched and merged into `extendedParameters`; a non-UUID or
+   not-found value is skipped without error.
+
+4. **GIVEN** a `locking` rule with action "lock" and a target object id **WHEN**
+   the rule runs **THEN** the object is locked for the configured duration
+   (default 3600s) and the locked object replaces the body; an unknown locking
+   action leaves the data untouched.
+
+**Notes:**
+- `processExtendInputRule` and `RuleService::extendExternalUrl` both write `body._extendedInput`; the pipeline `unset()`s `body._extendedInput` after the rule loop completes.
+
+### REQ-RULE-003: Authentication and Error Rules
+
+The system MUST provide an `authentication` rule that enforces per-endpoint
+credential checks and an `error` rule that returns a configured error response.
+The authentication rule MUST read the credential from the `Authorization`
+header (or a configured header name, case/underscore-insensitive), return HTTP
+403 when the header is absent, and dispatch to the configured authentication
+type — `apikey`, `jwt`/`jwt-zgw`, `basic`, or `oauth` — returning HTTP 401 on a
+caught `AuthenticationException` and HTTP 501 for an unsupported type; on
+success it returns the data unchanged. The error rule MUST return a
+`JSONResponse` built from the configured `name`, `message`, and `code`,
+optionally including the JSON-Logic result as an `errors` array.
+
+**Scenarios:**
+
+1. **GIVEN** an `authentication` rule and a request with no Authorization header
+   **WHEN** the rule runs **THEN** the response is HTTP 403 with a "forbidden"
+   error and the pipeline short-circuits.
+
+2. **GIVEN** an `authentication` rule of type `apikey` and an invalid key
+   **WHEN** the rule runs **THEN** the response is HTTP 401 carrying the
+   exception message and details.
+
+3. **GIVEN** an `authentication` rule with an unsupported type **WHEN** the rule
+   runs **THEN** the response is HTTP 501 Not Implemented.
+
+4. **GIVEN** an `error` rule with `includeJsonLogicResult` true **WHEN** the rule
+   runs after a condition that produced a logic result **THEN** the response
+   body includes that result under `errors` and uses the configured status code.
+
+**Notes:**
+- The authentication rule returns the data envelope **unchanged** on success rather than recording the authenticated principal; downstream rules and the target dispatch run with no record of which credential passed. Documented as observed; flagged as a follow-up for principal propagation.
+
+### REQ-RULE-004: File, Synchronisation, and Download Rules
+
+The system MUST provide rules that handle file persistence, mid-request
+synchronisation, and file downloads. `write_file` MUST base64-decode payload(s)
+at a configured `filePath` and persist them via OpenRegister `FileService`
+against the target object. `fileparts_create` / `filepart_upload` MUST
+orchestrate TUS-style chunked uploads via the storage service. `synchronization`
+MUST trigger a configured synchronisation through `SynchronizationService`
+(honouring test/force flags, optional pre/post delays, and result-merge
+configuration). `download` MUST resolve a file for the target object and return
+it as a `DataDownloadResponse`.
+
+**Scenarios:**
+
+1. **GIVEN** a `write_file` rule and a body carrying base64 file content at the
+   configured path **WHEN** the rule runs **THEN** each file is decoded and
+   written via OpenRegister FileService and the path(s) replace the content in
+   the envelope.
+
+2. **GIVEN** a `synchronization` rule referencing a synchronisation by id or
+   reference **WHEN** the rule runs **THEN** `SynchronizationService::synchronize`
+   is invoked with the resolved test/force/mutationType flags and the body is
+   merged or overwritten per the rule's result configuration.
+
+3. **GIVEN** a `download` rule and a target object with a resolvable file **WHEN**
+   the rule runs **THEN** a `DataDownloadResponse` carrying the file content,
+   name, and mime type is returned and the pipeline short-circuits.
+
+4. **GIVEN** a `fileparts_create` rule applied before the object exists (null
+   objectId) **WHEN** the rule runs **THEN** an exception is thrown ("Filepart
+   rules can only be applied after the object has been created").
+
+**Notes:**
+- **Silent failure (flagged):** `processWriteFileRule` wraps each
+  `FileService::addFile` call in a `try/catch (Exception)` whose body is empty —
+  per-file write failures are swallowed with no log and no error surfaced to the
+  caller. The rule reports success even when some/all files failed to write.
+  Documented as observed behaviour; recommended for follow-up hardening.
+- **Stub (flagged):** `processJavaScriptRule` (rule type `javascript`) is a
+  no-op — it returns the data unchanged with a `@todo` for the unimplemented JS
+  engine. The rule type is dispatchable but inert.
+- `processSyncRule` honours `synchronization.preDelay` / `postDelay` via
+  blocking `sleep()` calls inside the request thread.
+
+### REQ-RULE-005: Custom Software-Catalogus Rules
+
+The system MUST provide a `custom` rule type that dispatches on a configured
+custom-rule `type`. `softwareCatalogus` MUST build a GEMMA/ArchiMate export
+model — validating and back-filling property definitions, resolving Voorziening
+and VoorzieningGebruik objects from OpenRegister, creating ArchiMate elements,
+relations, nodes, and connections, and assembling them into the export
+structure. `connectRelations` MUST extend the catalogue model for a UUID model
+id taken from the request path. An external-extension rule
+(`extend_external_input`) MUST fetch referenced external objects over HTTP
+(reusing or creating a Source row by location), optionally validate them against
+a schema, and merge them into `extendedParameters`. An unsupported custom-rule
+type MUST throw.
+
+**Scenarios:**
+
+1. **GIVEN** a `custom` rule of type `softwareCatalogus` and a register/schema
+   configuration **WHEN** the rule runs **THEN** the export body is populated
+   with property definitions, elements, relationships, views, and organisation
+   folders for the resolved Voorzieningen.
+
+2. **GIVEN** a `custom` rule of type `connectRelations` and a path ending in a
+   valid UUID **WHEN** the rule runs **THEN** the catalogue model is extended
+   for that id and an HTTP 200 "Connected views succesfully" response is
+   returned; a missing/invalid id returns HTTP 200 "model id was not provided".
+
+3. **GIVEN** an `extend_external_input` rule referencing an external URL **WHEN**
+   the rule runs **THEN** the object is fetched (creating a Source by location
+   if none exists), optionally validated, and merged into `extendedParameters`;
+   a validation failure returns HTTP 400 with field-level errors.
+
+4. **GIVEN** a `custom` rule of an unrecognised type **WHEN** the rule runs
+   **THEN** an exception "Unsupported custom rule type" is thrown (surfaced as
+   HTTP 500 by the pipeline).
+
+**Notes:**
+- The software-catalogus rule carries hard-coded constants — fixed node and
+  relation UUID pools (`NODE_IDS`, `RELATION_IDS`), property-definition ids, and
+  the model name "Turfburg (test VNG Realisatie)". `@TODO` comments mark these
+  for replacement with stored identifiers. Documented as observed; this is
+  test/demo-shaped data baked into production code.
+- `extendExternalUrl` auto-creates a `Source` register object for any unseen
+  external URL with `isEnabled: true`, then calls it via `CallService`. This is
+  an implicit write side-effect of a read-extension rule; flagged for review.

--- a/openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-rule-pipeline/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: retrofit-2026-05-25-rule-pipeline
+
+> Retrofit change. Each task records a retroactive annotation of already-existing code, not new implementation work. All boxes are checked because the behaviour ships today. ADR-032 cap respected (≤5).
+
+- [x] task-1: rule-pipeline#REQ-RULE-001 — Ordered rule pipeline execution (retroactive annotation)
+- [x] task-2: rule-pipeline#REQ-RULE-002 — Data-mutation rules (retroactive annotation)
+- [x] task-3: rule-pipeline#REQ-RULE-003 — Authentication and error rules (retroactive annotation)
+- [x] task-4: rule-pipeline#REQ-RULE-004 — File, synchronisation, and download rules (retroactive annotation)
+- [x] task-5: rule-pipeline#REQ-RULE-005 — Custom software-catalogus rules (retroactive annotation)

--- a/openspec/specs/rule-pipeline/spec.md
+++ b/openspec/specs/rule-pipeline/spec.md
@@ -1,0 +1,219 @@
+---
+retrofit: true
+---
+
+# Endpoint Rule Pipeline
+
+## Purpose
+
+OpenConnector endpoints can carry an ordered list of rules that run before and
+after the request reaches its target (a register/schema or an external source).
+Rules implement endpoint-level business logic — authentication enforcement,
+data mapping, object persistence, file handling, synchronisation triggers,
+audit-trail reads, locking, custom transforms, and configured error responses.
+This capability describes the **observed behaviour** of the rule-processing
+engine (`EndpointService` rule methods + `RuleService` custom rules) as it
+exists today. It is a retrofit spec: the code already exists, and these REQs
+document it rather than prescribe new work. Per ADR-002 the rule engine is an
+openconnector-local concept with no OpenRegister equivalent.
+
+## Requirements
+
+### REQ-RULE-001: Ordered Rule Pipeline Execution
+
+The system MUST resolve an endpoint's configured rules into rule entities,
+sort them by their numeric `order` field (ascending, default 0), and process
+each rule in turn for the requested timing phase. For each rule the system MUST
+first evaluate the rule's JSON-Logic `conditions` and its `timing` ("before"
+or "after"); a rule whose conditions do not pass OR whose timing does not match
+the current phase MUST be skipped (logged at info level) without mutating the
+data envelope. When a rule's processing returns a `JSONResponse` or
+`DataDownloadResponse`, pipeline execution MUST short-circuit and that response
+MUST be returned immediately. Any exception thrown while applying a rule MUST be
+caught and surfaced as an HTTP 500 `JSONResponse` whose body carries the
+endpoint name, rule name, rule type, and error message.
+
+**Scenarios:**
+
+1. **GIVEN** an endpoint with three rules of `order` 30, 10, 20 **WHEN** the
+   pipeline runs **THEN** the rules execute in the sequence 10, 20, 30.
+
+2. **GIVEN** a rule whose JSON-Logic `conditions` evaluate to false **WHEN** the
+   pipeline reaches it **THEN** the rule is skipped, an info log records the
+   skip, and the data envelope is unchanged.
+
+3. **GIVEN** a rule with `timing` "after" **WHEN** the pipeline runs the "before"
+   phase **THEN** that rule is skipped during the before phase.
+
+4. **GIVEN** a rule whose processing throws an exception **WHEN** the pipeline
+   applies it **THEN** the response is HTTP 500 with a body containing the
+   endpoint name, rule name, rule type, and the exception message, and no
+   further rules run.
+
+5. **GIVEN** a rule that returns a `JSONResponse` (e.g. an error or override
+   rule) **WHEN** the pipeline applies it **THEN** that response is returned
+   immediately and subsequent rules are not processed.
+
+**Notes:**
+- `getRuleById()` resolves rules via OpenRegister `find(register: 'openconnector', schema: 'rule')` and returns `null` on lookup failure (logged), so an unresolvable rule id is silently dropped from the chain rather than failing the request. Documented as observed behaviour; flagged for future tightening.
+- Rule entities are re-fetched and re-sorted on every request; there is no caching of the resolved rule chain.
+
+### REQ-RULE-002: Data-Mutation Rules
+
+The system MUST provide rules that mutate the request/response data envelope
+against an OpenRegister object or schema. `save_object` MUST persist
+`data['body']` to a configured register/schema (optionally pre-mapping it) via
+OpenRegister `ObjectService::saveObject`. `mapping` MUST transform the body
+through a configured mapping object — iterating per-result when the body is a
+GET result set with `mapResults` enabled, otherwise mapping the whole body.
+`extend_input` MUST resolve UUID-valued request parameters to full OpenRegister
+objects and attach them under `extendedParameters` / `body._extendedInput`.
+`override` (timing "after" only) MUST re-persist a previously written object
+with the flow-token body. `locking` MUST lock or unlock the target object via
+OpenRegister `lockObject` / `unlockObject`.
+
+**Scenarios:**
+
+1. **GIVEN** a `save_object` rule with a configured register, schema, and
+   optional mapping **WHEN** the rule runs **THEN** the body is (optionally
+   mapped and) persisted via OpenRegister and the saved object replaces
+   `data['body']`.
+
+2. **GIVEN** a `mapping` rule and a GET body containing a `results` array with
+   `mapResults` not disabled **WHEN** the rule runs **THEN** the mapping is
+   applied to each result element individually.
+
+3. **GIVEN** an `extend_input` rule whose configured parameter holds a valid
+   UUID **WHEN** the rule runs **THEN** the referenced OpenRegister object is
+   fetched and merged into `extendedParameters`; a non-UUID or
+   not-found value is skipped without error.
+
+4. **GIVEN** a `locking` rule with action "lock" and a target object id **WHEN**
+   the rule runs **THEN** the object is locked for the configured duration
+   (default 3600s) and the locked object replaces the body; an unknown locking
+   action leaves the data untouched.
+
+**Notes:**
+- `processExtendInputRule` and `RuleService::extendExternalUrl` both write `body._extendedInput`; the pipeline `unset()`s `body._extendedInput` after the rule loop completes.
+
+### REQ-RULE-003: Authentication and Error Rules
+
+The system MUST provide an `authentication` rule that enforces per-endpoint
+credential checks and an `error` rule that returns a configured error response.
+The authentication rule MUST read the credential from the `Authorization`
+header (or a configured header name, case/underscore-insensitive), return HTTP
+403 when the header is absent, and dispatch to the configured authentication
+type — `apikey`, `jwt`/`jwt-zgw`, `basic`, or `oauth` — returning HTTP 401 on a
+caught `AuthenticationException` and HTTP 501 for an unsupported type; on
+success it returns the data unchanged. The error rule MUST return a
+`JSONResponse` built from the configured `name`, `message`, and `code`,
+optionally including the JSON-Logic result as an `errors` array.
+
+**Scenarios:**
+
+1. **GIVEN** an `authentication` rule and a request with no Authorization header
+   **WHEN** the rule runs **THEN** the response is HTTP 403 with a "forbidden"
+   error and the pipeline short-circuits.
+
+2. **GIVEN** an `authentication` rule of type `apikey` and an invalid key
+   **WHEN** the rule runs **THEN** the response is HTTP 401 carrying the
+   exception message and details.
+
+3. **GIVEN** an `authentication` rule with an unsupported type **WHEN** the rule
+   runs **THEN** the response is HTTP 501 Not Implemented.
+
+4. **GIVEN** an `error` rule with `includeJsonLogicResult` true **WHEN** the rule
+   runs after a condition that produced a logic result **THEN** the response
+   body includes that result under `errors` and uses the configured status code.
+
+**Notes:**
+- The authentication rule returns the data envelope **unchanged** on success rather than recording the authenticated principal; downstream rules and the target dispatch run with no record of which credential passed. Documented as observed; flagged as a follow-up for principal propagation.
+
+### REQ-RULE-004: File, Synchronisation, and Download Rules
+
+The system MUST provide rules that handle file persistence, mid-request
+synchronisation, and file downloads. `write_file` MUST base64-decode payload(s)
+at a configured `filePath` and persist them via OpenRegister `FileService`
+against the target object. `fileparts_create` / `filepart_upload` MUST
+orchestrate TUS-style chunked uploads via the storage service. `synchronization`
+MUST trigger a configured synchronisation through `SynchronizationService`
+(honouring test/force flags, optional pre/post delays, and result-merge
+configuration). `download` MUST resolve a file for the target object and return
+it as a `DataDownloadResponse`.
+
+**Scenarios:**
+
+1. **GIVEN** a `write_file` rule and a body carrying base64 file content at the
+   configured path **WHEN** the rule runs **THEN** each file is decoded and
+   written via OpenRegister FileService and the path(s) replace the content in
+   the envelope.
+
+2. **GIVEN** a `synchronization` rule referencing a synchronisation by id or
+   reference **WHEN** the rule runs **THEN** `SynchronizationService::synchronize`
+   is invoked with the resolved test/force/mutationType flags and the body is
+   merged or overwritten per the rule's result configuration.
+
+3. **GIVEN** a `download` rule and a target object with a resolvable file **WHEN**
+   the rule runs **THEN** a `DataDownloadResponse` carrying the file content,
+   name, and mime type is returned and the pipeline short-circuits.
+
+4. **GIVEN** a `fileparts_create` rule applied before the object exists (null
+   objectId) **WHEN** the rule runs **THEN** an exception is thrown ("Filepart
+   rules can only be applied after the object has been created").
+
+**Notes:**
+- **Silent failure (flagged):** `processWriteFileRule` wraps each
+  `FileService::addFile` call in a `try/catch (Exception)` whose body is empty —
+  per-file write failures are swallowed with no log and no error surfaced to the
+  caller. The rule reports success even when some/all files failed to write.
+  Documented as observed behaviour; recommended for follow-up hardening.
+- **Stub (flagged):** `processJavaScriptRule` (rule type `javascript`) is a
+  no-op — it returns the data unchanged with a `@todo` for the unimplemented JS
+  engine. The rule type is dispatchable but inert.
+- `processSyncRule` honours `synchronization.preDelay` / `postDelay` via
+  blocking `sleep()` calls inside the request thread.
+
+### REQ-RULE-005: Custom Software-Catalogus Rules
+
+The system MUST provide a `custom` rule type that dispatches on a configured
+custom-rule `type`. `softwareCatalogus` MUST build a GEMMA/ArchiMate export
+model — validating and back-filling property definitions, resolving Voorziening
+and VoorzieningGebruik objects from OpenRegister, creating ArchiMate elements,
+relations, nodes, and connections, and assembling them into the export
+structure. `connectRelations` MUST extend the catalogue model for a UUID model
+id taken from the request path. An external-extension rule
+(`extend_external_input`) MUST fetch referenced external objects over HTTP
+(reusing or creating a Source row by location), optionally validate them against
+a schema, and merge them into `extendedParameters`. An unsupported custom-rule
+type MUST throw.
+
+**Scenarios:**
+
+1. **GIVEN** a `custom` rule of type `softwareCatalogus` and a register/schema
+   configuration **WHEN** the rule runs **THEN** the export body is populated
+   with property definitions, elements, relationships, views, and organisation
+   folders for the resolved Voorzieningen.
+
+2. **GIVEN** a `custom` rule of type `connectRelations` and a path ending in a
+   valid UUID **WHEN** the rule runs **THEN** the catalogue model is extended
+   for that id and an HTTP 200 "Connected views succesfully" response is
+   returned; a missing/invalid id returns HTTP 200 "model id was not provided".
+
+3. **GIVEN** an `extend_external_input` rule referencing an external URL **WHEN**
+   the rule runs **THEN** the object is fetched (creating a Source by location
+   if none exists), optionally validated, and merged into `extendedParameters`;
+   a validation failure returns HTTP 400 with field-level errors.
+
+4. **GIVEN** a `custom` rule of an unrecognised type **WHEN** the rule runs
+   **THEN** an exception "Unsupported custom rule type" is thrown (surfaced as
+   HTTP 500 by the pipeline).
+
+**Notes:**
+- The software-catalogus rule carries hard-coded constants — fixed node and
+  relation UUID pools (`NODE_IDS`, `RELATION_IDS`), property-definition ids, and
+  the model name "Turfburg (test VNG Realisatie)". `@TODO` comments mark these
+  for replacement with stored identifiers. Documented as observed; this is
+  test/demo-shaped data baked into production code.
+- `extendExternalUrl` auto-creates a `Source` register object for any unseen
+  external URL with `isEnabled: true`, then calls it via `CallService`. This is
+  an implicit write side-effect of a read-extension rule; flagged for review.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behaviour of 31 methods under the `rule-pipeline` cluster as 5 new REQs.

Ghost change: `retrofit-2026-05-25-rule-pipeline`. New capability spec landed at `openspec/specs/rule-pipeline/spec.md` (`retrofit: true`).

Refs #936 (coverage umbrella). PRODUCTION app — full review.

### What this PR does
- Drafts 5 REQs covering the endpoint rule engine: ordered pipeline execution (REQ-RULE-001), data-mutation rules (002), authentication/error rules (003), file/sync/download rules (004), custom software-catalogus rules (005)
- Creates `tasks.md` with one task per REQ (all `[x]` — code already exists)
- Annotates 31 methods across `lib/Service/EndpointService.php` (19 rule-evaluation methods) and `lib/Service/RuleService.php` (file header + 12 custom-rule/external-extension methods) with `@spec .../tasks.md#task-N`
- Records the annotation commit in `.git-blame-ignore-revs`

### What this PR does NOT do
- No code behaviour changes — docblock `@spec` annotations only
- Does not silently fix observed-but-suspicious behaviour — surfaced in spec Notes (see below)

### Security / silent-fail findings flagged in Notes (NOT fixed here)
- **Silent failure** — `processWriteFileRule` swallows per-file `FileService::addFile` exceptions in empty `catch` blocks (no log); rule reports success even when writes fail (REQ-RULE-004)
- **Stub** — `processJavaScriptRule` (rule type `javascript`) is a dispatchable no-op `@todo` (REQ-RULE-004)
- **Auth** — `processAuthenticationRule` returns data unchanged on success and does not propagate the authenticated principal downstream (REQ-RULE-003)
- **Write side-effect** — `RuleService::extendExternalUrl` auto-creates enabled `Source` register rows for any unseen external URL as a side-effect of a read-extension rule (REQ-RULE-005)
- **Demo data in prod** — software-catalogus rule carries hard-coded UUID pools, property ids, and the model name "Turfburg (test VNG Realisatie)" (REQ-RULE-005)
- **Dropped rule** — `getRuleById` silently returns null on lookup failure, dropping unresolvable rule ids from the chain (REQ-RULE-001; method itself annotated under sibling `endpoint-runtime` cluster)

### Review focus
- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- One REQ per distinct observable behaviour (5 REQs fold 31 methods per ADR-032 cap)

Specter: app_specs row for `rule-pipeline` will be flagged as retrofit cohort on the next `sync_spec_content.py` run after this merges to development (sync reads the canonical checkout).

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `rule-pipeline`