### PR TITLE
chore(nav): adopt three-section nav model + bump nc-vue to beta.97

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ The OpenConnector Nextcloud app provides a ESB-framework to work together in an 
 
 **Support:** For support, contact support@conduction.nl. For a Service Level Agreement (SLA), contact sales@conduction.nl.
     ]]></description>
-	<version>0.2.8</version>
+	<version>0.2.9</version>
 	<licence>agpl</licence>
 	<category>integration</category>
 	<author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^1.0.0-beta.73",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.97",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@mdi/js": "^7.4.47",
@@ -2045,9 +2045,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.73",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.73.tgz",
-      "integrity": "sha512-1kVmy8VoRjNQBPKleXV+2kXyWdXhRfl/ZU4q8dZeDVxsHn1CVyqTZX0NjOaaasoTN6EOZ7oHdcURRPSEZasszg==",
+      "version": "1.0.0-beta.97",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.97.tgz",
+      "integrity": "sha512-jlRpA1tjIX3ysP8a42S6lrbrcZfN63yHDzgWMBNaf9Ofs0jvVqqkYawLuEj8vGMU1H4hwvyb0lEOHIsNRmHP6g==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -2062,6 +2062,7 @@
         "@codemirror/view": "^6.0.0",
         "@microsoft/fetch-event-source": "^2.0.1",
         "@nextcloud/dialogs": "^6.4.2",
+        "@nextcloud/event-bus": "^3.3.3",
         "@nextcloud/notify_push": "^1.0.0",
         "@types/react": "^18.0.0",
         "@uiw/codemirror-theme-github": "^4.25.8",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^1.0.0-beta.73",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.97",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@mdi/js": "^7.4.47",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -80,7 +80,7 @@
       "label": "Documentation",
       "icon": "BookOpenVariant",
       "href": "https://openconnector.conduction.nl",
-      "section": "settings",
+      "section": "footer",
       "order": 15
     },
     {


### PR DESCRIPTION
Moves Documentation to `section: "footer"` (bottom-pinned via CnAppNav's native pinned prop); settings-section entries render in the new NcAppNavigationSettings foldout. Bumps `@conduction/nextcloud-vue` to `^1.0.0-beta.97` (the release with the new CnAppNav) so the footer section renders correctly. Version → 0.2.9.

Production app — opened for review per merge-authority.