### PR TITLE
retrofit: reverse-spec endpoint-runtime (5 REQs / 32 methods)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Retrofit annotation commit (opsx-annotate, 2026-05-24)
 78b6624686d0c027295843e24b5c8e1a2ed3458b
+
+# Retrofit annotation commit (reverse-spec endpoint-runtime, 2026-05-25)
+8564b07120d45a195ba4ad9aa602ab0d700a9ac2

--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -16,6 +16,8 @@
  * @version GIT: <git_id>
  *
  * @link https://www.OpenConnector.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-1
  */
 
 namespace OCA\OpenConnector\Controller;
@@ -147,6 +149,8 @@ class EndpointsController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      * @PublicPage
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-1
      */
     public function handlePath(string $_path): Response
     {
@@ -210,6 +214,8 @@ class EndpointsController extends Controller
      * @PublicPage
      *
      * @since 7.0.0
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-1
      */
     #[NoCSRFRequired]
     #[PublicPage]
@@ -239,6 +245,8 @@ class EndpointsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-1
      */
     public function logs(SearchService $searchService): JSONResponse
     {
@@ -265,6 +273,8 @@ class EndpointsController extends Controller
      * @param ObjectEntity $endpoint The endpoint to check.
      *
      * @return boolean True if the endpoint is simple and can be optimized.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-2
      */
     private function isSimpleEndpoint(ObjectEntity $endpoint): bool
     {
@@ -288,6 +298,8 @@ class EndpointsController extends Controller
      * @param string       $path     The request path.
      *
      * @return JSONResponse The direct response from ObjectService.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-2
      */
     private function handleSimpleSchemaRequest(ObjectEntity $endpoint, string $path): JSONResponse
     {
@@ -435,6 +447,8 @@ class EndpointsController extends Controller
      * @param string $path          The actual request path.
      *
      * @return array The parsed parameters.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-1
      */
     private function getPathParameters(array $endpointArray, string $path): array
     {
@@ -461,6 +475,8 @@ class EndpointsController extends Controller
      * @param string $path       The request path.
      *
      * @return string The pagination URL.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-1
      */
     private function buildPaginationUrl(array $parameters, string $path): string
     {

--- a/lib/Service/EndpointCacheService.php
+++ b/lib/Service/EndpointCacheService.php
@@ -17,6 +17,8 @@
  * @version GIT: <git_id>
  *
  * @link https://www.OpenConnector.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-4
  */
 
 namespace OCA\OpenConnector\Service;
@@ -88,6 +90,8 @@ class EndpointCacheService
      * @return ObjectEntity|null Returns the best matching endpoint or null if none found.
      *
      * @throws \Exception When multiple endpoints match (ambiguous routing).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-4
      */
     public function findByPathRegex(string $path, string $method, bool $isRetry=false): ?ObjectEntity
     {
@@ -169,6 +173,8 @@ class EndpointCacheService
      * Get all endpoints from cache or database as ObjectEntity arrays (for performance).
      *
      * @return array Array of ObjectEntity instances (for faster filtering).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-4
      */
     public function getAllEndpoints(): array
     {
@@ -212,6 +218,8 @@ class EndpointCacheService
      * Fetch all endpoints from OpenRegister ObjectService.
      *
      * @return array Array of ObjectEntity instances.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-4
      */
     private function fetchEndpointsFromOr(): array
     {
@@ -229,6 +237,8 @@ class EndpointCacheService
      * Refresh the endpoint cache from OpenRegister.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-4
      */
     public function refreshCache(): void
     {
@@ -271,6 +281,8 @@ class EndpointCacheService
      * This should be called when endpoints are created, updated, or deleted.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-4
      */
     public function clearCache(): void
     {
@@ -298,6 +310,8 @@ class EndpointCacheService
      * @param string $endpoint The endpoint path pattern.
      *
      * @return string The regex pattern for matching.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-4
      */
     private function createEndpointRegex(string $endpoint): string
     {
@@ -330,6 +344,8 @@ class EndpointCacheService
      * Get cache statistics for monitoring.
      *
      * @return array Cache statistics.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-4
      */
     public function getCacheStats(): array
     {

--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -121,6 +121,8 @@ class EndpointService
      * @param array $responseData The data from the responses found in the rules and openregister.
      *
      * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function parseMessage(array $response, array $responseData): array
     {
@@ -181,6 +183,8 @@ class EndpointService
      * @param IRequest $request The current request, used to determine the request identifier.
      *
      * @return Response
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function transformError(Response $result, IRequest $request): Response
     {
@@ -218,6 +222,8 @@ class EndpointService
      *
      * @return JSONResponse Response containing the result
      * @throws Exception When endpoint configuration is invalid
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-3
      */
     public function handleRequest(ObjectEntity $endpoint, IRequest $request, string $path): Response
     {
@@ -385,6 +391,8 @@ class EndpointService
      * @param string $path          The path called by the client.
      *
      * @return array The parsed path with the fields having the correct name.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-3
      */
     private function getPathParameters(array $endpointArray, string $path): array
     {
@@ -429,6 +437,8 @@ class EndpointService
      *
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function replaceInternalReferences(
         QBMapper|ORObjectService|ObjectServiceMapperAdapter $mapper,
@@ -523,6 +533,8 @@ class EndpointService
      * @param array $extend The original extend array
      *
      * @return array The reduced extend array
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function reduceExtendKeys(array $extend): array
     {
@@ -577,6 +589,8 @@ class EndpointService
      * @param array     $extend          Optional extend specification controlling which keys are inlined.
      *
      * @return array The modified array with UUIDs replaced by URLs.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function replaceUuidsInArray(array $data, array $uuidToUrlMap, ?bool $isRelatedObject=false, array $extend=[]): array
     {
@@ -645,6 +659,8 @@ class EndpointService
      * @return array The updated request parameters.
      *
      * @throws ContainerExceptionInterface|NotFoundExceptionInterface
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function rewriteExternalReferences(array $parameters, ORObjectService|ObjectServiceMapperAdapter|QBMapper $mapper): array
     {
@@ -703,6 +719,8 @@ class EndpointService
      * @return Entity|array The object(s) confirming to the request.
      *
      * @throws Exception
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-3
      */
     private function getObjects(
         ORObjectService|ObjectServiceMapperAdapter|QBMapper $mapper,
@@ -846,6 +864,8 @@ class EndpointService
      *
      * @throws DoesNotExistException|LoaderError|MultipleObjectsReturnedException|SyntaxError
      * @throws ContainerExceptionInterface|NotFoundExceptionInterface
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-3
      */
     private function handleSchemaRequest(ObjectEntity $endpoint, FlowToken &$flowToken, string $path): JSONResponse
     {
@@ -983,6 +1003,8 @@ class EndpointService
      * Gets the raw content for a http request from the input stream.
      *
      * @return string The raw content body for a http request
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function getRawContent(): string
     {
@@ -996,6 +1018,8 @@ class EndpointService
      * @param bool  $proxyHeaders Whether the proxy headers should be returned.
      *
      * @return array The resulting headers.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function getHeaders(array $server, bool $proxyHeaders=false): array
     {
@@ -1037,6 +1061,8 @@ class EndpointService
      *
      * @return array
      * @throws Exception
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-3
      */
     private function checkConditions(ObjectEntity $endpoint, IRequest $request): array
     {
@@ -1062,6 +1088,8 @@ class EndpointService
      *
      * @return JSONResponse
      * @throws GuzzleException|LoaderError|SyntaxError|\OCP\DB\Exception
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-3
      */
     private function handleSourceRequest(ObjectEntity $endpoint, IRequest $request): JSONResponse
     {
@@ -1102,6 +1130,8 @@ class EndpointService
      * @return string The generated url.
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-3
      */
     public function generateEndpointUrl(
         string $id,
@@ -1383,6 +1413,8 @@ class EndpointService
      * @param string $id The unique identifier of the rule
      *
      * @return ObjectEntity|null The rule entity if found, or null if not found
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-3
      */
     private function getRuleById(string $id): ?ObjectEntity
     {
@@ -2281,6 +2313,8 @@ class EndpointService
      * @param IRequest $request The current request, used to inspect headers and raw body.
      *
      * @return mixed Parsed data (array for JSON/XML) or original string.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function parseContent(IRequest $request): mixed
     {
@@ -2331,6 +2365,8 @@ class EndpointService
      * @param string $content Content to check.
      *
      * @return bool True if content is valid XML.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md#task-5
      */
     private function looksLikeXml(string $content): bool
     {

--- a/openspec/changes/retrofit-2026-05-25-endpoint-runtime/design.md
+++ b/openspec/changes/retrofit-2026-05-25-endpoint-runtime/design.md
@@ -1,0 +1,43 @@
+# Design — retrofit-2026-05-25-endpoint-runtime
+
+> **Retrofit change.** Tasks describe retroactive annotation of existing code,
+> not new implementation work. No code behaviour changes — only `@spec`
+> annotations are added to the affected methods, and the spec delta is merged
+> into `openspec/specs/endpoint-runtime/spec.md` on archive.
+
+## Context
+
+The `endpoint-runtime` cluster (Bucket 2b, 32 methods, no capability owner) is
+the endpoint request entry point. It spans `EndpointsController.php` (generic
+dispatch + simple fast path), `EndpointService.php` (full pipeline + target
+dispatch + request/response normalisation), and `EndpointCacheService.php`
+(endpoint resolution cache). Target dispatch follows ADR-008's polymorphic
+`targetType` / `targetId` contract.
+
+The cluster shares `EndpointService.php` with the `rule-pipeline` cluster.
+Dispatch / caching / normalisation methods are annotated here; rule-evaluation
+methods are annotated by the sibling `rule-pipeline` retrofit. `getRuleById` is
+a generic lookup helper used by the dispatch path and is annotated here per the
+coverage report's cluster assignment.
+
+## Decisions
+
+- **`--cluster`, not `--extend`.** No existing capability owns this behaviour
+  (the only main spec is `prometheus-metrics`). A new `endpoint-runtime`
+  capability is the correct home.
+- **5 REQs fold 32 methods.** Grouped by observable behaviour: generic dispatch
+  + CORS (001), simple fast path (002), full pipeline + target dispatch (003),
+  endpoint cache (004), request/response normalisation (005). One REQ per
+  coherent behaviour cluster rather than one per method.
+- **Observed, not aspirational.** The exception-trace leak, the placeholder
+  `logs()` stub, and the by-design regex duplication are documented in Notes,
+  not changed.
+
+## Risks / follow-ups
+
+Surfaced in the spec Notes for human triage — NOT addressed by this
+annotation-only change:
+- `handleRequest` returns `$e->getTrace()` to clients (information disclosure,
+  OWASP A05:2021).
+- `getRuleById` silently drops unresolvable rule ids.
+- `logs()` returns an empty result placeholder pending call-log wiring.

--- a/openspec/changes/retrofit-2026-05-25-endpoint-runtime/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-endpoint-runtime/proposal.md
@@ -1,0 +1,44 @@
+# Retrofit — endpoint-runtime
+
+Describes the observed behaviour of 32 methods under the `endpoint-runtime`
+cluster as 5 new REQs. Code already exists — this change retroactively
+specifies it. Source: `openspec/coverage-report.md` generated 2026-05-24,
+Bucket 2b cluster `endpoint-runtime` (no capability owner).
+
+## Motivation
+
+The endpoint dispatch / caching / normalisation layer is core platform
+behaviour with no spec coverage. It is the request entry point for every
+configured OpenConnector endpoint and needs a foundational capability spec
+under `openspec/specs/`. This is the second of two shared-`EndpointService`
+clusters; the rule-evaluation half is covered separately by the `rule-pipeline`
+cluster. Target dispatch follows ADR-008 (`targetType` / `targetId` polymorphic
+resolution).
+
+## Affected code units
+
+`lib/Controller/EndpointsController.php`:
+- `handlePath()`, `preflightedCors()`, `logs()`, `getPathParameters()`, `buildPaginationUrl()` — REQ-EP-001
+- `isSimpleEndpoint()`, `handleSimpleSchemaRequest()` — REQ-EP-002
+
+`lib/Service/EndpointService.php` (dispatch + normalisation methods):
+- `handleRequest()`, `handleSchemaRequest()`, `handleSourceRequest()`, `getObjects()`, `checkConditions()`, `generateEndpointUrl()`, `getPathParameters()`, `getRuleById()` — REQ-EP-003
+- `parseContent()`, `looksLikeXml()`, `getRawContent()`, `getHeaders()`, `parseMessage()`, `transformError()`, `replaceInternalReferences()`, `rewriteExternalReferences()`, `replaceUuidsInArray()`, `reduceExtendKeys()` — REQ-EP-005
+
+`lib/Service/EndpointCacheService.php`:
+- `findByPathRegex()`, `getAllEndpoints()`, `fetchEndpointsFromOr()`, `refreshCache()`, `clearCache()`, `createEndpointRegex()`, `getCacheStats()` — REQ-EP-004
+
+(Rule-evaluation methods in `EndpointService.php` are annotated under the
+sibling `rule-pipeline` cluster, per the coverage report's cluster assignment.)
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes.
+- Draft REQs that match behaviour (not aspirational).
+- Notes sections surface observed-but-suspicious behaviour:
+  - `handleRequest` returns the full exception stack trace in the HTTP 400 body — information disclosure (REQ-EP-003).
+  - `getRuleById` silently drops unresolvable rule ids (REQ-EP-003).
+  - `createEndpointRegex` is a by-design duplicate of `EndpointMapper::createEndpointRegex` (REQ-EP-004).
+  - `logs()` returns an empty paginated result as a placeholder until call-log wiring lands (REQ-EP-001).
+
+Source: openspec/coverage-report.md generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-endpoint-runtime/specs/endpoint-runtime/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-endpoint-runtime/specs/endpoint-runtime/spec.md
@@ -1,0 +1,221 @@
+---
+retrofit: true
+---
+
+# Endpoint Runtime Dispatch
+
+## Purpose
+
+OpenConnector exposes configurable endpoints under `/api/endpoint/{path}`. At
+request time the runtime resolves the path to a registered endpoint, applies
+CORS, optionally short-circuits "simple" schema CRUD, and otherwise runs the
+full request pipeline — condition checks, before/after rule processing, and
+dispatch to either an OpenRegister register/schema (object CRUD) or an external
+Source (proxy via CallService). This capability describes the **observed
+behaviour** of the endpoint dispatch + caching + request/response normalisation
+layer (`EndpointsController`, `EndpointService` dispatch methods, and
+`EndpointCacheService`) as it exists today. It is a retrofit spec: the code
+already exists, and these REQs document it. Target resolution follows the
+polymorphic `targetType` / `targetId` contract in ADR-008. Rule processing
+itself is specified separately under the `rule-pipeline` capability.
+
+## Requirements
+
+### REQ-EP-001: Generic Path Dispatch and CORS
+
+The system MUST expose a public generic dispatcher at
+`/api/endpoint/{_path}` that resolves the request path and HTTP method to a
+single registered endpoint via the endpoint cache, returning HTTP 404 when no
+endpoint matches and HTTP 409 when the path/method is ambiguous (multiple
+matches). On a match it MUST route to the simple fast-path or the full
+`EndpointService` pipeline, convert the response to XML when the `Accept` header
+requests `application/xml`, and apply CORS via `corsAfterController`. The system
+MUST also provide a CORS preflight (`OPTIONS`) response carrying the configured
+allowed methods, headers, max-age, and `Access-Control-Allow-Credentials: false`.
+
+**Scenarios:**
+
+1. **GIVEN** a request to `/api/endpoint/{path}` whose path+method match exactly
+   one registered endpoint **WHEN** `handlePath` runs **THEN** the request is
+   routed to that endpoint and a CORS-decorated response is returned.
+
+2. **GIVEN** a request whose path+method match no endpoint **WHEN** `handlePath`
+   runs **THEN** the response is HTTP 404 with a localised "No matching endpoint"
+   message.
+
+3. **GIVEN** a request whose path+method match more than one endpoint **WHEN**
+   the cache service raises the ambiguity exception **THEN** `handlePath` returns
+   HTTP 409 with the conflicting endpoint names.
+
+4. **GIVEN** a matched JSON response and a request `Accept: application/xml`
+   header **WHEN** `handlePath` finishes **THEN** the response is converted to an
+   `XMLResponse` preserving status and headers.
+
+5. **GIVEN** an `OPTIONS` preflight request **WHEN** `preflightedCors` runs
+   **THEN** the response carries the configured Allow-Methods / Allow-Headers /
+   Max-Age and `Access-Control-Allow-Credentials: false`.
+
+**Notes:**
+- `getPathParameters` (controller) and `buildPaginationUrl` are helpers of this
+  dispatch path; the latter builds absolute next/previous URLs from the request
+  protocol+host.
+- `handlePath` carries `@NoAdminRequired @NoCSRFRequired @PublicPage` docblock
+  annotations; the endpoint's own authentication is enforced by an
+  `authentication` rule in the rule pipeline, not by the controller.
+
+### REQ-EP-002: Simple-Endpoint Fast Path
+
+The system MUST detect "simple" endpoints — those targeting a single
+register/schema with no rules, conditions, input/output mappings, or
+configurations and using a standard HTTP method — and serve them directly via
+the OpenRegister mapper, bypassing the full rule pipeline. The fast path MUST
+parse the composite `targetId` (`"{registerId}/{schemaId}"`), validate both
+parts are numeric (HTTP 500 on misconfiguration), and map GET (single/collection
+with pagination), POST (201), PUT, PATCH, and DELETE (204) to the corresponding
+mapper operations, returning HTTP 405 for unsupported methods.
+
+**Scenarios:**
+
+1. **GIVEN** an endpoint with no rules/conditions/mappings/configurations,
+   `targetType` `register/schema`, and a standard method **WHEN** `isSimpleEndpoint`
+   is evaluated **THEN** it returns true and the request bypasses `EndpointService`.
+
+2. **GIVEN** a simple GET collection request **WHEN** `handleSimpleSchemaRequest`
+   runs **THEN** objects are returned paginated with `count`, `results`, and
+   `next`/`previous` links where applicable.
+
+3. **GIVEN** a simple POST request **WHEN** the rule runs **THEN** the object is
+   created via the mapper and returned with HTTP 201.
+
+4. **GIVEN** a simple endpoint with an empty or non-numeric `targetId` **WHEN**
+   the fast path runs **THEN** it logs the misconfiguration and returns HTTP 500
+   with a descriptive error.
+
+5. **GIVEN** a simple PUT/PATCH/DELETE request without an `id` path parameter
+   **WHEN** the fast path runs **THEN** it returns HTTP 400 requiring an id.
+
+### REQ-EP-003: Full Pipeline and Target Dispatch
+
+For non-simple endpoints the system MUST run the full request pipeline:
+evaluate endpoint `conditions` (returning HTTP 400 with offending fields when
+they fail), build a `FlowToken` request envelope, process "before" rules,
+dispatch on `targetType` — `register/schema` to OpenRegister object CRUD
+(`handleSchemaRequest` / `getObjects`) or `api` to an external Source proxied
+through `CallService` (`handleSourceRequest`) — then process "after" rules and
+return the response with a method-appropriate status code (POST→201,
+DELETE→204, otherwise 200, or a configured `defaultStatusCode`). An endpoint
+with neither a schema nor a source target MUST raise an error.
+
+**Scenarios:**
+
+1. **GIVEN** an endpoint with `targetType` `register/schema` **WHEN**
+   `handleRequest` runs **THEN** before-rules run, the schema CRUD operation is
+   dispatched via the OpenRegister mapper, after-rules run, and the response
+   carries the method-appropriate status code.
+
+2. **GIVEN** an endpoint with `targetType` `api` **WHEN** `handleRequest` runs
+   **THEN** the request is proxied to the referenced Source via `CallService`
+   and the source's response body and status code are returned.
+
+3. **GIVEN** an endpoint whose `conditions` fail for the incoming request
+   **WHEN** `checkConditions` runs **THEN** `handleRequest` returns HTTP 400 with
+   the list of offending fields and no target dispatch occurs.
+
+4. **GIVEN** an endpoint with neither schema nor source target **WHEN**
+   `handleRequest` runs **THEN** an exception "Endpoint must specify either a
+   schema or source connection" is thrown.
+
+5. **GIVEN** a GET request for a single object id that does not exist **WHEN**
+   `getObjects` runs **THEN** it sets status 404 and returns a "not found"
+   payload.
+
+**Notes:**
+- **Information disclosure (flagged):** the `handleRequest` top-level
+  `catch (Exception)` returns the full `$e->getTrace()` in the HTTP 400 response
+  body. Stack traces in client-facing responses leak internal paths and call
+  structure (OWASP A05:2021). Documented as observed; recommended for follow-up.
+- `handleSchemaRequest` maps OpenRegister `ValidationException` /
+  `CustomValidationException` to the mapper's validation-response handler;
+  other exceptions re-throw to the `handleRequest` catch.
+- `getRuleById` (lookup helper used by the dispatch + rule path) returns null on
+  any lookup exception (logged), silently dropping unresolvable rule ids.
+- `generateEndpointUrl` resolves the public URL of an object by finding a GET
+  endpoint whose `targetId` matches the object's `register/schema`.
+
+### REQ-EP-004: Endpoint Resolution Cache
+
+The system MUST cache the registered endpoint set to avoid an OpenRegister
+query on every request. Resolution (`findByPathRegex`) MUST filter cached
+endpoints by compiled `endpointRegex` and method; on a cache miss it MUST
+refresh once and retry (single retry, no infinite recursion). The cache MUST be
+layered: a request-lifetime in-memory copy plus a distributed cache with a
+1-hour TTL, with a fall-back to a direct OpenRegister query when the cache
+errors. The system MUST provide explicit `refreshCache`, `clearCache` (invoked
+on endpoint create/update/delete), regex compilation (`createEndpointRegex`),
+and a `getCacheStats` diagnostics method.
+
+**Scenarios:**
+
+1. **GIVEN** a populated cache **WHEN** `findByPathRegex` is called **THEN** the
+   matching endpoint is resolved from cache without an OpenRegister query.
+
+2. **GIVEN** an empty cache and a path that should match **WHEN** `findByPathRegex`
+   finds no match on the first pass **THEN** it refreshes the cache once and
+   retries exactly once before returning null.
+
+3. **GIVEN** a path that matches more than one cached endpoint **WHEN**
+   `findByPathRegex` runs **THEN** it throws an ambiguous-routing exception
+   listing the matching endpoint names.
+
+4. **GIVEN** the distributed cache raises an error **WHEN** `getAllEndpoints`
+   runs **THEN** it logs a warning and falls back to a direct OpenRegister query
+   via `fetchEndpointsFromOr`.
+
+5. **GIVEN** endpoints are modified **WHEN** `clearCache` is called **THEN** the
+   in-memory and distributed caches are dropped so the next resolution reloads
+   fresh data.
+
+**Notes:**
+- `createEndpointRegex` duplicates `EndpointMapper::createEndpointRegex` by
+  design (the docblock notes this is "to maintain cache service independence").
+  Documented as observed duplication.
+
+### REQ-EP-005: Request and Response Normalisation
+
+The system MUST normalise inbound and outbound payloads. Inbound: parse raw
+`php://input` (`getRawContent`), decode JSON, XML (when the content-type or a
+content sniff via `looksLikeXml` indicates XML), or multipart form data
+(`parseContent`); normalise request headers including optional proxy headers
+(`getHeaders`). Outbound: map upstream validation errors into an RFC-7807-shaped
+problem response (`transformError` + `parseMessage`); rewrite internal
+OpenRegister UUID references to public endpoint URLs on output
+(`replaceInternalReferences` / `replaceUuidsInArray`) and rewrite incoming URLs
+back to internal UUIDs on input (`rewriteExternalReferences`); normalise the
+OpenRegister `extend` syntax (`reduceExtendKeys`).
+
+**Scenarios:**
+
+1. **GIVEN** a request body of JSON, XML, or multipart form data **WHEN**
+   `parseContent` runs **THEN** the body is decoded to the corresponding
+   structured array (falling back to request params when decoding fails).
+
+2. **GIVEN** an upstream "Validation failed" error with a missing-property
+   message **WHEN** `transformError` / `parseMessage` run **THEN** the response
+   is a problem document with `type`, `code`, `status`, `instance`, `detail`,
+   and an `invalidParams` array.
+
+3. **GIVEN** a serialised object containing internal UUID references **WHEN**
+   `replaceInternalReferences` runs **THEN** the UUIDs are replaced with public
+   endpoint URLs in the output.
+
+4. **GIVEN** an inbound payload containing public object URLs **WHEN**
+   `rewriteExternalReferences` runs **THEN** the URLs are rewritten to internal
+   OpenRegister UUIDs before persistence.
+
+5. **GIVEN** a request with an `extend` parameter **WHEN** `reduceExtendKeys`
+   runs **THEN** the extend syntax is normalised for the OpenRegister mapper.
+
+**Notes:**
+- `getHeaders` filters `HTTP_`-prefixed server keys and conditionally excludes
+  `X-Forwarded*` / `X-Real-IP` / `X-Original-Uri` proxy headers unless
+  proxy-header mode is requested.

--- a/openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-endpoint-runtime/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: retrofit-2026-05-25-endpoint-runtime
+
+> Retrofit change. Each task records a retroactive annotation of already-existing code, not new implementation work. All boxes are checked because the behaviour ships today. ADR-032 cap respected (≤5).
+
+- [x] task-1: endpoint-runtime#REQ-EP-001 — Generic path dispatch and CORS (retroactive annotation)
+- [x] task-2: endpoint-runtime#REQ-EP-002 — Simple-endpoint fast path (retroactive annotation)
+- [x] task-3: endpoint-runtime#REQ-EP-003 — Full pipeline and target dispatch (retroactive annotation)
+- [x] task-4: endpoint-runtime#REQ-EP-004 — Endpoint resolution cache (retroactive annotation)
+- [x] task-5: endpoint-runtime#REQ-EP-005 — Request and response normalisation (retroactive annotation)

--- a/openspec/specs/endpoint-runtime/spec.md
+++ b/openspec/specs/endpoint-runtime/spec.md
@@ -1,0 +1,221 @@
+---
+retrofit: true
+---
+
+# Endpoint Runtime Dispatch
+
+## Purpose
+
+OpenConnector exposes configurable endpoints under `/api/endpoint/{path}`. At
+request time the runtime resolves the path to a registered endpoint, applies
+CORS, optionally short-circuits "simple" schema CRUD, and otherwise runs the
+full request pipeline — condition checks, before/after rule processing, and
+dispatch to either an OpenRegister register/schema (object CRUD) or an external
+Source (proxy via CallService). This capability describes the **observed
+behaviour** of the endpoint dispatch + caching + request/response normalisation
+layer (`EndpointsController`, `EndpointService` dispatch methods, and
+`EndpointCacheService`) as it exists today. It is a retrofit spec: the code
+already exists, and these REQs document it. Target resolution follows the
+polymorphic `targetType` / `targetId` contract in ADR-008. Rule processing
+itself is specified separately under the `rule-pipeline` capability.
+
+## Requirements
+
+### REQ-EP-001: Generic Path Dispatch and CORS
+
+The system MUST expose a public generic dispatcher at
+`/api/endpoint/{_path}` that resolves the request path and HTTP method to a
+single registered endpoint via the endpoint cache, returning HTTP 404 when no
+endpoint matches and HTTP 409 when the path/method is ambiguous (multiple
+matches). On a match it MUST route to the simple fast-path or the full
+`EndpointService` pipeline, convert the response to XML when the `Accept` header
+requests `application/xml`, and apply CORS via `corsAfterController`. The system
+MUST also provide a CORS preflight (`OPTIONS`) response carrying the configured
+allowed methods, headers, max-age, and `Access-Control-Allow-Credentials: false`.
+
+**Scenarios:**
+
+1. **GIVEN** a request to `/api/endpoint/{path}` whose path+method match exactly
+   one registered endpoint **WHEN** `handlePath` runs **THEN** the request is
+   routed to that endpoint and a CORS-decorated response is returned.
+
+2. **GIVEN** a request whose path+method match no endpoint **WHEN** `handlePath`
+   runs **THEN** the response is HTTP 404 with a localised "No matching endpoint"
+   message.
+
+3. **GIVEN** a request whose path+method match more than one endpoint **WHEN**
+   the cache service raises the ambiguity exception **THEN** `handlePath` returns
+   HTTP 409 with the conflicting endpoint names.
+
+4. **GIVEN** a matched JSON response and a request `Accept: application/xml`
+   header **WHEN** `handlePath` finishes **THEN** the response is converted to an
+   `XMLResponse` preserving status and headers.
+
+5. **GIVEN** an `OPTIONS` preflight request **WHEN** `preflightedCors` runs
+   **THEN** the response carries the configured Allow-Methods / Allow-Headers /
+   Max-Age and `Access-Control-Allow-Credentials: false`.
+
+**Notes:**
+- `getPathParameters` (controller) and `buildPaginationUrl` are helpers of this
+  dispatch path; the latter builds absolute next/previous URLs from the request
+  protocol+host.
+- `handlePath` carries `@NoAdminRequired @NoCSRFRequired @PublicPage` docblock
+  annotations; the endpoint's own authentication is enforced by an
+  `authentication` rule in the rule pipeline, not by the controller.
+
+### REQ-EP-002: Simple-Endpoint Fast Path
+
+The system MUST detect "simple" endpoints — those targeting a single
+register/schema with no rules, conditions, input/output mappings, or
+configurations and using a standard HTTP method — and serve them directly via
+the OpenRegister mapper, bypassing the full rule pipeline. The fast path MUST
+parse the composite `targetId` (`"{registerId}/{schemaId}"`), validate both
+parts are numeric (HTTP 500 on misconfiguration), and map GET (single/collection
+with pagination), POST (201), PUT, PATCH, and DELETE (204) to the corresponding
+mapper operations, returning HTTP 405 for unsupported methods.
+
+**Scenarios:**
+
+1. **GIVEN** an endpoint with no rules/conditions/mappings/configurations,
+   `targetType` `register/schema`, and a standard method **WHEN** `isSimpleEndpoint`
+   is evaluated **THEN** it returns true and the request bypasses `EndpointService`.
+
+2. **GIVEN** a simple GET collection request **WHEN** `handleSimpleSchemaRequest`
+   runs **THEN** objects are returned paginated with `count`, `results`, and
+   `next`/`previous` links where applicable.
+
+3. **GIVEN** a simple POST request **WHEN** the rule runs **THEN** the object is
+   created via the mapper and returned with HTTP 201.
+
+4. **GIVEN** a simple endpoint with an empty or non-numeric `targetId` **WHEN**
+   the fast path runs **THEN** it logs the misconfiguration and returns HTTP 500
+   with a descriptive error.
+
+5. **GIVEN** a simple PUT/PATCH/DELETE request without an `id` path parameter
+   **WHEN** the fast path runs **THEN** it returns HTTP 400 requiring an id.
+
+### REQ-EP-003: Full Pipeline and Target Dispatch
+
+For non-simple endpoints the system MUST run the full request pipeline:
+evaluate endpoint `conditions` (returning HTTP 400 with offending fields when
+they fail), build a `FlowToken` request envelope, process "before" rules,
+dispatch on `targetType` — `register/schema` to OpenRegister object CRUD
+(`handleSchemaRequest` / `getObjects`) or `api` to an external Source proxied
+through `CallService` (`handleSourceRequest`) — then process "after" rules and
+return the response with a method-appropriate status code (POST→201,
+DELETE→204, otherwise 200, or a configured `defaultStatusCode`). An endpoint
+with neither a schema nor a source target MUST raise an error.
+
+**Scenarios:**
+
+1. **GIVEN** an endpoint with `targetType` `register/schema` **WHEN**
+   `handleRequest` runs **THEN** before-rules run, the schema CRUD operation is
+   dispatched via the OpenRegister mapper, after-rules run, and the response
+   carries the method-appropriate status code.
+
+2. **GIVEN** an endpoint with `targetType` `api` **WHEN** `handleRequest` runs
+   **THEN** the request is proxied to the referenced Source via `CallService`
+   and the source's response body and status code are returned.
+
+3. **GIVEN** an endpoint whose `conditions` fail for the incoming request
+   **WHEN** `checkConditions` runs **THEN** `handleRequest` returns HTTP 400 with
+   the list of offending fields and no target dispatch occurs.
+
+4. **GIVEN** an endpoint with neither schema nor source target **WHEN**
+   `handleRequest` runs **THEN** an exception "Endpoint must specify either a
+   schema or source connection" is thrown.
+
+5. **GIVEN** a GET request for a single object id that does not exist **WHEN**
+   `getObjects` runs **THEN** it sets status 404 and returns a "not found"
+   payload.
+
+**Notes:**
+- **Information disclosure (flagged):** the `handleRequest` top-level
+  `catch (Exception)` returns the full `$e->getTrace()` in the HTTP 400 response
+  body. Stack traces in client-facing responses leak internal paths and call
+  structure (OWASP A05:2021). Documented as observed; recommended for follow-up.
+- `handleSchemaRequest` maps OpenRegister `ValidationException` /
+  `CustomValidationException` to the mapper's validation-response handler;
+  other exceptions re-throw to the `handleRequest` catch.
+- `getRuleById` (lookup helper used by the dispatch + rule path) returns null on
+  any lookup exception (logged), silently dropping unresolvable rule ids.
+- `generateEndpointUrl` resolves the public URL of an object by finding a GET
+  endpoint whose `targetId` matches the object's `register/schema`.
+
+### REQ-EP-004: Endpoint Resolution Cache
+
+The system MUST cache the registered endpoint set to avoid an OpenRegister
+query on every request. Resolution (`findByPathRegex`) MUST filter cached
+endpoints by compiled `endpointRegex` and method; on a cache miss it MUST
+refresh once and retry (single retry, no infinite recursion). The cache MUST be
+layered: a request-lifetime in-memory copy plus a distributed cache with a
+1-hour TTL, with a fall-back to a direct OpenRegister query when the cache
+errors. The system MUST provide explicit `refreshCache`, `clearCache` (invoked
+on endpoint create/update/delete), regex compilation (`createEndpointRegex`),
+and a `getCacheStats` diagnostics method.
+
+**Scenarios:**
+
+1. **GIVEN** a populated cache **WHEN** `findByPathRegex` is called **THEN** the
+   matching endpoint is resolved from cache without an OpenRegister query.
+
+2. **GIVEN** an empty cache and a path that should match **WHEN** `findByPathRegex`
+   finds no match on the first pass **THEN** it refreshes the cache once and
+   retries exactly once before returning null.
+
+3. **GIVEN** a path that matches more than one cached endpoint **WHEN**
+   `findByPathRegex` runs **THEN** it throws an ambiguous-routing exception
+   listing the matching endpoint names.
+
+4. **GIVEN** the distributed cache raises an error **WHEN** `getAllEndpoints`
+   runs **THEN** it logs a warning and falls back to a direct OpenRegister query
+   via `fetchEndpointsFromOr`.
+
+5. **GIVEN** endpoints are modified **WHEN** `clearCache` is called **THEN** the
+   in-memory and distributed caches are dropped so the next resolution reloads
+   fresh data.
+
+**Notes:**
+- `createEndpointRegex` duplicates `EndpointMapper::createEndpointRegex` by
+  design (the docblock notes this is "to maintain cache service independence").
+  Documented as observed duplication.
+
+### REQ-EP-005: Request and Response Normalisation
+
+The system MUST normalise inbound and outbound payloads. Inbound: parse raw
+`php://input` (`getRawContent`), decode JSON, XML (when the content-type or a
+content sniff via `looksLikeXml` indicates XML), or multipart form data
+(`parseContent`); normalise request headers including optional proxy headers
+(`getHeaders`). Outbound: map upstream validation errors into an RFC-7807-shaped
+problem response (`transformError` + `parseMessage`); rewrite internal
+OpenRegister UUID references to public endpoint URLs on output
+(`replaceInternalReferences` / `replaceUuidsInArray`) and rewrite incoming URLs
+back to internal UUIDs on input (`rewriteExternalReferences`); normalise the
+OpenRegister `extend` syntax (`reduceExtendKeys`).
+
+**Scenarios:**
+
+1. **GIVEN** a request body of JSON, XML, or multipart form data **WHEN**
+   `parseContent` runs **THEN** the body is decoded to the corresponding
+   structured array (falling back to request params when decoding fails).
+
+2. **GIVEN** an upstream "Validation failed" error with a missing-property
+   message **WHEN** `transformError` / `parseMessage` run **THEN** the response
+   is a problem document with `type`, `code`, `status`, `instance`, `detail`,
+   and an `invalidParams` array.
+
+3. **GIVEN** a serialised object containing internal UUID references **WHEN**
+   `replaceInternalReferences` runs **THEN** the UUIDs are replaced with public
+   endpoint URLs in the output.
+
+4. **GIVEN** an inbound payload containing public object URLs **WHEN**
+   `rewriteExternalReferences` runs **THEN** the URLs are rewritten to internal
+   OpenRegister UUIDs before persistence.
+
+5. **GIVEN** a request with an `extend` parameter **WHEN** `reduceExtendKeys`
+   runs **THEN** the extend syntax is normalised for the OpenRegister mapper.
+
+**Notes:**
+- `getHeaders` filters `HTTP_`-prefixed server keys and conditionally excludes
+  `X-Forwarded*` / `X-Real-IP` / `X-Original-Uri` proxy headers unless
+  proxy-header mode is requested.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behaviour of 32 methods under the `endpoint-runtime` cluster as 5 new REQs.

Ghost change: `retrofit-2026-05-25-endpoint-runtime`. New capability spec landed at `openspec/specs/endpoint-runtime/spec.md` (`retrofit: true`).

Refs #936 (coverage umbrella). PRODUCTION app — full review. Sibling of `rule-pipeline` PR #954 (both clusters share `EndpointService.php`; rule-evaluation methods are annotated there, dispatch/caching/normalisation methods here).

### What this PR does
- Drafts 5 REQs covering the endpoint runtime: generic path dispatch + CORS (REQ-EP-001), simple-endpoint fast path (002), full pipeline + target dispatch (003), endpoint resolution cache (004), request/response normalisation (005)
- Creates `tasks.md` with one task per REQ (all `[x]` — code already exists)
- Annotates 32 methods across `lib/Controller/EndpointsController.php` (file header + 7 methods), `lib/Service/EndpointService.php` (18 dispatch/normalisation methods), and `lib/Service/EndpointCacheService.php` (file header + 7 methods) with `@spec .../tasks.md#task-N`
- Records the annotation commit in `.git-blame-ignore-revs`

### What this PR does NOT do
- No code behaviour changes — docblock `@spec` annotations only
- Does not silently fix observed-but-suspicious behaviour — surfaced in spec Notes (see below)

### Security / silent-fail findings flagged in Notes (NOT fixed here)
- **Information disclosure** — `EndpointService::handleRequest` top-level `catch (Exception)` returns the full `$e->getTrace()` in the HTTP 400 response body. Stack traces leak internal paths and call structure to clients (OWASP A05:2021) (REQ-EP-003)
- **Dropped rule** — `getRuleById` returns null on any lookup exception (logged), silently dropping unresolvable rule ids from the chain (REQ-EP-003)
- **Placeholder stub** — `EndpointsController::logs()` returns an empty paginated result as a placeholder until call-log wiring lands (REQ-EP-001)
- **By-design duplication** — `EndpointCacheService::createEndpointRegex` duplicates `EndpointMapper::createEndpointRegex` to keep the cache service independent (REQ-EP-004)

### Review focus
- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- One REQ per distinct observable behaviour (5 REQs fold 32 methods per ADR-032 cap)
- Cluster split with `rule-pipeline` (#954): each shared-`EndpointService` method assigned to exactly one cluster

Specter: app_specs row for `endpoint-runtime` will be flagged as retrofit cohort on the next `sync_spec_content.py` run after this merges to development (sync reads the canonical checkout).

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `endpoint-runtime`