### PR TITLE
retrofit: reverse-spec user-management-and-login (5 REQs / 31 methods)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Retrofit annotation commit (opsx-annotate, 2026-05-24)
 78b6624686d0c027295843e24b5c8e1a2ed3458b
+
+# Retrofit annotation commit (reverse-spec user-management-and-login, 2026-05-25)
+263e579134d9d5c2c9f1b1c7a4b3392a3a59ea7b

--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -194,6 +194,8 @@ class UserController extends Controller
      * @PublicPage
      *
      * @return Response The CORS response with appropriate headers.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-4
      */
     #[NoCSRFRequired]
     #[PublicPage]
@@ -211,6 +213,8 @@ class UserController extends Controller
      * @PublicPage
      *
      * @return Response The CORS response with appropriate headers.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-4
      */
     #[NoCSRFRequired]
     #[PublicPage]
@@ -226,6 +230,8 @@ class UserController extends Controller
      * Used by both /api/user/me and /api/user/login OPTIONS preflights.
      *
      * @return Response
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-4
      */
     private function buildCorsPreflightResponse(): Response
     {
@@ -259,6 +265,8 @@ class UserController extends Controller
      * @param JSONResponse $response The response to add CORS headers to.
      *
      * @return JSONResponse The response with CORS headers added.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-4
      */
     private function addCorsHeaders(JSONResponse $response): JSONResponse
     {
@@ -295,6 +303,8 @@ class UserController extends Controller
      *
      * @psalm-return   JSONResponse
      * @phpstan-return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     public function me(): JSONResponse
     {
@@ -358,6 +368,8 @@ class UserController extends Controller
      *
      * @psalm-return   JSONResponse
      * @phpstan-return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     public function updateMe(): JSONResponse
     {
@@ -429,6 +441,8 @@ class UserController extends Controller
      *
      * @psalm-return   JSONResponse
      * @phpstan-return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-2
      */
     public function login(): JSONResponse
     {
@@ -617,6 +631,8 @@ class UserController extends Controller
      * @psalm-return   int
      * @phpstan-param  string $memoryLimit
      * @phpstan-return int
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-2
      */
     private function convertToBytes(string $memoryLimit): int
     {
@@ -652,6 +668,8 @@ class UserController extends Controller
      * @NoCSRFRequired
      * @PublicPage
      * @return          JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-3
      */
     public function logout(): JSONResponse
     {

--- a/lib/Service/SecurityService.php
+++ b/lib/Service/SecurityService.php
@@ -164,6 +164,8 @@ class SecurityService
      * @param string $ipAddress The IP address of the request.
      *
      * @return array Result with 'allowed' boolean and optional 'delay' or 'lockout_until'.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-2
      */
     public function checkLoginRateLimit(string $username, string $ipAddress): array
     {
@@ -262,6 +264,8 @@ class SecurityService
      * @param string $reason    The reason for login failure.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-2
      */
     public function recordFailedLoginAttempt(string $username, string $ipAddress, string $reason='invalid_credentials'): void
     {
@@ -336,6 +340,8 @@ class SecurityService
      * @param string $ipAddress The IP address of the successful attempt.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-2
      */
     public function recordSuccessfulLogin(string $username, string $ipAddress): void
     {
@@ -375,6 +381,8 @@ class SecurityService
      * @param int   $maxLength Maximum allowed length for strings.
      *
      * @return mixed Sanitized input.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-5
      */
     public function sanitizeInput(mixed $input, int $maxLength=255): mixed
     {
@@ -431,6 +439,8 @@ class SecurityService
      * @param array $credentials The login credentials to validate.
      *
      * @return array Validated and sanitized credentials or error information.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-2
      */
     public function validateLoginCredentials(array $credentials): array
     {
@@ -490,6 +500,8 @@ class SecurityService
      * @param JSONResponse $response The response to add headers to.
      *
      * @return JSONResponse The response with added security headers.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-5
      */
     public function addSecurityHeaders(JSONResponse $response): JSONResponse
     {
@@ -525,6 +537,8 @@ class SecurityService
      * @param IRequest $request The request object.
      *
      * @return string The client IP address.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-2
      */
     public function getClientIpAddress(IRequest $request): string
     {
@@ -569,6 +583,8 @@ class SecurityService
      * @param string $input The input string to sanitize.
      *
      * @return string Sanitized cache key.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-2
      */
     private function sanitizeForCacheKey(string $input): string
     {
@@ -588,6 +604,8 @@ class SecurityService
      * @param array  $context Additional context data.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-2
      */
     private function logSecurityEvent(string $event, array $context=[]): void
     {

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -86,6 +86,8 @@ class UserService
      *
      * @psalm-return   IUser|null
      * @phpstan-return IUser|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     public function getCurrentUser(): ?IUser
     {
@@ -107,6 +109,8 @@ class UserService
      * @psalm-return   array
      * @phpstan-param  IUser $user
      * @phpstan-return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     public function buildUserDataArray(IUser $user): array
     {
@@ -229,6 +233,8 @@ class UserService
      * @phpstan-param  IUser $user
      * @phpstan-param  array $data
      * @phpstan-return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     public function updateUserProperties(IUser $user, array $data): array
     {
@@ -272,6 +278,8 @@ class UserService
      * @psalm-return   array{firstName: string|null, lastName: string|null, middleName: string|null}
      * @phpstan-param  IUser $user
      * @phpstan-return array{firstName: string|null, lastName: string|null, middleName: string|null}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     public function getCustomNameFields(IUser $user): array
     {
@@ -317,6 +325,8 @@ class UserService
      * @phpstan-param  IUser $user
      * @phpstan-param  array $nameFields
      * @phpstan-return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     public function setCustomNameFields(IUser $user, array $nameFields): void
     {
@@ -348,6 +358,8 @@ class UserService
      * @psalm-return   array
      * @phpstan-param  IUser $user
      * @phpstan-return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     private function buildQuotaInformation(IUser $user): array
     {
@@ -432,6 +444,8 @@ class UserService
      * @psalm-return   int
      * @phpstan-param  string $userId
      * @phpstan-return int
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     private function getUsedSpaceMemorySafe(string $userId): int
     {
@@ -502,6 +516,8 @@ class UserService
      * @psalm-return   array{0: string, 1: string}
      * @phpstan-param  IUser $user
      * @phpstan-return array{0: string, 1: string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     private function getLanguageAndLocale(IUser $user): array
     {
@@ -545,6 +561,8 @@ class UserService
      * @psalm-return   array
      * @phpstan-param  IUser $user
      * @phpstan-return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     private function getAdditionalProfileInfo(IUser $user): array
     {
@@ -610,6 +628,8 @@ class UserService
      * @psalm-return   array
      * @phpstan-param  IUser $user
      * @phpstan-return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     private function getAccountManagerPropertiesSelectively(IUser $user): array
     {
@@ -673,6 +693,8 @@ class UserService
      * @phpstan-param  IUser $user
      * @phpstan-param  array $data
      * @phpstan-return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     private function updateStandardUserProperties(IUser $user, array $data): void
     {
@@ -728,6 +750,8 @@ class UserService
      * @phpstan-param  IUser $user
      * @phpstan-param  array $data
      * @phpstan-return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     private function updateProfileProperties(IUser $user, array $data): void
     {
@@ -822,6 +846,8 @@ class UserService
      * @psalm-return   string
      * @phpstan-param  string $propertyName
      * @phpstan-return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-1
      */
     private function getDefaultPropertyScope(string $propertyName): string
     {

--- a/openspec/changes/archive/retrofit-2026-05-25-user-management-and-login/design.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-user-management-and-login/design.md
@@ -1,0 +1,41 @@
+# Design — Retrofit user-management-and-login
+
+> **Retrofit change.** Tasks describe retroactive annotation, not new implementation work.
+> The code described here already exists and ships in production. No behavior changes.
+
+## Context
+
+`user-management-and-login` groups OpenConnector's self-contained REST auth surface and
+profile management, spanning three files:
+
+1. **`UserController`** — the HTTP surface (`me`, `updateMe`, `login`, `logout`) plus CORS
+   preflight/header helpers and the `convertToBytes` memory-limit parser.
+2. **`UserService`** — profile composition and capability-gated updates over `IUserManager`,
+   `IAccountManager`, and the `core` user-config namespace.
+3. **`SecurityService`** — login rate limiting, lockout, progressive backoff, input
+   sanitisation, IP resolution, security headers, and security-event logging.
+
+## Decisions
+
+- **One capability, five REQs.** The 31 units cluster into self-profile (REQ-001), login +
+  brute-force protection (REQ-002), logout (REQ-003), CORS (REQ-004), and sanitisation +
+  hardening (REQ-005). Login is split from generic security-helpers because its observable
+  contract (rate limit, lockout, anti-enumeration, memory guard) is the highest-value review
+  surface in this cluster.
+- **Document, do not fix.** Four observed issues are recorded in the spec Notes rather than
+  silently corrected: the reflected-`Origin` + `Allow-Credentials: true` CORS posture
+  (security), `me()`'s inline Basic-auth branch vs its route auth posture, the
+  `getUsedSpaceMemorySafe()` overwrite ordering, and the `succesful_login` switch-case typo.
+
+## Annotation plan
+
+Each method gets `@spec openspec/changes/retrofit-2026-05-25-user-management-and-login/tasks.md#task-N`
+mapped per the REQ → task table:
+
+| REQ | task | methods |
+|---|---|---|
+| REQ-001 | task-1 | me, updateMe, getCurrentUser, buildUserDataArray, updateUserProperties, getCustomNameFields, setCustomNameFields, buildQuotaInformation, getUsedSpaceMemorySafe, getLanguageAndLocale, getAdditionalProfileInfo, getAccountManagerPropertiesSelectively, updateStandardUserProperties, updateProfileProperties, getDefaultPropertyScope |
+| REQ-002 | task-2 | login, convertToBytes, checkLoginRateLimit, recordFailedLoginAttempt, recordSuccessfulLogin, validateLoginCredentials, getClientIpAddress, sanitizeForCacheKey, logSecurityEvent |
+| REQ-003 | task-3 | logout |
+| REQ-004 | task-4 | preflightedCorsMe, preflightedCorsLogin, buildCorsPreflightResponse, addCorsHeaders |
+| REQ-005 | task-5 | sanitizeInput, addSecurityHeaders |

--- a/openspec/changes/archive/retrofit-2026-05-25-user-management-and-login/proposal.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-user-management-and-login/proposal.md
@@ -1,0 +1,53 @@
+---
+kind: spec
+---
+
+# Retrofit — user-management-and-login
+
+Describes observed behavior of 31 methods under `user-management-and-login` as 5 new REQs.
+Code already exists — this change retroactively specifies it. New capability
+`user-management-and-login`.
+
+## Affected code units
+
+- lib/Controller/UserController.php::me()
+- lib/Controller/UserController.php::updateMe()
+- lib/Controller/UserController.php::login()
+- lib/Controller/UserController.php::logout()
+- lib/Controller/UserController.php::preflightedCorsMe()
+- lib/Controller/UserController.php::preflightedCorsLogin()
+- lib/Controller/UserController.php::buildCorsPreflightResponse()
+- lib/Controller/UserController.php::addCorsHeaders()
+- lib/Controller/UserController.php::convertToBytes()
+- lib/Service/UserService.php::getCurrentUser()
+- lib/Service/UserService.php::buildUserDataArray()
+- lib/Service/UserService.php::updateUserProperties()
+- lib/Service/UserService.php::getCustomNameFields()
+- lib/Service/UserService.php::setCustomNameFields()
+- lib/Service/UserService.php::buildQuotaInformation()
+- lib/Service/UserService.php::getUsedSpaceMemorySafe()
+- lib/Service/UserService.php::getLanguageAndLocale()
+- lib/Service/UserService.php::getAdditionalProfileInfo()
+- lib/Service/UserService.php::getAccountManagerPropertiesSelectively()
+- lib/Service/UserService.php::updateStandardUserProperties()
+- lib/Service/UserService.php::updateProfileProperties()
+- lib/Service/UserService.php::getDefaultPropertyScope()
+- lib/Service/SecurityService.php::checkLoginRateLimit()
+- lib/Service/SecurityService.php::recordFailedLoginAttempt()
+- lib/Service/SecurityService.php::recordSuccessfulLogin()
+- lib/Service/SecurityService.php::sanitizeInput()
+- lib/Service/SecurityService.php::validateLoginCredentials()
+- lib/Service/SecurityService.php::addSecurityHeaders()
+- lib/Service/SecurityService.php::getClientIpAddress()
+- lib/Service/SecurityService.php::sanitizeForCacheKey()
+- lib/Service/SecurityService.php::logSecurityEvent()
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces observed-but-suspicious behavior: reflected-Origin CORS with
+  `Allow-Credentials: true`; `me()` inline Basic auth vs route auth posture;
+  `getUsedSpaceMemorySafe()` overwrite ordering; `succesful_login` typo
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/archive/retrofit-2026-05-25-user-management-and-login/specs/user-management-and-login/spec.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-user-management-and-login/specs/user-management-and-login/spec.md
@@ -1,0 +1,195 @@
+---
+retrofit: true
+status: implemented
+---
+
+# User Management and Login Specification
+
+## Purpose
+
+OpenConnector exposes a self-contained REST authentication surface (`/api/user/login`,
+`/api/user/me`, `/api/user/logout`) for browser SPA and external API clients, layered on
+Nextcloud's `IUserManager` / `IUserSession`. Login is hardened with per-username + per-IP
+rate limiting, progressive backoff, account/IP lockout, anti-enumeration error messages,
+memory monitoring, and security event logging (`SecurityService`). The profile surface
+(`UserService`) composes a comprehensive user payload (groups, quota, language, custom
+name fields, AccountManager profile properties) and applies capability-gated updates. This
+spec captures the observed behavior of 31 code units retroactively; the code already exists.
+
+## ADDED Requirements
+
+### REQ-001: Read and update the authenticated user's own profile
+
+The system MUST expose `@NoAdminRequired @NoCSRFRequired` endpoints for a user to read and
+update their own profile. `me()` resolves the session user (`UserService::getCurrentUser()`),
+falling back to inline HTTP Basic auth (`Authorization: Basic`) when no session exists, and
+returns the composed profile (`buildUserDataArray()`) — or HTTP 401 when unauthenticated and
+500 on unexpected error. `updateMe()` requires a session user (401 otherwise), sanitises the
+request body (`SecurityService::sanitizeInput()`), strips `_`-prefixed system keys, and
+applies updates (`updateUserProperties()`). `buildUserDataArray()` composes uid, display
+name, email, quota (`buildQuotaInformation()` → `getUsedSpaceMemorySafe()`), language/locale
+(`getLanguageAndLocale()`), group memberships, backend capabilities (feature-detected via
+`method_exists`), additional profile info (`getAdditionalProfileInfo()` /
+`getAccountManagerPropertiesSelectively()`), custom name fields (`getCustomNameFields()` /
+`setCustomNameFields()` in the `core` namespace), and organisation stats.
+`updateUserProperties()` switches active organisation when requested, then applies standard
+NC properties (`updateStandardUserProperties()` — capability-gated display name/email/
+password/language/locale) and AccountManager profile properties (`updateProfileProperties()`
+with default scopes from `getDefaultPropertyScope()`).
+
+#### Scenario: Read own profile when authenticated
+
+- GIVEN a logged-in session user
+- WHEN `GET /api/user/me` is called
+- THEN HTTP 200 with the composed user payload (uid, groups, quota, language, profile fields)
+
+#### Scenario: Unauthenticated profile read is rejected
+
+- GIVEN no session user and no valid Basic auth header
+- WHEN `GET /api/user/me` is called
+- THEN HTTP 401 with a generic "not logged in" message and security headers
+
+#### Scenario: Update is capability-gated
+
+- GIVEN a logged-in user whose backend reports `canChangeDisplayName() === false`
+- WHEN `updateMe()` is called with a `displayName` field
+- THEN the display name is NOT changed (the capability gate blocks it)
+
+#### Scenario: System keys are stripped from updates
+
+- GIVEN an update payload containing `_internal` keys alongside profile fields
+- WHEN `updateMe()` runs
+- THEN every `_`-prefixed key is removed before properties are applied
+
+### REQ-002: Authenticate via the custom login endpoint with brute-force protection
+
+The system MUST provide a `@PublicPage` `POST /api/user/login` that authenticates a
+username/password against `IUserManager::checkPassword()` and establishes a Nextcloud
+session token. Before authenticating it: monitors memory (returns 503 when usage exceeds
+80% of `memory_limit`, parsed by `convertToBytes()`); resolves the client IP
+(`getClientIpAddress()`, preferring validated public forwarded-header IPs over the remote
+address); validates and sanitises credentials (`validateLoginCredentials()` — 400 on missing/
+short/invalid-character username or over-long password); and checks the rate limit
+(`checkLoginRateLimit()` — 429 with progressive delay / lockout window). On failure it
+records the attempt (`recordFailedLoginAttempt()`, which locks out the username and/or IP
+after `RATE_LIMIT_ATTEMPTS` within `RATE_LIMIT_WINDOW`) and returns a generic
+"Invalid username or password" to prevent username enumeration. On success it records the
+event (`recordSuccessfulLogin()`, clearing the username counter and progressive delay),
+sets the session user, creates a session token, verifies the session, and returns the
+sanitised user payload plus session cookie hints. All responses carry security headers.
+
+#### Scenario: Successful login establishes a session
+
+- GIVEN valid credentials for an enabled account within the rate limit
+- WHEN `POST /api/user/login` is called
+- THEN the user is set in the session, a session token is created, and HTTP 200 returns the user payload and session info
+
+#### Scenario: Failed login is rate-limited and anti-enumeration
+
+- GIVEN an invalid password
+- WHEN `POST /api/user/login` is called
+- THEN the failed attempt is recorded and HTTP 401 returns a generic "Invalid username or password" message (no indication whether the username exists)
+
+#### Scenario: Lockout after repeated failures
+
+- GIVEN `RATE_LIMIT_ATTEMPTS` failed attempts for a username within the window
+- WHEN a further login is attempted
+- THEN `checkLoginRateLimit()` returns `allowed: false` and the endpoint responds HTTP 429 with a lockout window
+
+#### Scenario: Memory guard short-circuits login
+
+- GIVEN initial memory usage already exceeds 80% of the configured `memory_limit`
+- WHEN `POST /api/user/login` is called
+- THEN HTTP 503 is returned before authentication is attempted
+
+### REQ-003: Terminate the active session on logout
+
+The system MUST provide a `@PublicPage` `logout()` endpoint that terminates the active user
+session via `IUserSession::logout()` and returns `{ "logout": true }`.
+
+#### Scenario: Logout clears the session
+
+- GIVEN an active session
+- WHEN `logout()` is called
+- THEN the session is terminated and HTTP 200 returns `{ "logout": true }`
+
+### REQ-004: Support credentialed cross-origin browser clients via CORS
+
+The system MUST answer CORS preflights for `/api/user/me` and `/api/user/login`
+(`preflightedCorsMe()` / `preflightedCorsLogin()` → `buildCorsPreflightResponse()`) and
+attach CORS headers to credentialed JSON responses (`addCorsHeaders()`). Both reflect the
+request `Origin` header into `Access-Control-Allow-Origin`, set
+`Access-Control-Allow-Credentials: true`, and advertise the configured methods/headers/
+max-age. When no `Origin` header is present (server-side tooling) the origin defaults to
+`http://localhost:3000`.
+
+#### Scenario: Preflight returns credentialed CORS headers
+
+- GIVEN an OPTIONS request to `/api/user/login` with an `Origin` header
+- WHEN `preflightedCorsLogin()` runs
+- THEN the response reflects that origin, sets `Access-Control-Allow-Credentials: true`, and advertises the allowed methods and headers
+
+### REQ-005: Sanitise input and harden responses
+
+The system MUST sanitise user input and harden API responses. `sanitizeInput()` recursively
+trims, length-caps (default 255), strips null bytes, HTML-encodes (`htmlspecialchars` with
+`ENT_QUOTES | ENT_HTML5`), and removes dangerous patterns (script tags, `javascript:` /
+`vbscript:` protocols, inline event handlers); non-string scalars pass through unchanged.
+`addSecurityHeaders()` attaches `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`,
+`X-XSS-Protection`, a strict `Referrer-Policy`, a locked-down `Content-Security-Policy`, and
+no-store cache directives to every authentication response.
+
+#### Scenario: Script payload is neutralised
+
+- GIVEN a profile field containing `<script>alert(1)</script>`
+- WHEN `sanitizeInput()` runs
+- THEN the script tag is removed / HTML-encoded so it cannot execute when echoed
+
+#### Scenario: Auth responses carry hardening headers
+
+- GIVEN any response from `me()`, `updateMe()`, or `login()`
+- WHEN it is returned
+- THEN it includes `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, a strict CSP, and no-store cache headers
+
+## Non-Functional Requirements
+
+- **Security:** Login MUST resist brute force (rate limit + lockout + progressive delay) and username enumeration (generic error messages) — REQ-002.
+- **Internationalization:** Controller messages MUST be translatable via `IL10N` (ADR-007); Dutch and English are supported.
+
+## Acceptance Criteria
+
+- [x] Self-profile read/update is capability-gated and session-bound
+- [x] Login enforces rate limiting, lockout, and anti-enumeration
+- [x] Logout terminates the session
+- [x] CORS preflight + response headers support credentialed clients
+- [x] Input sanitisation and security headers are applied to auth responses
+
+## Notes
+
+- **Security — reflected `Origin` + `Allow-Credentials: true` (REQ-004).** Both
+  `buildCorsPreflightResponse()` and `addCorsHeaders()` echo the request `Origin` header
+  verbatim into `Access-Control-Allow-Origin` while also setting
+  `Access-Control-Allow-Credentials: true`. Reflecting an arbitrary origin with credentials
+  effectively permits any site to make credentialed cross-origin requests once a session
+  cookie exists — a recognised CORS misconfiguration (it defeats the SOP protection that a
+  wildcard-with-credentials is explicitly forbidden to provide). Documented as observed
+  behavior; recommend a follow-up to validate `Origin` against an allowlist (admin-config or
+  trusted-domains) rather than reflecting it. Not a finding this change fixes — flagged for
+  security review.
+- **Security — `me()` accepts inline HTTP Basic auth but is not `@PublicPage`.** `me()` is
+  `@NoAdminRequired @NoCSRFRequired` (so NC requires an authenticated session by default),
+  yet the body also accepts a `Basic` credential and calls
+  `IUserManager::checkPassword()` directly. The Basic-auth branch is only reachable when NC's
+  own session check passes, so it is effectively dead unless the route is also public —
+  confirm the route declaration in `appinfo/routes.php`. Documented as observed.
+- **Observed quirk — `getUsedSpaceMemorySafe()` is overwritten in `buildQuotaInformation()`.**
+  The latter calls `getUsedSpaceMemorySafe()` and then, if `getUsedSpace()` exists on the
+  user, overwrites the result with it — so the "memory-safe" DB path is discarded whenever
+  the backend implements `getUsedSpace()`. Likely not the intended fallback ordering.
+  Documented as observed; not changed.
+- **Observed typo — `logSecurityEvent()` switch has `case 'succesful_login'`** (missing an
+  's'); the real event emitted by `recordSuccessfulLogin()` is `successful_login`, so it
+  falls through to the default `info` branch. Benign (same log level) but the case is dead.
+- **`UserController` constructs `SecurityService` with `new`** rather than DI. Observed; the
+  service has no DI-only dependencies so behavior is unaffected, but it bypasses container
+  test substitution.

--- a/openspec/changes/archive/retrofit-2026-05-25-user-management-and-login/tasks.md
+++ b/openspec/changes/archive/retrofit-2026-05-25-user-management-and-login/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: user-management-and-login#REQ-001 — Read and update the authenticated user's own profile (retroactive annotation)
+- [x] task-2: user-management-and-login#REQ-002 — Authenticate via the custom login endpoint with brute-force protection (retroactive annotation)
+- [x] task-3: user-management-and-login#REQ-003 — Terminate the active session on logout (retroactive annotation)
+- [x] task-4: user-management-and-login#REQ-004 — Support credentialed cross-origin browser clients via CORS (retroactive annotation)
+- [x] task-5: user-management-and-login#REQ-005 — Sanitise input and harden responses (retroactive annotation)

--- a/openspec/specs/user-management-and-login/spec.md
+++ b/openspec/specs/user-management-and-login/spec.md
@@ -1,0 +1,195 @@
+---
+retrofit: true
+status: implemented
+---
+
+# User Management and Login Specification
+
+## Purpose
+
+OpenConnector exposes a self-contained REST authentication surface (`/api/user/login`,
+`/api/user/me`, `/api/user/logout`) for browser SPA and external API clients, layered on
+Nextcloud's `IUserManager` / `IUserSession`. Login is hardened with per-username + per-IP
+rate limiting, progressive backoff, account/IP lockout, anti-enumeration error messages,
+memory monitoring, and security event logging (`SecurityService`). The profile surface
+(`UserService`) composes a comprehensive user payload (groups, quota, language, custom
+name fields, AccountManager profile properties) and applies capability-gated updates. This
+spec captures the observed behavior of 31 code units retroactively; the code already exists.
+
+## ADDED Requirements
+
+### REQ-001: Read and update the authenticated user's own profile
+
+The system MUST expose `@NoAdminRequired @NoCSRFRequired` endpoints for a user to read and
+update their own profile. `me()` resolves the session user (`UserService::getCurrentUser()`),
+falling back to inline HTTP Basic auth (`Authorization: Basic`) when no session exists, and
+returns the composed profile (`buildUserDataArray()`) — or HTTP 401 when unauthenticated and
+500 on unexpected error. `updateMe()` requires a session user (401 otherwise), sanitises the
+request body (`SecurityService::sanitizeInput()`), strips `_`-prefixed system keys, and
+applies updates (`updateUserProperties()`). `buildUserDataArray()` composes uid, display
+name, email, quota (`buildQuotaInformation()` → `getUsedSpaceMemorySafe()`), language/locale
+(`getLanguageAndLocale()`), group memberships, backend capabilities (feature-detected via
+`method_exists`), additional profile info (`getAdditionalProfileInfo()` /
+`getAccountManagerPropertiesSelectively()`), custom name fields (`getCustomNameFields()` /
+`setCustomNameFields()` in the `core` namespace), and organisation stats.
+`updateUserProperties()` switches active organisation when requested, then applies standard
+NC properties (`updateStandardUserProperties()` — capability-gated display name/email/
+password/language/locale) and AccountManager profile properties (`updateProfileProperties()`
+with default scopes from `getDefaultPropertyScope()`).
+
+#### Scenario: Read own profile when authenticated
+
+- GIVEN a logged-in session user
+- WHEN `GET /api/user/me` is called
+- THEN HTTP 200 with the composed user payload (uid, groups, quota, language, profile fields)
+
+#### Scenario: Unauthenticated profile read is rejected
+
+- GIVEN no session user and no valid Basic auth header
+- WHEN `GET /api/user/me` is called
+- THEN HTTP 401 with a generic "not logged in" message and security headers
+
+#### Scenario: Update is capability-gated
+
+- GIVEN a logged-in user whose backend reports `canChangeDisplayName() === false`
+- WHEN `updateMe()` is called with a `displayName` field
+- THEN the display name is NOT changed (the capability gate blocks it)
+
+#### Scenario: System keys are stripped from updates
+
+- GIVEN an update payload containing `_internal` keys alongside profile fields
+- WHEN `updateMe()` runs
+- THEN every `_`-prefixed key is removed before properties are applied
+
+### REQ-002: Authenticate via the custom login endpoint with brute-force protection
+
+The system MUST provide a `@PublicPage` `POST /api/user/login` that authenticates a
+username/password against `IUserManager::checkPassword()` and establishes a Nextcloud
+session token. Before authenticating it: monitors memory (returns 503 when usage exceeds
+80% of `memory_limit`, parsed by `convertToBytes()`); resolves the client IP
+(`getClientIpAddress()`, preferring validated public forwarded-header IPs over the remote
+address); validates and sanitises credentials (`validateLoginCredentials()` — 400 on missing/
+short/invalid-character username or over-long password); and checks the rate limit
+(`checkLoginRateLimit()` — 429 with progressive delay / lockout window). On failure it
+records the attempt (`recordFailedLoginAttempt()`, which locks out the username and/or IP
+after `RATE_LIMIT_ATTEMPTS` within `RATE_LIMIT_WINDOW`) and returns a generic
+"Invalid username or password" to prevent username enumeration. On success it records the
+event (`recordSuccessfulLogin()`, clearing the username counter and progressive delay),
+sets the session user, creates a session token, verifies the session, and returns the
+sanitised user payload plus session cookie hints. All responses carry security headers.
+
+#### Scenario: Successful login establishes a session
+
+- GIVEN valid credentials for an enabled account within the rate limit
+- WHEN `POST /api/user/login` is called
+- THEN the user is set in the session, a session token is created, and HTTP 200 returns the user payload and session info
+
+#### Scenario: Failed login is rate-limited and anti-enumeration
+
+- GIVEN an invalid password
+- WHEN `POST /api/user/login` is called
+- THEN the failed attempt is recorded and HTTP 401 returns a generic "Invalid username or password" message (no indication whether the username exists)
+
+#### Scenario: Lockout after repeated failures
+
+- GIVEN `RATE_LIMIT_ATTEMPTS` failed attempts for a username within the window
+- WHEN a further login is attempted
+- THEN `checkLoginRateLimit()` returns `allowed: false` and the endpoint responds HTTP 429 with a lockout window
+
+#### Scenario: Memory guard short-circuits login
+
+- GIVEN initial memory usage already exceeds 80% of the configured `memory_limit`
+- WHEN `POST /api/user/login` is called
+- THEN HTTP 503 is returned before authentication is attempted
+
+### REQ-003: Terminate the active session on logout
+
+The system MUST provide a `@PublicPage` `logout()` endpoint that terminates the active user
+session via `IUserSession::logout()` and returns `{ "logout": true }`.
+
+#### Scenario: Logout clears the session
+
+- GIVEN an active session
+- WHEN `logout()` is called
+- THEN the session is terminated and HTTP 200 returns `{ "logout": true }`
+
+### REQ-004: Support credentialed cross-origin browser clients via CORS
+
+The system MUST answer CORS preflights for `/api/user/me` and `/api/user/login`
+(`preflightedCorsMe()` / `preflightedCorsLogin()` → `buildCorsPreflightResponse()`) and
+attach CORS headers to credentialed JSON responses (`addCorsHeaders()`). Both reflect the
+request `Origin` header into `Access-Control-Allow-Origin`, set
+`Access-Control-Allow-Credentials: true`, and advertise the configured methods/headers/
+max-age. When no `Origin` header is present (server-side tooling) the origin defaults to
+`http://localhost:3000`.
+
+#### Scenario: Preflight returns credentialed CORS headers
+
+- GIVEN an OPTIONS request to `/api/user/login` with an `Origin` header
+- WHEN `preflightedCorsLogin()` runs
+- THEN the response reflects that origin, sets `Access-Control-Allow-Credentials: true`, and advertises the allowed methods and headers
+
+### REQ-005: Sanitise input and harden responses
+
+The system MUST sanitise user input and harden API responses. `sanitizeInput()` recursively
+trims, length-caps (default 255), strips null bytes, HTML-encodes (`htmlspecialchars` with
+`ENT_QUOTES | ENT_HTML5`), and removes dangerous patterns (script tags, `javascript:` /
+`vbscript:` protocols, inline event handlers); non-string scalars pass through unchanged.
+`addSecurityHeaders()` attaches `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`,
+`X-XSS-Protection`, a strict `Referrer-Policy`, a locked-down `Content-Security-Policy`, and
+no-store cache directives to every authentication response.
+
+#### Scenario: Script payload is neutralised
+
+- GIVEN a profile field containing `<script>alert(1)</script>`
+- WHEN `sanitizeInput()` runs
+- THEN the script tag is removed / HTML-encoded so it cannot execute when echoed
+
+#### Scenario: Auth responses carry hardening headers
+
+- GIVEN any response from `me()`, `updateMe()`, or `login()`
+- WHEN it is returned
+- THEN it includes `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, a strict CSP, and no-store cache headers
+
+## Non-Functional Requirements
+
+- **Security:** Login MUST resist brute force (rate limit + lockout + progressive delay) and username enumeration (generic error messages) — REQ-002.
+- **Internationalization:** Controller messages MUST be translatable via `IL10N` (ADR-007); Dutch and English are supported.
+
+## Acceptance Criteria
+
+- [x] Self-profile read/update is capability-gated and session-bound
+- [x] Login enforces rate limiting, lockout, and anti-enumeration
+- [x] Logout terminates the session
+- [x] CORS preflight + response headers support credentialed clients
+- [x] Input sanitisation and security headers are applied to auth responses
+
+## Notes
+
+- **Security — reflected `Origin` + `Allow-Credentials: true` (REQ-004).** Both
+  `buildCorsPreflightResponse()` and `addCorsHeaders()` echo the request `Origin` header
+  verbatim into `Access-Control-Allow-Origin` while also setting
+  `Access-Control-Allow-Credentials: true`. Reflecting an arbitrary origin with credentials
+  effectively permits any site to make credentialed cross-origin requests once a session
+  cookie exists — a recognised CORS misconfiguration (it defeats the SOP protection that a
+  wildcard-with-credentials is explicitly forbidden to provide). Documented as observed
+  behavior; recommend a follow-up to validate `Origin` against an allowlist (admin-config or
+  trusted-domains) rather than reflecting it. Not a finding this change fixes — flagged for
+  security review.
+- **Security — `me()` accepts inline HTTP Basic auth but is not `@PublicPage`.** `me()` is
+  `@NoAdminRequired @NoCSRFRequired` (so NC requires an authenticated session by default),
+  yet the body also accepts a `Basic` credential and calls
+  `IUserManager::checkPassword()` directly. The Basic-auth branch is only reachable when NC's
+  own session check passes, so it is effectively dead unless the route is also public —
+  confirm the route declaration in `appinfo/routes.php`. Documented as observed.
+- **Observed quirk — `getUsedSpaceMemorySafe()` is overwritten in `buildQuotaInformation()`.**
+  The latter calls `getUsedSpaceMemorySafe()` and then, if `getUsedSpace()` exists on the
+  user, overwrites the result with it — so the "memory-safe" DB path is discarded whenever
+  the backend implements `getUsedSpace()`. Likely not the intended fallback ordering.
+  Documented as observed; not changed.
+- **Observed typo — `logSecurityEvent()` switch has `case 'succesful_login'`** (missing an
+  's'); the real event emitted by `recordSuccessfulLogin()` is `successful_login`, so it
+  falls through to the default `info` branch. Benign (same log level) but the case is dead.
+- **`UserController` constructs `SecurityService` with `new`** rather than DI. Observed; the
+  service has no DI-only dependencies so behavior is unaffected, but it bypasses container
+  test substitution.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 31 methods under `user-management-and-login` as 5 new REQs.

Ghost change: `retrofit-2026-05-25-user-management-and-login` (archived). Refs #936.

### What this PR does
- Drafts 5 REQs as a new capability spec (`openspec/specs/user-management-and-login/spec.md`, `retrofit: true`): self-profile read/update, custom login with brute-force protection, logout, credentialed CORS, input sanitisation + security headers
- Creates tasks.md with one task per REQ
- Annotates 31 methods with `@spec` tags across `UserController`, `UserService`, `SecurityService`
- Archives the change (merges spec delta into main specs)

### What this PR does NOT do
- No code behavior changes — docblock `@spec` annotations only
- Does not silently fix observed-but-buggy behavior — Notes flag it

### Security / correctness findings flagged in spec notes
- 🔴 **Reflected `Origin` + `Access-Control-Allow-Credentials: true`** (`buildCorsPreflightResponse()`, `addCorsHeaders()`) — both echo the request `Origin` verbatim into `Access-Control-Allow-Origin` while allowing credentials. This lets any site make credentialed cross-origin requests once a session cookie exists (CORS misconfiguration). Recommend an `Origin` allowlist; flagged for security review, not fixed here.
- 🟡 **`me()` accepts inline HTTP Basic auth but is `@NoAdminRequired`/`@NoCSRFRequired`, not `@PublicPage`** — the Basic-auth branch is only reachable behind NC's own session check unless the route is also public. Confirm `appinfo/routes.php`.
- 🟡 **`getUsedSpaceMemorySafe()` is overwritten by `getUsedSpace()`** in `buildQuotaInformation()` — the memory-safe DB path is discarded when the backend implements `getUsedSpace()`.
- 🟡 **`logSecurityEvent()` switch has `case 'succesful_login'`** (typo) — dead case; the real event `successful_login` falls through to the default info branch (benign).

### Review focus
- REQ language matches observed behavior (not aspirational)
- Scenarios are testable (especially rate-limit / lockout / anti-enumeration)
- One REQ per distinct observable behavior

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `user-management-and-login`