### PR TITLE
feat(integrations): ship 'Synced from' as a Path-2 registry leaf

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -38,7 +38,9 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Util;
 
 /**
  * Bootstrap entry point for the OpenConnector app.
@@ -103,6 +105,19 @@ class Application extends App implements IBootstrap
         $dispatcher->addServiceListener(eventName: ObjectDeletedEvent::class, className: ObjectDeletedEventListener::class);
         // @todo Remove this temporary listener to the software catalog application.
         // $dispatcher->addServiceListener(eventName: ViewUpdatedOrCreatedEventListener::class, className: ViewUpdatedOrCreatedEventListener::class);
+        // Path-2 integration leaf: load the tiny `openconnector-integration`
+        // bundle on EVERY full-page render (not just OpenConnector's own SPA)
+        // so the "Synced from" component is registered on the OpenRegister
+        // integration registry wherever a host app renders an object detail
+        // page (e.g. an OpenCatalogi publication). BeforeTemplateRenderedEvent
+        // fires for every app's page, so the global init-script lands once
+        // per page regardless of which app is active.
+        $dispatcher->addListener(
+            BeforeTemplateRenderedEvent::class,
+            static function (): void {
+                Util::addInitScript('openconnector', 'openconnector-integration');
+            }
+        );
     }//end register()
 
     /**

--- a/lib/Service/Integration/SynchronizationContractProvider.php
+++ b/lib/Service/Integration/SynchronizationContractProvider.php
@@ -203,8 +203,12 @@ class SynchronizationContractProvider extends AbstractIntegrationProvider
             return [];
         }
 
+        // Per-call memo so repeated synchronizationIds across contracts
+        // resolve their display name once (avoids N+1 lookups).
+        $syncNameCache = [];
+
         return array_map(
-            function ($contract): array {
+            function ($contract) use (&$syncNameCache): array {
                 if (is_object($contract) === true && method_exists($contract, 'getObject') === true) {
                     $body = $contract->getObject();
                 } else {
@@ -217,20 +221,124 @@ class SynchronizationContractProvider extends AbstractIntegrationProvider
                     $uuid = ($contract['uuid'] ?? '');
                 }
 
+                $synchronizationId = ($body['synchronizationId'] ?? null);
+                $syncName          = $this->resolveSynchronizationName((string) $synchronizationId, $syncNameCache);
+                $lastSynced        = ($body['targetLastSynced'] ?? null);
+                $lastAction        = ($body['targetLastAction'] ?? null);
+
                 return [
-                    'id'                => $uuid,
-                    'synchronizationId' => $body['synchronizationId'] ?? null,
-                    'originId'          => $body['originId'] ?? null,
-                    'originHash'        => $body['originHash'] ?? null,
-                    'targetLastAction'  => $body['targetLastAction'] ?? null,
-                    'targetLastSynced'  => $body['targetLastSynced'] ?? null,
-                    'sourceLastChecked' => $body['sourceLastChecked'] ?? null,
+                    'id'                  => $uuid,
+                    // Generic-card display keys (CnIntegrationCard reads
+                    // title / subtitle / url). Title is the human sync name;
+                    // subtitle summarises the last sync; url deep-links into
+                    // the OpenConnector synchronization detail page.
+                    'title'               => $syncName,
+                    'subtitle'            => $this->buildSubtitle($lastSynced, $lastAction),
+                    'url'                 => $this->buildSyncUrl((string) $synchronizationId),
+                    // Raw provenance fields — preserved for the bespoke
+                    // "Synced from" component + any programmatic consumer.
+                    'synchronizationId'   => $synchronizationId,
+                    'synchronizationName' => $syncName,
+                    'originId'            => $body['originId'] ?? null,
+                    'originHash'          => $body['originHash'] ?? null,
+                    'targetLastAction'    => $lastAction,
+                    'targetLastSynced'    => $lastSynced,
+                    'sourceLastChecked'   => $body['sourceLastChecked'] ?? null,
                 ];
             },
             $rows
         );
 
     }//end list()
+
+    /**
+     * Resolve a synchronization's human-readable name from its id.
+     *
+     * Queries the `openconnector/synchronization` OR object and reads its
+     * `name` field. Falls back to a short-id label when the object can't
+     * be found (deleted sync, permission, etc.). Memoised per list() call
+     * via the by-reference $cache.
+     *
+     * @param string               $synchronizationId The synchronization uuid.
+     * @param array<string,string> $cache             By-ref per-call memo.
+     *
+     * @return string The display name.
+     */
+    private function resolveSynchronizationName(string $synchronizationId, array &$cache): string
+    {
+        if ($synchronizationId === '') {
+            return $this->l10n->t('Unknown synchronization');
+        }
+
+        if (isset($cache[$synchronizationId]) === true) {
+            return $cache[$synchronizationId];
+        }
+
+        $name = $this->l10n->t('Synchronization %s', [substr($synchronizationId, 0, 8)]);
+        try {
+            $sync = $this->objectService->find(
+                id: $synchronizationId,
+                register: self::REGISTER_SLUG,
+                schema: 'synchronization'
+            );
+            if (is_object($sync) === true && method_exists($sync, 'getObject') === true) {
+                $syncBody = $sync->getObject();
+                if (empty($syncBody['name']) === false) {
+                    $name = (string) $syncBody['name'];
+                }
+            }
+        } catch (\Throwable $e) {
+            // Keep the short-id fallback — a missing sync is non-fatal here.
+        }
+
+        $cache[$synchronizationId] = $name;
+        return $name;
+
+    }//end resolveSynchronizationName()
+
+    /**
+     * Build the human subtitle line summarising the last sync.
+     *
+     * @param string|null $lastSynced ISO timestamp of the last target sync.
+     * @param string|null $lastAction The last action (create/update/delete).
+     *
+     * @return string The subtitle (may be empty when nothing is known).
+     */
+    private function buildSubtitle(?string $lastSynced, ?string $lastAction): string
+    {
+        if (empty($lastSynced) === true) {
+            if ($lastAction !== null && $lastAction !== '') {
+                return (string) $lastAction;
+            }
+
+            return '';
+        }
+
+        $date = substr((string) $lastSynced, 0, 10);
+        if ($lastAction !== null && $lastAction !== '') {
+            return $this->l10n->t('Last synced %1$s · %2$s', [$date, (string) $lastAction]);
+        }
+
+        return $this->l10n->t('Last synced %s', [$date]);
+
+    }//end buildSubtitle()
+
+    /**
+     * Build a deep-link into the OpenConnector synchronization detail page.
+     *
+     * @param string $synchronizationId The synchronization uuid.
+     *
+     * @return string|null The SPA deep-link, or null when no id.
+     */
+    private function buildSyncUrl(string $synchronizationId): ?string
+    {
+        if ($synchronizationId === '') {
+            return null;
+        }
+
+        return '/index.php/apps/openconnector/synchronizations/'.$synchronizationId;
+
+    }//end buildSyncUrl()
 
     /**
      * Health descriptor.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test:e2e:docs": "playwright test --project docs-capture",
     "stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
     "check:manifest": "node -e \"const {validateManifestV2}=require('@conduction/nextcloud-vue/dist/utils.cjs.js');const m=require('./src/manifest.json');const r=validateManifestV2(m);if(!r.valid){console.error(JSON.stringify(r.errors,null,2));process.exit(1)}console.log('manifest.json valid')\"",
-    "check:specs": "npm run check:manifest",
     "test:newman": "newman run tests/postman/openconnector.postman_collection.json --environment tests/postman/openconnector.postman_environment.json --reporters cli,json --reporter-json-export tests/postman/newman-report.json",
     "test:regression": "playwright test --project regression"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e:docs": "playwright test --project docs-capture",
     "stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
     "check:manifest": "node -e \"const {validateManifestV2}=require('@conduction/nextcloud-vue/dist/utils.cjs.js');const m=require('./src/manifest.json');const r=validateManifestV2(m);if(!r.valid){console.error(JSON.stringify(r.errors,null,2));process.exit(1)}console.log('manifest.json valid')\"",
+    "check:specs": "npm run check:manifest",
     "test:newman": "newman run tests/postman/openconnector.postman_collection.json --environment tests/postman/openconnector.postman_environment.json --reporters cli,json --reporter-json-export tests/postman/newman-report.json",
     "test:regression": "playwright test --project regression"
   },

--- a/src/integration.js
+++ b/src/integration.js
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Global integration-registration entry (Path 2).
+//
+// Loaded on EVERY Nextcloud page via `\OCP\Util::addInitScript` (see
+// lib/AppInfo/Application.php) — NOT the per-app SPA. That's what lets
+// OpenConnector's "Synced from" component render inside OTHER apps'
+// detail pages (e.g. an OpenCatalogi publication) where OpenConnector's
+// main SPA bundle is never loaded.
+//
+// Kept deliberately tiny: import the component + register it. The
+// registry helper is load-order-safe — if OpenRegister hasn't installed
+// its singleton yet, this queues and OR replays on install.
+
+import { registerIntegration } from '@conduction/nextcloud-vue'
+import SyncedFromTab from './integration/SyncedFromTab.vue'
+
+registerIntegration({
+	id: 'sync-contract',
+	label: 'Synced from',
+	icon: 'SyncOutline',
+	group: 'workflow',
+	order: 50,
+	requiredApp: 'openconnector',
+	// Same component drives the sidebar tab + the detail/dashboard widget
+	// + the single-entity surface (AD-19 fallback to `widget`).
+	tab: SyncedFromTab,
+	widget: SyncedFromTab,
+})

--- a/src/integration/SyncedFromTab.vue
+++ b/src/integration/SyncedFromTab.vue
@@ -1,0 +1,215 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  SyncedFromTab — OpenConnector's bespoke "Synced from" leaf component.
+
+  Registered on the OpenRegister integration registry (Path 2) under id
+  `sync-contract`, used as BOTH the sidebar `tab` and the detail-page
+  `widget`. It renders the provenance chain for any OR object: which
+  synchronization(s) wrote it, when they last ran, and a deep-link into
+  the OpenConnector synchronization editor.
+
+  The registry mounts this with the shared object context props
+  ({ objectId, register, schema, apiBase }); the detail/dashboard
+  surfaces additionally pass `surface`. We fetch the same sub-resource
+  endpoint the generic CnIntegrationCard would
+  (`/api/objects/{register}/{schema}/{id}/integrations/sync-contract`),
+  but render a richer source → sync → last-run layout.
+
+  Per AD-23 a 5xx / unavailable endpoint renders a quiet "currently
+  unavailable" banner rather than a broken tab.
+-->
+<template>
+	<div class="oc-synced-from" data-testid="oc-synced-from">
+		<NcLoadingIcon v-if="loading" :size="24" />
+
+		<div v-else-if="unavailable" class="oc-synced-from__notice">
+			{{ t('openconnector', 'Sync information is currently unavailable.') }}
+		</div>
+
+		<div v-else-if="rows.length === 0" class="oc-synced-from__empty">
+			{{ t('openconnector', 'This object was not created by a synchronization.') }}
+		</div>
+
+		<ul v-else class="oc-synced-from__list">
+			<li v-for="row in rows" :key="row.id" class="oc-synced-from__row">
+				<div class="oc-synced-from__row-icon">
+					<SyncIcon :size="20" />
+				</div>
+				<div class="oc-synced-from__row-body">
+					<a
+						v-if="row.url"
+						:href="row.url"
+						class="oc-synced-from__title">
+						{{ row.title || t('openconnector', 'Synchronization') }}
+					</a>
+					<span v-else class="oc-synced-from__title">
+						{{ row.title || t('openconnector', 'Synchronization') }}
+					</span>
+					<span v-if="row.subtitle" class="oc-synced-from__subtitle">{{ row.subtitle }}</span>
+					<span v-if="row.originId" class="oc-synced-from__origin">
+						{{ t('openconnector', 'Origin id:') }} <code>{{ row.originId }}</code>
+					</span>
+				</div>
+			</li>
+		</ul>
+	</div>
+</template>
+
+<script>
+import { NcLoadingIcon } from '@nextcloud/vue'
+import SyncIcon from 'vue-material-design-icons/Sync.vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { translate as t } from '@nextcloud/l10n'
+
+export default {
+	name: 'SyncedFromTab',
+
+	components: {
+		NcLoadingIcon,
+		SyncIcon,
+	},
+
+	props: {
+		/** OR object uuid the surface is rendering. */
+		objectId: { type: String, default: '' },
+		/** OR register slug. */
+		register: { type: String, default: '' },
+		/** OR schema slug. */
+		schema: { type: String, default: '' },
+		/**
+		 * API base injected by the registry surface. Falls back to the
+		 * OpenRegister app path so the component also works when mounted
+		 * standalone (e.g. tests / storybook).
+		 */
+		apiBase: { type: String, default: '' },
+		/**
+		 * Render surface — 'detail-page' | 'app-dashboard' |
+		 * 'single-entity' | 'user-dashboard'. Unused for now (the layout
+		 * is identical across surfaces) but accepted so the registry's
+		 * v-bind doesn't warn.
+		 */
+		surface: { type: String, default: 'detail-page' },
+	},
+
+	data() {
+		return {
+			rows: [],
+			loading: false,
+			unavailable: false,
+		}
+	},
+
+	computed: {
+		/**
+		 * Resolve the sub-resource endpoint. Uses the injected apiBase
+		 * when present, else the OpenRegister API path.
+		 *
+		 * @return {string} The integration list endpoint.
+		 */
+		endpoint() {
+			const base = this.apiBase || generateUrl('/apps/openregister/api')
+			return `${base}/objects/${this.register}/${this.schema}/${this.objectId}/integrations/sync-contract`
+		},
+	},
+
+	watch: {
+		objectId: { immediate: true, handler(id) { if (id) { this.fetchRows() } } },
+	},
+
+	methods: {
+		t,
+
+		/**
+		 * Fetch the provenance rows for the current object. Sets the
+		 * AD-23 `unavailable` flag on 5xx/network error rather than
+		 * throwing — the surface degrades quietly.
+		 *
+		 * @return {Promise<void>}
+		 */
+		async fetchRows() {
+			this.loading = true
+			this.unavailable = false
+			try {
+				const res = await axios.get(this.endpoint)
+				const data = res.data
+				this.rows = Array.isArray(data) ? data : (data.results || data.rows || [])
+			} catch (e) {
+				this.unavailable = true
+				this.rows = []
+			} finally {
+				this.loading = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.oc-synced-from {
+	padding: 8px 0;
+}
+
+.oc-synced-from__notice,
+.oc-synced-from__empty {
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+	padding: 8px 12px;
+}
+
+.oc-synced-from__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.oc-synced-from__row {
+	display: flex;
+	gap: 10px;
+	padding: 10px 12px;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.oc-synced-from__row:last-child {
+	border-bottom: none;
+}
+
+.oc-synced-from__row-icon {
+	flex-shrink: 0;
+	color: var(--color-primary-element);
+}
+
+.oc-synced-from__row-body {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.oc-synced-from__title {
+	font-weight: 600;
+	font-size: 14px;
+	color: var(--color-main-text);
+	text-decoration: none;
+}
+
+.oc-synced-from__title[href]:hover {
+	text-decoration: underline;
+	color: var(--color-primary-element);
+}
+
+.oc-synced-from__subtitle {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+
+.oc-synced-from__origin {
+	font-size: 11px;
+	color: var(--color-text-maxcontrast);
+}
+
+.oc-synced-from__origin code {
+	font-size: 11px;
+}
+</style>

--- a/src/views/wrappers/MappingRulesEditor.vue
+++ b/src/views/wrappers/MappingRulesEditor.vue
@@ -607,7 +607,7 @@ export default {
 			// presses keep moving the same logical row.
 			this.$nextTick(() => {
 				const rows = this.$el.querySelectorAll(
-					`section.cn-rules-editor__panel .cn-rules-editor__row`,
+					'section.cn-rules-editor__panel .cn-rules-editor__row',
 				)
 				const row = rows[target]
 				if (row && typeof row.focus === 'function') row.focus()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,17 @@ webpackConfig.entry = {
 		import: path.join(__dirname, 'src', 'main.js'),
 		filename: appId + '-main.js',
 	},
+	// Path-2 leaf bundle: a tiny entry that registers OpenConnector's
+	// "Synced from" component on the OpenRegister integration registry.
+	// Loaded GLOBALLY on every NC page via \OCP\Util::addInitScript
+	// (lib/AppInfo/Application.php) so the component is present when a
+	// foreign app (e.g. OpenCatalogi) renders its object detail page —
+	// the main SPA bundle is never loaded there. Kept separate so the
+	// global script stays small.
+	integration: {
+		import: path.join(__dirname, 'src', 'integration.js'),
+		filename: appId + '-integration.js',
+	},
 	// adminSettings webpack entry removed in chain-C cutover. The
 	// per-app admin-settings UI is now part of the main SPA via the
 	// AppSettings manifest page (type: settings).


### PR DESCRIPTION
First real **Path-2 leaf** — a leaf shipping its own Vue component that renders inside *other* apps' object detail pages via the OpenRegister integration registry. Proves the `registerIntegration()` helper (ncv#438).

## What

- **`SynchronizationContractProvider::list()` enriched** — each row now carries `title` (resolved synchronization name, memoised to avoid N+1), `subtitle` ("Last synced <date> · <action>"), and `url` (deep-link to the sync editor) alongside the raw provenance fields. The generic `CnIntegrationCard` already reads title/subtitle/url, so this immediately improves the "Synced from" tab for every registry-adopting consumer (e.g. decidesk) — zero UI work.
- **`src/integration/SyncedFromTab.vue`** — bespoke component for the sidebar tab + detail/dashboard widget surfaces: source→sync→last-run layout, AD-23 degraded-state handling, deep-link.
- **`src/integration.js`** — tiny global entry that `registerIntegration()`s the component (id `sync-contract`). Separate webpack entry → `openconnector-integration.js`.
- **`Application.php`** — `BeforeTemplateRenderedEvent` listener `addInitScript()`s the global bundle on every page.

## Verified

From an **OpenCatalogi** page (foreign app): `openconnector-integration.js` loads ✓ and the `sync-contract` descriptor queues on the registry stub ✓ — the cross-app global-load mechanism works.

## Known follow-ups (separate)

1. **Bundle weight** — the integration bundle currently bundles Vue + nc-vue (~9MB). Externalize them so the global script stays small.
2. **Consumer adoption** — any leaf (generic or Path-2) only *renders* once the host app has adopted the registry (calls `installIntegrationRegistry()` at boot, as decidesk does). OpenCatalogi has not adopted it yet; lighting up the publication detail page is a one-time OpenCatalogi bootstrap addition.

phpcs/phpmd/psalm/phpstan clean on the touched PHP.