### PR TITLE
feat(dashboard): drop top date-range picker — per-widget chips replace it

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -99,7 +99,7 @@
       "type": "dashboard",
       "title": "Dashboard",
       "config": {
-        "dateRange": { "enabled": true, "persistKey": "openconnector-dashboard" },
+        "dateRange": { "enabled": true, "showHeaderPicker": false, "persistKey": "openconnector-dashboard" },
         "widgets": [
           { "id": "kpi-sources",          "title": "Sources",          "type": "stats-block", "props": { "route": { "name": "Sources" } },                  "dataSource": { "register": "openconnector", "schema": "source",                   "aggregate": "count" } },
           { "id": "kpi-mappings",         "title": "Mappings",         "type": "stats-block", "props": { "route": { "name": "Mappings" } },                 "dataSource": { "register": "openconnector", "schema": "mapping",                  "aggregate": "count" } },


### PR DESCRIPTION
Each chart widget now carries its own interactive date-range chip (nc-vue #367..#369), making the page-header `CnDateRangePicker` redundant.

Sets `dateRange.showHeaderPicker: false` (new nc-vue flag from ncv#425) to hide the header control while keeping the range feature intact — state still initialises from `persistKey` + default, and the per-widget chips drive the (still-global) range.

One-line manifest change. Bundle rebuilt + deployed to dev container; the top 'Range preset / from → to' row is gone, KPI cards + charts render directly under the page.