### PR TITLE
retrofit: drive openconnector spec-coverage to 0 (45 backend + 370 frontend)

### DIFF
--- a/lib/Controller/ConsumersController.php
+++ b/lib/Controller/ConsumersController.php
@@ -56,6 +56,8 @@ class ConsumersController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell render — returns the index template only, no domain behavior (framework lifecycle).
      */
     public function page(): TemplateResponse
     {

--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -123,6 +123,8 @@ class EndpointsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell render — returns the index template only, no domain behavior (framework lifecycle).
      */
     public function page(): TemplateResponse
     {

--- a/lib/Controller/EventsController.php
+++ b/lib/Controller/EventsController.php
@@ -68,6 +68,8 @@ class EventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell render — returns the index template only, no domain behavior (framework lifecycle).
      */
     public function page(): TemplateResponse
     {

--- a/lib/Controller/JobsController.php
+++ b/lib/Controller/JobsController.php
@@ -74,6 +74,8 @@ class JobsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell render — returns the index template only, no domain behavior (framework lifecycle).
      */
     public function page(): TemplateResponse
     {

--- a/lib/Controller/MappingsController.php
+++ b/lib/Controller/MappingsController.php
@@ -77,6 +77,8 @@ class MappingsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell render — returns the index template only, no domain behavior (framework lifecycle).
      */
     public function page(): TemplateResponse
     {

--- a/lib/Controller/PdokController.php
+++ b/lib/Controller/PdokController.php
@@ -62,6 +62,8 @@ class PdokController extends Controller
      * @param string $q Partial address text (min 1 char).
      *
      * @return JSONResponse Normalised suggestion documents or a 400 / 503 error envelope.
+     *
+     * @spec openspec/changes/add-pdok-adapter/tasks.md#OC-8
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -84,6 +86,8 @@ class PdokController extends Controller
      * @param string $id PDOK identifier.
      *
      * @return JSONResponse Normalised lookup payload, or 400 / 404 / 503.
+     *
+     * @spec openspec/changes/add-pdok-adapter/tasks.md#OC-8
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -123,6 +127,8 @@ class PdokController extends Controller
      * @param int    $start Page offset.
      *
      * @return JSONResponse Normalised results or 400 / 503.
+     *
+     * @spec openspec/changes/add-pdok-adapter/tasks.md#OC-8
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -146,6 +152,8 @@ class PdokController extends Controller
      * @param float|null $lng Longitude (WGS84).
      *
      * @return JSONResponse Normalised address or 400 / 503.
+     *
+     * @spec openspec/changes/add-pdok-adapter/tasks.md#OC-8
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]

--- a/lib/Controller/RulesController.php
+++ b/lib/Controller/RulesController.php
@@ -56,6 +56,8 @@ class RulesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell render — returns the index template only, no domain behavior (framework lifecycle).
      */
     public function page(): TemplateResponse
     {

--- a/lib/Controller/SourcesController.php
+++ b/lib/Controller/SourcesController.php
@@ -70,6 +70,8 @@ class SourcesController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse The rendered template response.
+     *
+     * @spec exclude SPA-shell render — returns the index template only, no domain behavior (framework lifecycle).
      */
     public function page(): TemplateResponse
     {

--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -84,6 +84,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function dashboard(): TemplateResponse
     {
@@ -100,6 +102,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function sources(): TemplateResponse
     {
@@ -116,6 +120,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function sourcesLogs(): TemplateResponse
     {
@@ -132,6 +138,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function endpoints(): TemplateResponse
     {
@@ -148,6 +156,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function endpointsLogs(): TemplateResponse
     {
@@ -166,6 +176,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function endpointsId(string $id): TemplateResponse
     {
@@ -182,6 +194,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function consumers(): TemplateResponse
     {
@@ -200,6 +214,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function consumersId(string $id): TemplateResponse
     {
@@ -216,6 +232,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function webhooks(): TemplateResponse
     {
@@ -232,6 +250,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function jobs(): TemplateResponse
     {
@@ -248,6 +268,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function jobsLogs(): TemplateResponse
     {
@@ -264,6 +286,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function mappings(): TemplateResponse
     {
@@ -282,6 +306,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function mappingsId(string $id): TemplateResponse
     {
@@ -298,6 +324,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function rules(): TemplateResponse
     {
@@ -316,6 +344,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function rulesId(string $id): TemplateResponse
     {
@@ -332,6 +362,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function synchronizations(): TemplateResponse
     {
@@ -348,6 +380,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function synchronizationsContracts(): TemplateResponse
     {
@@ -364,6 +398,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function synchronizationsLogs(): TemplateResponse
     {
@@ -380,6 +416,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function cloudEvents(): TemplateResponse
     {
@@ -396,6 +434,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function cloudEventsEvents(): TemplateResponse
     {
@@ -414,6 +454,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function cloudEventsEventsId(string $id): TemplateResponse
     {
@@ -430,6 +472,8 @@ class UiController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec exclude SPA-shell route handler — delegates to makeSpaResponse() returning the index template, no domain behavior (framework lifecycle).
      */
     public function cloudEventsLogs(): TemplateResponse
     {

--- a/lib/Service/ConfigurationHandlers/ConfigurationHandlerInterface.php
+++ b/lib/Service/ConfigurationHandlers/ConfigurationHandlerInterface.php
@@ -34,6 +34,8 @@ interface ConfigurationHandlerInterface
      * @param array<int, int|string>                                                           $mappingIds Collected mapping ids (out parameter).
      *
      * @return array The OpenAPI entity specification.
+     *
+     * @spec openspec/specs/configuration-export-import/spec.md#REQ-001
      */
     public function export(Entity $entity, array $mappings, array &$mappingIds=[]): array;
 
@@ -44,6 +46,8 @@ interface ConfigurationHandlerInterface
      * @param array<string,array{idToSlug:array<string,string>,slugToId:array<string,string>}> $mappings The global mappings for ID/slug conversion.
      *
      * @return Entity The imported entity.
+     *
+     * @spec openspec/specs/configuration-export-import/spec.md#REQ-003
      */
     public function import(array $data, array $mappings): Entity;
 
@@ -51,6 +55,8 @@ interface ConfigurationHandlerInterface
      * Get the entity type this handler is responsible for.
      *
      * @return string The entity type.
+     *
+     * @spec openspec/specs/configuration-export-import/spec.md#REQ-003
      */
     public function getEntityType(): string;
 }//end interface

--- a/lib/Service/IBabsConnectorService.php
+++ b/lib/Service/IBabsConnectorService.php
@@ -53,6 +53,8 @@ class IBabsConnectorService
      * @param ObjectEntity $source The iBabs source configuration.
      *
      * @return array Result with 'success' boolean and 'message' string.
+     *
+     * @spec openspec/changes/ibabs-notubiz-connector/specs/ibabs-notubiz-connector/spec.md#REQ-RIS-001
      */
     public function testConnection(ObjectEntity $source): array
     {
@@ -110,6 +112,8 @@ class IBabsConnectorService
      * @param array        $voorstel The voorstel data including document path and metadata.
      *
      * @return array Result with 'success' boolean and 'vergaderstukId'.
+     *
+     * @spec openspec/changes/ibabs-notubiz-connector/specs/ibabs-notubiz-connector/spec.md#REQ-RIS-002
      */
     public function pushVoorstel(ObjectEntity $source, array $voorstel): array
     {
@@ -148,6 +152,8 @@ class IBabsConnectorService
      * @param ObjectEntity $source The iBabs source configuration.
      *
      * @return array Array of besluit records with zaak references and status.
+     *
+     * @spec openspec/changes/ibabs-notubiz-connector/specs/ibabs-notubiz-connector/spec.md#REQ-RIS-031
      */
     public function pollBesluiten(ObjectEntity $source): array
     {
@@ -164,6 +170,8 @@ class IBabsConnectorService
      * @param string $ibabsStatus The iBabs besluit status.
      *
      * @return string The corresponding Procest zaak status.
+     *
+     * @spec openspec/changes/ibabs-notubiz-connector/specs/ibabs-notubiz-connector/spec.md#REQ-RIS-004
      */
     public function mapBesluitStatus(string $ibabsStatus): string
     {

--- a/lib/Service/Migration/LegacyToRegisterMigrator.php
+++ b/lib/Service/Migration/LegacyToRegisterMigrator.php
@@ -191,6 +191,8 @@ class LegacyToRegisterMigrator
      * @param integer     $batchSize  Default 10,000; valid range [100, 100000].
      *
      * @return array<array{slug:string,legacyCount:int,migratedCount:int,skipped:int,fkRewrites:int,elapsedMs:int}>
+     *
+     * @spec openspec/changes/openconnector-register-storage/specs/openconnector-storage-migration/spec.md
      */
     public function migrateAll(bool $dryRun=false, ?string $entitySlug=null, int $batchSize=10000): array
     {

--- a/lib/Service/StUFFieldMapper.php
+++ b/lib/Service/StUFFieldMapper.php
@@ -73,6 +73,8 @@ class StUFFieldMapper
      * @param array|null $mapping Custom field mapping (null uses defaults).
      *
      * @return array Array of StUF field name to value pairs.
+     *
+     * @spec openspec/changes/stuf-adapter/specs/stuf-adapter/spec.md#REQ-STUF-002
      */
     public function mapPersonToStUF(array $person, ?array $mapping=null): array
     {
@@ -108,6 +110,8 @@ class StUFFieldMapper
      * @param array|null $mapping  Custom field mapping (null uses defaults).
      *
      * @return array Array of OpenRegister property name to value pairs.
+     *
+     * @spec openspec/changes/stuf-adapter/specs/stuf-adapter/spec.md#REQ-STUF-002
      */
     public function mapStUFToPerson(array $stufData, ?array $mapping=null): array
     {
@@ -139,6 +143,8 @@ class StUFFieldMapper
      * @param array|null $mapping Custom address field mapping.
      *
      * @return array Array of StUF address field name to value pairs.
+     *
+     * @spec openspec/changes/stuf-adapter/specs/stuf-adapter/spec.md#REQ-STUF-004
      */
     public function mapAddressToStUF(array $address, ?array $mapping=null): array
     {
@@ -161,6 +167,8 @@ class StUFFieldMapper
      * @param string $isoDate The ISO 8601 date string (e.g., "1990-05-15").
      *
      * @return string The StUF date string (e.g., "19900515").
+     *
+     * @spec openspec/changes/stuf-adapter/specs/stuf-adapter/spec.md#REQ-STUF-053
      */
     public function isoDateToStUF(string $isoDate): string
     {
@@ -179,6 +187,8 @@ class StUFFieldMapper
      * @param string $stufDate The StUF date string (e.g., "19900515").
      *
      * @return string The ISO 8601 date string (e.g., "1990-05-15").
+     *
+     * @spec openspec/changes/stuf-adapter/specs/stuf-adapter/spec.md#REQ-STUF-053
      */
     public function stufDateToISO(string $stufDate): string
     {

--- a/openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/proposal.md
@@ -1,0 +1,19 @@
+# Retrofit — app-shell-and-logs-ui
+
+Describes the observed behaviour of 20 frontend methods under the
+`app-shell-and-logs-ui` cluster as 3 new REQs. Code already exists — this change
+retroactively specifies it. Source: `openspec/coverage-report.md` generated
+2026-05-25, frontend coverage gap.
+
+## Affected code units
+
+- src/App.vue
+- src/modals/v2/ModalHost.vue
+- src/views/wrappers/LogIndex.vue
+
+## Approach
+
+- Group the 20 methods by observable behaviour into 3 REQs (≤5 per ADR-032).
+- Draft REQs that match observed behaviour (not aspirational).
+
+Source: openspec/coverage-report.md generated 2026-05-25. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/specs/app-shell-and-logs-ui/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/specs/app-shell-and-logs-ui/spec.md
@@ -1,0 +1,65 @@
+---
+retrofit: true
+---
+
+# app-shell-and-logs-ui
+
+The Vue application shell glue and the log viewer: the root component's permission
+resolution and translate adapter, the modal-host event bus that mounts v2 modals on
+demand, and the generic log index page (call logs / endpoint logs / job logs / sync
+logs). This spec describes the observed behaviour of the already-shipping components.
+
+## Requirements
+
+### REQ-SHELLUI-001: App-shell permission resolution and translate adapter
+
+The root component SHALL resolve the current user's effective permission list —
+injecting an `admin` marker when Nextcloud reports the user as an admin (since the
+boolean admin flag is not present in the permissions array) — and SHALL provide a
+translate adapter that closes over the app id for the design-system components.
+
+#### Scenario: Admin marker injection
+- WHEN the current user is a Nextcloud admin
+- THEN `permissions` returns the base permission array with `'admin'` appended
+
+#### Scenario: Translate adapter
+- WHEN a design-system component calls the injected translate function with a key
+- THEN `translateForApp` returns the openconnector-scoped translation (or the key on miss)
+
+Notes: `App.vue` (2).
+
+### REQ-SHELLUI-002: Modal-host event bus
+
+The modal host SHALL subscribe to the modal event bus on mount and unsubscribe on
+destroy, and open/close the test-mapping and add-endpoint-rule v2 modals in response
+to bus events, carrying the event payload (mapping / endpoint) into the modal state.
+
+#### Scenario: Opening a modal via the bus
+- WHEN an `open test mapping` / `open add endpoint rule` event fires
+- THEN `openTestMapping` / `openAddEndpointRule` sets the corresponding modal open with its payload
+
+#### Scenario: Bus lifecycle
+- WHEN the host mounts it subscribes; WHEN it is destroyed `beforeDestroy` unsubscribes
+
+Notes: `ModalHost.vue` (6).
+
+### REQ-SHELLUI-003: Log index viewer
+
+The log index page SHALL select a per-log-type configuration (call/endpoint/job/sync),
+expose title/description, render rows + total from the configured fetcher, paginate
+(page/size), refresh on mount and on filter changes, define the log table columns, and
+open a per-row detail modal.
+
+#### Scenario: Loading logs for a type
+- WHEN the page mounts for a given `logType`
+- THEN `config` resolves the type's fetcher and `refresh` loads `rows`/`total`
+
+#### Scenario: Pagination
+- WHEN the user changes page or page size
+- THEN `onPageChanged` / `onPageSizeChanged` update state and re-fetch via `refresh`
+
+#### Scenario: Row detail
+- WHEN the user opens a log row
+- THEN `openDetail` stores the row and opens the configured detail modal
+
+Notes: `LogIndex.vue` (12).

--- a/openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: retrofit-2026-05-25-app-shell-and-logs-ui
+
+> Retrofit change. Each task records a retroactive annotation of already-existing code, not new implementation work. All boxes are checked because the behaviour ships today. ADR-032 cap respected (≤5).
+
+- [x] task-1: app-shell-and-logs-ui#REQ-SHELLUI-001 — App-shell permission resolution and translate adapter (retroactive annotation)
+- [x] task-2: app-shell-and-logs-ui#REQ-SHELLUI-002 — Modal-host event bus (retroactive annotation)
+- [x] task-3: app-shell-and-logs-ui#REQ-SHELLUI-003 — Log index viewer (retroactive annotation)

--- a/openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/proposal.md
@@ -1,0 +1,21 @@
+# Retrofit — endpoint-job-editor-ui
+
+Describes the observed behaviour of 27 frontend methods under the
+`endpoint-job-editor-ui` cluster as 5 new REQs. Code already exists — this change
+retroactively specifies it. Source: `openspec/coverage-report.md` generated
+2026-05-25, frontend coverage gap.
+
+## Affected code units
+
+- src/modals/Endpoint/EditEndpoint.vue
+- src/modals/v2/JobFormFields.vue
+- src/modals/Job/RunJob.vue
+- src/modals/Job/TestJob.vue
+- src/modals/TestSource/TestSource.vue
+
+## Approach
+
+- Group the 27 methods by observable behaviour into 5 REQs (≤5 per ADR-032).
+- Draft REQs that match observed behaviour (not aspirational).
+
+Source: openspec/coverage-report.md generated 2026-05-25. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/specs/endpoint-job-editor-ui/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/specs/endpoint-job-editor-ui/spec.md
@@ -1,0 +1,78 @@
+---
+retrofit: true
+---
+
+# endpoint-job-editor-ui
+
+The Vue surface for authoring endpoints and jobs and for running/testing jobs and
+sources: the endpoint edit modal, the job form fields, the run-job / test-job
+modals, and the test-source modal. This spec describes the observed behaviour of the
+already-shipping components.
+
+## Requirements
+
+### REQ-EPJOBUI-001: Endpoint edit modal
+
+The endpoint edit modal SHALL initialise an endpoint draft, fetch the available
+registers/schemas/configurations, derive schema options for the selected register,
+and persist the endpoint through the store. It supports closing and re-deriving
+options on update.
+
+#### Scenario: Editing an endpoint
+- WHEN the user fills the modal and saves
+- THEN `editEndpoint` persists the endpoint and the modal closes
+
+#### Scenario: Register selection derives schema options
+- WHEN a register is selected
+- THEN `setSchemaOptions` populates the schema selector for that register
+
+Notes: `EditEndpoint.vue` (9 methods/lifecycle).
+
+### REQ-EPJOBUI-002: Job form fields
+
+The job form SHALL present job-class options, conditionally show an arguments field,
+let the user pick a synchronization, render typed argument fields, and serialise/parse
+JSON argument values. It loads synchronizations on demand and relays picks to the parent.
+
+#### Scenario: Selecting a job class
+- WHEN the user picks a job class via `onJobClassPick`
+- THEN the selected class is recorded and `hasArgumentsField` decides whether the args field shows
+
+#### Scenario: JSON argument round-trips
+- WHEN the user edits a JSON argument field
+- THEN `jsonStringFor`/`onJsonInput` serialise and parse the value, rejecting malformed JSON
+
+Notes: `JobFormFields.vue` (11).
+
+### REQ-EPJOBUI-003: Run a job
+
+The run-job modal SHALL trigger a job run against the backend, surface success/error,
+and close.
+
+#### Scenario: Running a job
+- WHEN the user confirms the run-job modal
+- THEN `runJob` invokes the backend and the outcome is surfaced
+
+Notes: `RunJob.vue` (2).
+
+### REQ-EPJOBUI-004: Test a job
+
+The test-job modal SHALL trigger a job dry-run against the backend, surface the
+result, and close.
+
+#### Scenario: Testing a job
+- WHEN the user confirms the test-job modal
+- THEN `testJob` invokes the backend dry-run and the result is surfaced
+
+Notes: `TestJob.vue` (2).
+
+### REQ-EPJOBUI-005: Test a source
+
+The test-source modal SHALL issue a test call against the configured source, prettify
+the JSON response for display, surface errors, and close.
+
+#### Scenario: Testing a source
+- WHEN the user confirms the test-source modal
+- THEN `testSource` invokes the backend test call and `prettifyJson` formats the response
+
+Notes: `TestSource.vue` (3).

--- a/openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: retrofit-2026-05-25-endpoint-job-editor-ui
+
+> Retrofit change. Each task records a retroactive annotation of already-existing code, not new implementation work. All boxes are checked because the behaviour ships today. ADR-032 cap respected (≤5).
+
+- [x] task-1: endpoint-job-editor-ui#REQ-EPJOBUI-001 — Endpoint edit modal (retroactive annotation)
+- [x] task-2: endpoint-job-editor-ui#REQ-EPJOBUI-002 — Job form fields (retroactive annotation)
+- [x] task-3: endpoint-job-editor-ui#REQ-EPJOBUI-003 — Run a job (retroactive annotation)
+- [x] task-4: endpoint-job-editor-ui#REQ-EPJOBUI-004 — Test a job (retroactive annotation)
+- [x] task-5: endpoint-job-editor-ui#REQ-EPJOBUI-005 — Test a source (retroactive annotation)

--- a/openspec/changes/retrofit-2026-05-25-mapping-editor-ui/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-mapping-editor-ui/proposal.md
@@ -1,0 +1,31 @@
+# Retrofit — mapping-editor-ui
+
+Describes the observed behaviour of 95 frontend methods under the
+`mapping-editor-ui` cluster as 5 new REQs. Code already exists — this change
+retroactively specifies it. Source: `openspec/coverage-report.md` generated
+2026-05-25, frontend coverage gap.
+
+## Motivation
+
+The mapping authoring + testing UI (detail page, rule editor, edit dialog, test
+modals, result panel) is core platform behaviour with no spec coverage. It is an
+openconnector-local Vue surface, so it gets a foundational capability spec under
+`openspec/specs/`.
+
+## Affected code units
+
+- src/views/wrappers/MappingDetailPage.vue
+- src/views/wrappers/MappingRulesEditor.vue
+- src/views/wrappers/EditMappingRuleDialog.vue
+- src/modals/MappingTest/TestMapping.vue
+- src/modals/MappingTest/components/TestMappingInputObject.vue
+- src/modals/MappingTest/components/TestMappingMappingSelect.vue
+- src/modals/MappingTest/components/TestMappingResult.vue
+- src/modals/v2/TestMappingModal.vue
+
+## Approach
+
+- Group the 95 methods by observable behaviour into 5 REQs (≤5 per ADR-032).
+- Draft REQs that match observed behaviour (not aspirational).
+
+Source: openspec/coverage-report.md generated 2026-05-25. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-25-mapping-editor-ui/specs/mapping-editor-ui/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-mapping-editor-ui/specs/mapping-editor-ui/spec.md
@@ -1,0 +1,99 @@
+---
+retrofit: true
+---
+
+# mapping-editor-ui
+
+The Vue surface for authoring and testing OpenConnector mappings: the mapping
+detail page, the mapping/cast/unset rule editor, the edit-rule dialog, and the
+test-mapping modals (input object, mapping/schema selectors, result panel). This
+spec describes the observed behaviour of the already-shipping components.
+
+## Requirements
+
+### REQ-MAPUI-001: Mapping detail page load, edit, and persistence
+
+The mapping detail page SHALL resolve the active mapping from the object store,
+expose its title/description/pass-through flag, render derived rule collections
+(mapping, cast, unset), surface load errors, and persist field/rule patches back
+through the store. It registers the object type on creation and reloads on id change.
+
+#### Scenario: Detail page loads a mapping
+- WHEN the page mounts with a mapping id
+- THEN `ensureRegistered` registers the object type and the mapping is fetched into the store
+
+#### Scenario: A field or rule change is persisted
+- WHEN the user toggles pass-through or edits rules
+- THEN `persistPatch` writes the patch to the store and the derived collections update
+
+#### Scenario: Load failure surfaces a message
+- WHEN the fetch fails
+- THEN `loadError`/`errorMessage` expose the failure and `reload` re-issues the fetch
+
+Notes: `MappingDetailPage.vue` (30 methods/computeds/watchers/lifecycle).
+
+### REQ-MAPUI-002: Mapping / cast / unset rule editing
+
+The rule editor SHALL render mapping, cast, and unset rules as tabbed, reorderable
+row lists, support create/edit/delete per kind, prevent duplicate keys, and commit
+changes (key rename, value change, reorder) back to the parent as updated rule maps.
+
+#### Scenario: Creating a rule
+- WHEN the user invokes `openCreate(kind)` and submits the dialog
+- THEN `commitMapping`/`commitCast`/`commitUnset` adds the new rule and emits the updated collection
+
+#### Scenario: Reordering rules
+- WHEN the user reorders rows or invokes `moveRow`
+- THEN the rule order is updated and emitted to the parent
+
+#### Scenario: Deleting a rule
+- WHEN the user invokes `deleteRule`/`deleteUnset`
+- THEN the rule is removed and the updated collection is emitted
+
+Notes: `MappingRulesEditor.vue` (19).
+
+### REQ-MAPUI-003: Edit-mapping-rule dialog with validation
+
+The edit-rule dialog SHALL adapt its fields to the rule kind (mapping/cast/unset),
+offer cast-type options, validate the property key (required, no duplicate), compute
+contextual title/labels/placeholders/help, and emit a submit payload only when valid.
+
+#### Scenario: Submit guarded by validation
+- WHEN the property key is empty or duplicates an existing key
+- THEN `canSubmit` is false and `propertyError` describes the problem
+
+#### Scenario: Cast type selection
+- WHEN the user picks a cast type via `onCastTypeInput`
+- THEN the selected cast value is recorded for the submit payload
+
+Notes: `EditMappingRuleDialog.vue` (12).
+
+### REQ-MAPUI-004: Test-mapping execution and result rendering
+
+The test-mapping surface SHALL collect an input object (validating JSON), let the
+user select a mapping and target schema, run the mapping test against the backend,
+and render the transformed result. It loads mappings/schemas on open, guards the run
+when inputs are incomplete, and surfaces validation errors.
+
+#### Scenario: Running a mapping test
+- WHEN the user supplies a valid input object and selects a mapping, then runs the test
+- THEN `testMapping`/`runTest` posts to the backend and the result panel renders the output
+
+#### Scenario: Invalid input JSON blocks the test
+- WHEN the input object is not valid JSON
+- THEN `validJson` reports the error and the test is not run
+
+Notes: `TestMapping.vue` (5), `TestMappingInputObject.vue` (2),
+`TestMappingMappingSelect.vue` (14), `TestMappingResult.vue` partial (2),
+`v2/TestMappingModal.vue` (10).
+
+### REQ-MAPUI-005: Persist a mapped result as an OpenRegister object
+
+The result panel SHALL let the user pick a target register and save the transformed
+mapping output as an OpenRegister object.
+
+#### Scenario: Saving the mapped result
+- WHEN the user selects a register and invokes save
+- THEN `saveObject` persists the transformed payload as a new object in the chosen register
+
+Notes: `TestMappingResult.vue` `fetchRegisters` + `saveObject` (1 of its 3 methods is `setup`, covered under REQ-MAPUI-004).

--- a/openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: retrofit-2026-05-25-mapping-editor-ui
+
+> Retrofit change. Each task records a retroactive annotation of already-existing code, not new implementation work. All boxes are checked because the behaviour ships today. ADR-032 cap respected (≤5).
+
+- [x] task-1: mapping-editor-ui#REQ-MAPUI-001 — Mapping detail page load, edit, and persistence (retroactive annotation)
+- [x] task-2: mapping-editor-ui#REQ-MAPUI-002 — Mapping / cast / unset rule editing (retroactive annotation)
+- [x] task-3: mapping-editor-ui#REQ-MAPUI-003 — Edit-mapping-rule dialog with validation (retroactive annotation)
+- [x] task-4: mapping-editor-ui#REQ-MAPUI-004 — Test-mapping execution and result rendering (retroactive annotation)
+- [x] task-5: mapping-editor-ui#REQ-MAPUI-005 — Persist a mapped result as an OpenRegister object (retroactive annotation)

--- a/openspec/changes/retrofit-2026-05-25-rule-editor-ui/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-rule-editor-ui/proposal.md
@@ -1,0 +1,32 @@
+# Retrofit — rule-editor-ui
+
+Describes the observed behaviour of 144 frontend methods under the
+`rule-editor-ui` cluster as 5 new REQs. Code already exists — this change
+retroactively specifies it. Source: `openspec/coverage-report.md` generated
+2026-05-25, frontend coverage gap.
+
+## Motivation
+
+The rule authoring UI (detail page, JsonLogic condition tree, action-type forms,
+edit modal, endpoint-attach dialogs) is core platform behaviour with no spec
+coverage. It is an openconnector-local Vue surface (no OpenRegister equivalent),
+so it gets a foundational capability spec under `openspec/specs/`.
+
+## Affected code units
+
+- src/views/Rule/RuleDetailPage.vue
+- src/views/Rule/RuleConditionGroup.vue
+- src/views/Rule/RuleConditionLeaf.vue
+- src/views/Rule/RuleActionConfig.vue
+- src/views/Rule/actionForms/*.vue (14 forms)
+- src/modals/Rule/EditRule.vue
+- src/modals/Endpoint/AddEndpointRule.vue
+- src/modals/v2/AddEndpointRuleModal.vue
+
+## Approach
+
+- Group the 144 methods by observable behaviour into 5 REQs (≤5 per ADR-032).
+- Draft REQs that match observed behaviour (not aspirational).
+- Notes sections record the file-to-REQ mapping.
+
+Source: openspec/coverage-report.md generated 2026-05-25. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-25-rule-editor-ui/specs/rule-editor-ui/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-rule-editor-ui/specs/rule-editor-ui/spec.md
@@ -1,0 +1,115 @@
+---
+retrofit: true
+---
+
+# rule-editor-ui
+
+The Vue surface for authoring OpenConnector rules: the rule detail page, the
+JsonLogic condition-tree editor, the action-type configuration panel with its
+per-action-type forms, the rule edit modal, and the dialogs that attach existing
+rules to an endpoint. This spec describes the observed behaviour of the
+already-shipping components.
+
+## Requirements
+
+### REQ-RULEUI-001: Rule detail page load, edit, and save lifecycle
+
+The rule detail page SHALL fetch the active rule, expose its fields for editing,
+track a dirty flag, normalise the rule's `conditions` between string/array/object
+representations, and persist changes through the object store. Save and cancel
+actions reset or restore local state; a load failure surfaces an error message
+with a retry affordance.
+
+#### Scenario: Editing a field marks the page dirty
+- WHEN the user changes a rule field via `updateField`
+- THEN the local copy is updated AND the `dirty` computed flag becomes true
+
+#### Scenario: Conditions are normalised on input
+- WHEN the user types raw conditions JSON
+- THEN `normaliseConditions` parses string/array/object/`and`/`or` shapes into the
+  canonical condition tree, and an empty value yields an empty condition set
+
+#### Scenario: Load failure offers retry
+- WHEN the initial `load()` fails
+- THEN an error message is shown AND `onRetry` re-issues the fetch
+
+Notes: `RuleDetailPage.vue` (16 methods/computeds/watchers).
+
+### REQ-RULEUI-002: JsonLogic condition-tree editing
+
+The condition editor SHALL render a recursive tree of `and`/`or` groups and leaf
+conditions. Group nodes support operator selection, adding leaves/sub-groups, and
+removing children. Leaf nodes resolve the active operator's argument schema
+(unary/binary/var), parse JSON slot values, coerce typed values, and emit
+structured update patches to the parent.
+
+#### Scenario: Adding a child to a group
+- WHEN the user invokes `addLeaf` or `addGroup` on a condition group
+- THEN a new child node is appended and an update is emitted to the parent
+
+#### Scenario: Operator change reshapes leaf arguments
+- WHEN the user picks a different operator on a leaf via `onOperatorPick`
+- THEN `argsForKind` rebuilds the argument slots for the new operator kind, carrying
+  forward the prior var/value where compatible, and `emitUpdate` propagates the patch
+
+#### Scenario: Invalid JSON slot input is rejected gracefully
+- WHEN the user enters non-array/non-JSON text into a JSON slot
+- THEN the malformed value is not committed to the condition tree
+
+Notes: `RuleConditionGroup.vue` (11), `RuleConditionLeaf.vue` (19).
+
+### REQ-RULEUI-003: Action-type configuration and per-action-type forms
+
+The action configuration panel SHALL present the available rule action types,
+swap in the matching action form component for the selected type, and relay the
+form's slot updates (mapping id, JavaScript code, raw JSON) back to the rule. Each
+action form (authentication, mapping, save-object, synchronization, file fetch/write,
+filepart create/upload, locking, download, error, extend-input, extend-external-input,
+upload) reads and emits its own action-specific configuration shape.
+
+#### Scenario: Selecting an action type swaps the form
+- WHEN the user picks an action type via `onTypePick`
+- THEN `formComponent` resolves to the matching action form and the action config is reset/seeded for that type
+
+#### Scenario: A form edits only its own configuration shape
+- WHEN the user edits a field in an action form (e.g. authentication type, mapping id, file path)
+- THEN the form emits an update carrying only that action's configuration keys
+
+Notes: `RuleActionConfig.vue` (12) + 14 actionForms (`AuthenticationForm`,
+`DownloadForm`, `ErrorForm`, `ExtendExternalInputForm`, `ExtendInputForm`,
+`FetchFileForm`, `FilepartUploadForm`, `FilepartsCreateForm`, `LockingForm`,
+`MappingForm`, `SaveObjectForm`, `SynchronizationForm`, `UploadForm`, `WriteFileForm`).
+
+### REQ-RULEUI-004: Rule edit modal with dynamic list management
+
+The rule edit modal SHALL load an existing rule (or initialise a blank one), bind
+its action-type-specific fields, and manage dynamic repeating lists (API keys,
+header/property mappings) by auto-appending a blank trailing row and pruning empty
+interior rows as the user types.
+
+#### Scenario: Auto-append a blank row
+- WHEN the user fills the last row of a dynamic list (API keys / mappings)
+- THEN a new blank trailing row is appended automatically
+
+#### Scenario: Prune empty interior rows
+- WHEN an interior row of a dynamic list is left empty
+- THEN that empty row is removed, keeping only filled rows plus the trailing blank
+
+Notes: `EditRule.vue` (22).
+
+### REQ-RULEUI-005: Attach existing rules to an endpoint
+
+The add-endpoint-rule dialogs SHALL fetch the available rules, let the user select
+one or more, and persist the selection onto the endpoint object via the OpenRegister
+object API. Success and failure are surfaced via toast notifications; the dialog
+guards save when nothing is selected or the endpoint id is missing.
+
+#### Scenario: Save attaches selected rules to the endpoint
+- WHEN the user confirms a selection and an endpoint id is present
+- THEN the endpoint object is updated with the chosen rule ids and a success toast shows
+
+#### Scenario: Save is guarded
+- WHEN no rule is selected or the endpoint id is missing
+- THEN `onSave` is a no-op
+
+Notes: `AddEndpointRule.vue` (3), `v2/AddEndpointRuleModal.vue` (9).

--- a/openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: retrofit-2026-05-25-rule-editor-ui
+
+> Retrofit change. Each task records a retroactive annotation of already-existing code, not new implementation work. All boxes are checked because the behaviour ships today. ADR-032 cap respected (≤5).
+
+- [x] task-1: rule-editor-ui#REQ-RULEUI-001 — Rule detail page load, edit, and save lifecycle (retroactive annotation)
+- [x] task-2: rule-editor-ui#REQ-RULEUI-002 — JsonLogic condition-tree editing (retroactive annotation)
+- [x] task-3: rule-editor-ui#REQ-RULEUI-003 — Action-type configuration and per-action-type forms (retroactive annotation)
+- [x] task-4: rule-editor-ui#REQ-RULEUI-004 — Rule edit modal with dynamic list management (retroactive annotation)
+- [x] task-5: rule-editor-ui#REQ-RULEUI-005 — Attach existing rules to an endpoint (retroactive annotation)

--- a/openspec/changes/retrofit-2026-05-25-sync-editor-ui/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-sync-editor-ui/proposal.md
@@ -1,0 +1,31 @@
+# Retrofit — sync-editor-ui
+
+Describes the observed behaviour of 84 frontend methods under the
+`sync-editor-ui` cluster as 5 new REQs. Code already exists — this change
+retroactively specifies it. Source: `openspec/coverage-report.md` generated
+2026-05-25, frontend coverage gap.
+
+## Motivation
+
+The synchronization authoring + run/test UI (detail page, config widget, mapping
+picker/preview, reference list, edit/run/test modals) is core platform behaviour
+with no spec coverage. It is an openconnector-local Vue surface, so it gets a
+foundational capability spec under `openspec/specs/`.
+
+## Affected code units
+
+- src/views/Synchronization/SynchronizationDetailPage.vue
+- src/views/Synchronization/SyncConfigWidget.vue
+- src/views/Synchronization/SyncMappingPicker.vue
+- src/views/Synchronization/SyncMappingPreview.vue
+- src/views/Synchronization/SyncReferenceList.vue
+- src/modals/Synchronization/EditSynchronization.vue
+- src/modals/Synchronization/RunSynchronization.vue
+- src/modals/Synchronization/TestSynchronization.vue
+
+## Approach
+
+- Group the 84 methods by observable behaviour into 5 REQs (≤5 per ADR-032).
+- Draft REQs that match observed behaviour (not aspirational).
+
+Source: openspec/coverage-report.md generated 2026-05-25. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-25-sync-editor-ui/specs/sync-editor-ui/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-sync-editor-ui/specs/sync-editor-ui/spec.md
@@ -1,0 +1,103 @@
+---
+retrofit: true
+---
+
+# sync-editor-ui
+
+The Vue surface for authoring, configuring, previewing, and running OpenConnector
+synchronizations: the synchronization detail page, the source/target config widget,
+the mapping picker + live preview, the reference list, the edit modal, and the
+run/test modals. This spec describes the observed behaviour of the already-shipping
+components.
+
+## Requirements
+
+### REQ-SYNCUI-001: Synchronization detail page load, edit, conditions, and save
+
+The synchronization detail page SHALL load the active synchronization, expose its
+fields and source/target type selectors, normalise its `conditions` into a JsonLogic
+group (string/array/object), track a dirty flag via normalised diff, and persist
+edits. It guards save when invalid and supports reset.
+
+#### Scenario: Editing marks the page dirty
+- WHEN the user changes a field via `updateDraft` or the condition tree
+- THEN `normalizeForDiff` recomputes and `dirty` becomes true
+
+#### Scenario: Conditions normalisation and serialisation
+- WHEN conditions are loaded or edited
+- THEN `normaliseConditions`/`serializeConditions` round-trip between the stored value and the visual group editor
+
+#### Scenario: Save guarded and reset
+- WHEN `canSave` is false the save is blocked; WHEN the user resets, `resetEdits` restores the loaded state
+
+Notes: `SynchronizationDetailPage.vue` (27 methods/computeds/watchers/setup).
+
+### REQ-SYNCUI-002: Source / target configuration widget
+
+The config widget SHALL present source-kind-specific configuration (API source,
+register+schema, file path), fetch the available sources and registers, derive schema
+options for the chosen register, relay config-key updates to the parent, and open a
+file picker for file-based sources.
+
+#### Scenario: Picking a register populates schema options
+- WHEN the user selects a register via `onRegisterPick`
+- THEN `schemaOptions` is derived for that register and `selectedSchema` resolves
+
+#### Scenario: Config updates are relayed
+- WHEN the user edits a config field via `onConfigUpdate`
+- THEN the updated config key/value is emitted to the parent
+
+#### Scenario: File source opens a picker
+- WHEN the source is file-based and the user opens the picker
+- THEN `openFilePicker` resolves a path into the file-path config field
+
+Notes: `SyncConfigWidget.vue` (19).
+
+### REQ-SYNCUI-003: Mapping picker, live preview, and reference list
+
+The mapping picker SHALL select primary/reverse/hash mappings (fetched on demand);
+the preview panel SHALL run a debounced live mapping preview against the backend and
+render the result; the reference list SHALL manage a multi-select of reference ids
+with fetched options.
+
+#### Scenario: Selecting mappings
+- WHEN the user picks a primary/reverse/hash mapping
+- THEN the selection resolves against fetched options and is emitted
+
+#### Scenario: Debounced preview
+- WHEN the user changes the preview input
+- THEN `scheduleRun`/`runPreview` posts to the backend after the debounce and renders the result
+
+Notes: `SyncMappingPicker.vue` (8), `SyncMappingPreview.vue` (9),
+`SyncReferenceList.vue` (5).
+
+### REQ-SYNCUI-004: Synchronization edit modal
+
+The edit modal SHALL load source/register/schema/rule/mapping option collections,
+react to source-type changes, install OpenRegister on demand, and submit the
+synchronization through the store. It supports launching the test flow and closing.
+
+#### Scenario: Editing a synchronization
+- WHEN the user fills the modal and submits
+- THEN `editSynchronization` persists the synchronization and the modal closes
+
+#### Scenario: Option collections load
+- WHEN the modal mounts
+- THEN `getSources`/`getRegisterWithSchemas`/`getSourceTargetMappings`/`getRules` populate the selectors
+
+Notes: `EditSynchronization.vue` (12).
+
+### REQ-SYNCUI-005: Run and test a synchronization
+
+The run and test modals SHALL trigger a synchronization run (or dry-run test) against
+the backend, surface the result/log, and close.
+
+#### Scenario: Running a synchronization
+- WHEN the user confirms the run modal
+- THEN `runSynchronization` invokes the backend run and the result is surfaced
+
+#### Scenario: Testing a synchronization
+- WHEN the user confirms the test modal
+- THEN `testSynchronization` invokes the backend dry-run and the result is surfaced
+
+Notes: `RunSynchronization.vue` (2), `TestSynchronization.vue` (2).

--- a/openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: retrofit-2026-05-25-sync-editor-ui
+
+> Retrofit change. Each task records a retroactive annotation of already-existing code, not new implementation work. All boxes are checked because the behaviour ships today. ADR-032 cap respected (≤5).
+
+- [x] task-1: sync-editor-ui#REQ-SYNCUI-001 — Synchronization detail page load, edit, conditions, and save (retroactive annotation)
+- [x] task-2: sync-editor-ui#REQ-SYNCUI-002 — Source / target configuration widget (retroactive annotation)
+- [x] task-3: sync-editor-ui#REQ-SYNCUI-003 — Mapping picker, live preview, and reference list (retroactive annotation)
+- [x] task-4: sync-editor-ui#REQ-SYNCUI-004 — Synchronization edit modal (retroactive annotation)
+- [x] task-5: sync-editor-ui#REQ-SYNCUI-005 — Run and test a synchronization (retroactive annotation)

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,7 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-1 */
 		permissions() {
 			const base = window.OC?.currentUser?.permissions ?? []
 			// CnAppNav's permission filter is an array-includes check; Nextcloud
@@ -66,6 +67,8 @@ export default {
 		 *
 		 * @param {string} key Translation key.
 		 * @return {string} Translated string (or the key on miss).
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-1
 		 */
 		translateForApp(key) {
 			return ncT('openconnector', key)

--- a/src/modals/Endpoint/AddEndpointRule.vue
+++ b/src/modals/Endpoint/AddEndpointRule.vue
@@ -90,6 +90,7 @@ export default {
 		this.loadAvailableRules()
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		async loadAvailableRules() {
 			this.loading = true
 
@@ -113,6 +114,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		async addRule() {
 			if (!this.ruleOptions.value) return
 
@@ -163,6 +165,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		closeModal() {
 			navigationStore.setModal(false)
 			clearTimeout(this.closeTimeoutFunc)

--- a/src/modals/Endpoint/EditEndpoint.vue
+++ b/src/modals/Endpoint/EditEndpoint.vue
@@ -200,12 +200,14 @@ export default {
 			this.setSchemaOptions(newVal)
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-1 */
 	mounted() {
 		this.initializeEndpointItem()
 		this.fetchRegisters()
 		this.fetchSchemas()
 		this.fetchConfigurations()
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-1 */
 	updated() {
 		if (navigationStore.modal === 'editEndpoint' && !this.hasUpdated) {
 			this.initializeEndpointItem()
@@ -214,6 +216,7 @@ export default {
 		}
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-1 */
 		initializeEndpointItem() {
 			if (endpointStore.endpointItem?.id) {
 				this.endpointItem = {
@@ -245,6 +248,7 @@ export default {
 				}
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-1 */
 		closeModal() {
 			navigationStore.setModal(false)
 			clearTimeout(this.closeTimeoutFunc)
@@ -268,6 +272,7 @@ export default {
 			this.targetTypeOptions.value = { label: 'register/schema' }
 			this.initialSchemaSet = false
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-1 */
 		async fetchRegisters() {
 			this.registersLoading = true
 
@@ -320,6 +325,7 @@ export default {
 
 			this.registersLoading = false
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-1 */
 		async fetchSchemas() {
 			this.schemasLoading = true
 
@@ -355,6 +361,7 @@ export default {
 
 			this.schemasLoading = false
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-1 */
 		async fetchConfigurations() {
 			this.configurationsLoading = true
 
@@ -398,6 +405,7 @@ export default {
 				this.configurationsLoading = false
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-1 */
 		setSchemaOptions(register) {
 			const schemaId = endpointStore.endpointItem?.targetId.split('/')[1]
 
@@ -423,6 +431,7 @@ export default {
 			this.initialSchemaSet = true
 
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-1 */
 		async editEndpoint() {
 			this.loading = true
 

--- a/src/modals/Job/RunJob.vue
+++ b/src/modals/Job/RunJob.vue
@@ -129,12 +129,14 @@ export default {
 		}
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-3 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.success = false
 			this.loading = false
 			this.error = false
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-3 */
 		async runJob() {
 			this.loading = true
 

--- a/src/modals/Job/TestJob.vue
+++ b/src/modals/Job/TestJob.vue
@@ -130,12 +130,14 @@ export default {
 		}
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-4 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.success = false
 			this.loading = false
 			this.error = false
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-4 */
 		async testJob() {
 			this.loading = true
 

--- a/src/modals/MappingTest/TestMapping.vue
+++ b/src/modals/MappingTest/TestMapping.vue
@@ -70,20 +70,24 @@ export default {
 		}
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		receiveInputObject(value) {
 			this.inputObject = value
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		receiveMappingSelected(value) {
 			value.selected && (this.mapping.selected = value.selected)
 			value.mappings && (this.mapping.mappings = value.mappings)
 			value.loading !== undefined && (this.mapping.loading = value.loading) // boolean
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		receiveMappingTest(value) {
 			value.result && (this.mappingTest.result = value.result)
 			value.success !== undefined && (this.mappingTest.success = value.success) // boolean
 			value.loading !== undefined && (this.mappingTest.loading = value.loading) // boolean
 			value.error !== undefined && (this.mappingTest.error = value.error) // boolean / string
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		receiveSchemaSelected(value) {
 			value?.selected !== undefined && (this.schema.selected = value.selected)
 			value.schemas && (this.schema.schemas = value.schemas)
@@ -91,6 +95,7 @@ export default {
 			value.loading !== undefined && (this.schema.loading = value.loading) // boolean
 			value.error !== undefined && (this.schema.error = value.error) // boolean / string
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		closeModal() {
 			navigationStore.setModal(false)
 		},

--- a/src/modals/MappingTest/components/TestMappingInputObject.vue
+++ b/src/modals/MappingTest/components/TestMappingInputObject.vue
@@ -34,6 +34,7 @@ export default {
 		}
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		emitInputObjectChanged(event) {
 			const data = {
 				value: event.target.value,
@@ -41,6 +42,7 @@ export default {
 			}
 			this.$emit('input-object-changed', data)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		validJson(object) {
 			try {
 				JSON.parse(object)

--- a/src/modals/MappingTest/components/TestMappingMappingSelect.vue
+++ b/src/modals/MappingTest/components/TestMappingMappingSelect.vue
@@ -280,6 +280,7 @@ export default {
 		},
 		// watch data and emit
 		mappingTest: {
+			/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 			handler(newVal) {
 				this.$emit('mapping-test', {
 					...newVal,
@@ -287,35 +288,42 @@ export default {
 			},
 			deep: true,
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		mappingsLoading(newVal) {
 			this.$emit('mapping-selected', {
 				loading: newVal,
 			})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		schemasLoading(newVal) {
 			this.$emit('schema-selected', {
 				loading: newVal,
 			})
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 	mounted() {
 		this.fetchMappings()
 		this.fetchSchemas()
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		closeModal() {
 			this.$emit('close-modal')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		emitMappingSelected(event) {
 			this.$emit('mapping-selected', {
 				selected: event,
 			})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		emitSchemaSelected(event) {
 			this.$emit('schema-selected', {
 				selected: event,
 			})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		setupEditFields(id) {
 			if (id === this.uniqueMappingId) { // "No mapping" option selected (Symbol comparisons can only return true if its the same symbol from the same variable)
 				this.mappingItem = {
@@ -333,6 +341,7 @@ export default {
 				this.mappingItem.unset = this.mappings.value.fullMapping.unset.join(', ') // turn the array into a string
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		async fetchMappings(currentMappingItem = null) {
 			this.mappingsLoading = true
 
@@ -387,6 +396,7 @@ export default {
 					this.mappingsLoading = false
 				})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		async fetchSchemas() {
 			this.schemasLoading = true
 
@@ -435,6 +445,7 @@ export default {
 
 			this.schemasLoading = false
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		async testMapping() {
 			this.mappingTest.loading = true
 			this.mappingTest.error = false
@@ -464,6 +475,7 @@ export default {
 					this.mappingTest.loading = false
 				})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		saveMappingChanges() {
 			this.savingMapping = true
 
@@ -492,6 +504,7 @@ export default {
 					this.savingMapping = false
 				})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		async installOpenRegister() {
 			console.info('Installing Open Register')
 			const token = document.querySelector('head[data-requesttoken]').getAttribute('data-requesttoken')
@@ -522,6 +535,7 @@ export default {
 				this.fetchSchemas()
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		validJson(object, optional = false) {
 			if (optional && !object) {
 				return true

--- a/src/modals/MappingTest/components/TestMappingResult.vue
+++ b/src/modals/MappingTest/components/TestMappingResult.vue
@@ -150,6 +150,7 @@ export default {
 			required: true,
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 	setup() {
 		return {
 			mdiCheckCircle,
@@ -174,6 +175,7 @@ export default {
 		this.fetchRegisters()
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		fetchRegisters() {
 			this.fetchRegistersLoading = true
 
@@ -197,6 +199,7 @@ export default {
 					this.fetchRegistersLoading = false
 				})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-5 */
 		saveObject() {
 			this.saveObjectLoading = true
 			this.saveObjectSuccess = null

--- a/src/modals/Rule/EditRule.vue
+++ b/src/modals/Rule/EditRule.vue
@@ -832,6 +832,7 @@ export default {
 	},
 	watch: {
 		apiKeys: {
+			/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 			handler(newVal) {
 				const currentApiKeysLength = newVal.length
 
@@ -851,6 +852,7 @@ export default {
 		},
 		// Auto-add empty extend_input item when last one is filled
 		'ruleItem.configuration.extend_input.items': {
+			/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 			handler(newVal) {
 				if (!newVal || newVal.length === 0) return
 
@@ -873,6 +875,7 @@ export default {
 		},
 		// Auto-add empty extend_external_input property when last one is filled
 		'ruleItem.configuration.extend_external_input.properties': {
+			/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 			handler(newVal) {
 				if (!newVal || newVal.length === 0) return
 
@@ -897,6 +900,7 @@ export default {
 			deep: true,
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 	mounted() {
 
 		if (this.IS_EDIT) {
@@ -1039,6 +1043,7 @@ export default {
 		}
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		async getMappings() {
 			try {
 				this.mappingOptions.loading = true
@@ -1101,6 +1106,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		getSources() {
 			this.sourcesLoading = true
 
@@ -1128,6 +1134,7 @@ export default {
 					this.sourcesLoading = false
 				})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		async getSchemas() {
 			this.schemasLoading = true
 
@@ -1181,6 +1188,7 @@ export default {
 			this.schemasLoading = false
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		async getSynchronizations() {
 			try {
 				this.syncOptions.loading = true
@@ -1211,6 +1219,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		async getAllowedUsers() {
 			this.usersLoading = true
 			const response = await fetch('/ocs/v1.php/cloud/users/details', {
@@ -1257,6 +1266,7 @@ export default {
 			this.usersLoading = false
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		async getApiKeysUsers() {
 			this.usersLoading = true
 			const response = await fetch('/ocs/v1.php/cloud/users/details', {
@@ -1315,6 +1325,7 @@ export default {
 
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		async getGroups() {
 			this.groupsLoading = true
 			const response = await fetch('/ocs/v1.php/cloud/groups/details', {
@@ -1356,6 +1367,7 @@ export default {
 			this.groupsLoading = false
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		setMethodOptions() {
 			const options = [
 				{ label: 'GET' },
@@ -1371,6 +1383,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		setActionOptions() {
 			const options = [
 				{ label: 'Post (Create)', id: 'post' },
@@ -1385,6 +1398,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		setTimingOptions() {
 			const options = [
 				{ label: 'Before', id: 'before' },
@@ -1397,32 +1411,38 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		addExtendExternalItem() {
 			if (!this.ruleItem.configuration.extend_external_input) {
 				this.ruleItem.configuration.extend_external_input = { validate: true, properties: [] }
 			}
 			this.ruleItem.configuration.extend_external_input.properties.push({ property: '', schema: '' })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		removeExtendExternalItem(index) {
 			if (index === 0) return
 			this.ruleItem.configuration.extend_external_input.properties.splice(index, 1)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		addExtendInputItem() {
 			if (!this.ruleItem.configuration.extend_input) {
 				this.ruleItem.configuration.extend_input = { items: [] }
 			}
 			this.ruleItem.configuration.extend_input.items.push({ property: '', extends: [] })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		removeExtendInputItem(index) {
 			if (index === 0) return
 			this.ruleItem.configuration.extend_input.items.splice(index, 1)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		closeModal() {
 			navigationStore.setModal(false)
 			clearTimeout(this.closeTimeoutFunc)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		isValidJson(str) {
 			if (!str) return true
 			try {
@@ -1433,6 +1453,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		formatJSONCondictions() {
 			try {
 				if (this.ruleItem.conditions) {
@@ -1445,6 +1466,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		formatJSONSourceConfiguration() {
 			try {
 				if (this.ruleItem.configuration.fetch_file.sourceConfiguration) {
@@ -1456,6 +1478,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		async installOpenRegister() {
 			console.info('Installing Open Register')
 			const token = document.querySelector('head[data-requesttoken]').getAttribute('data-requesttoken')
@@ -1487,6 +1510,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-4 */
 		editRule() {
 			this.loading = true
 

--- a/src/modals/Synchronization/EditSynchronization.vue
+++ b/src/modals/Synchronization/EditSynchronization.vue
@@ -466,15 +466,18 @@ export default {
 		}
 	},
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4 */
 		selectedRegisterSourceValueSchemas() {
 			return this.registerOptions?.sourceValue?.schemas || []
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4 */
 		selectedRegisterValueSchemas() {
 			return this.registerOptions?.value?.schemas || []
 		},
 	},
 	watch: {
 		'registerOptions.value': {
+			/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4 */
 			handler(newVal, oldVal) {
 				// Only clear schema if register ID actually changed
 				// Skip clearing during initialization (when oldVal is null in edit mode)
@@ -488,6 +491,7 @@ export default {
 			deep: true,
 		},
 		'registerOptions.sourceValue': {
+			/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4 */
 			handler(newVal, oldVal) {
 				// Only clear schema if register ID actually changed
 				// Skip clearing during initialization (when oldVal is null in edit mode)
@@ -501,6 +505,7 @@ export default {
 			deep: true,
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4 */
 	mounted() {
 		if (this.IS_EDIT) {
 			// If there is a synchronization item in the store, use it
@@ -526,6 +531,8 @@ export default {
 		 * Sets the loading state to true while fetching and updates the source options with the fetched data.
 		 * If a source is already selected, it sets it as the active source.
 		 * If the target type is 'api', it sets the active target source.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4
 		 */
 		getSources() {
 			this.sourcesLoading = true
@@ -566,6 +573,8 @@ export default {
 		 * Fetches the list of source-target mappings from the mapping store and updates the mapping options.
 		 * Sets the loading state to true while fetching and updates the mapping options with the fetched data.
 		 * If a mapping is already selected, it sets it as the active source and target mapping.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4
 		 */
 		getSourceTargetMappings() {
 			this.sourceTargetMappingLoading = true
@@ -613,6 +622,8 @@ export default {
 		 *
 		 * additionally it adds the schemas of a register to its options data,
 		 * which'll be used to populate the schema options when you select a register.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4
 		 */
 		getRegisterWithSchemas() {
 			this.registerLoading = true
@@ -719,6 +730,8 @@ export default {
 		 * Sets the loading state to true while fetching and updates the rules options with the fetched data.
 		 * If a rules is already selected, it sets it as the active rules.
 		 * If the target type is 'api', it sets the active target rules.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4
 		 */
 		getRules() {
 			this.rulesLoading = true
@@ -748,6 +761,8 @@ export default {
 		 * Sets the loading state to true while the installation is in progress.
 		 * Updates the state based on the success or failure of the installation.
 		 * If the installation is successful, it fetches the register and schema options.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4
 		 */
 		async installOpenRegister() {
 			this.openRegisterLoading = true
@@ -810,6 +825,8 @@ export default {
 		},
 		/**
 		 * Closes the modal and clears the timeout function.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4
 		 */
 		closeModal() {
 			navigationStore.setModal(false)
@@ -817,6 +834,8 @@ export default {
 		},
 		/**
 		 * Tests the synchronization configuration by running a test sync
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-5
 		 */
 		testSynchronization() {
 			// TODO: Implement test synchronization functionality
@@ -825,6 +844,8 @@ export default {
 		 * Edits the synchronization by saving the synchronization item to the store.
 		 * Sets the loading state to true while saving and updates the state based on the success or failure of the save operation.
 		 * If the save operation is successful, it closes the modal after a timeout.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-4
 		 */
 		editSynchronization() {
 			this.loading = true

--- a/src/modals/Synchronization/RunSynchronization.vue
+++ b/src/modals/Synchronization/RunSynchronization.vue
@@ -202,10 +202,12 @@ export default {
 		}
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-5 */
 		closeModal() {
 			navigationStore.setModal(false)
 			synchronizationStore.synchronizationRun = null
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-5 */
 		async runSynchronization() {
 			this.success = null
 			this.loading = true

--- a/src/modals/Synchronization/TestSynchronization.vue
+++ b/src/modals/Synchronization/TestSynchronization.vue
@@ -114,10 +114,12 @@ export default {
 		this.testSynchronization()
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-5 */
 		closeModal() {
 			navigationStore.setModal(false)
 			synchronizationStore.synchronizationTest = null
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-5 */
 		async testSynchronization() {
 			this.success = null
 			this.loading = true

--- a/src/modals/TestSource/TestSource.vue
+++ b/src/modals/TestSource/TestSource.vue
@@ -135,6 +135,7 @@ export default {
 		}
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-5 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.succes = false
@@ -147,6 +148,7 @@ export default {
 				type: '',
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-5 */
 		async testSource() {
 			this.loading = true
 
@@ -167,6 +169,7 @@ export default {
 				sourceStore.setSourceTest(false)
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-5 */
 		prettifyJson(json) {
 			if (!json) return ''
 			try {

--- a/src/modals/v2/AddEndpointRuleModal.vue
+++ b/src/modals/v2/AddEndpointRuleModal.vue
@@ -121,15 +121,19 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		endpointName() {
 			return this.endpoint?.name || this.endpoint?.title || ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		canSave() {
 			return this.selectedRules.length > 0
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		endpointId() {
 			return this.endpoint?.id || this.endpoint?.uuid
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		existingRuleIds() {
 			const raw = this.endpoint?.rules
 			if (!Array.isArray(raw)) return []
@@ -141,6 +145,7 @@ export default {
 	},
 
 	watch: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		open(value) {
 			if (value) {
 				this.resetState()
@@ -150,10 +155,12 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		onClose() {
 			this.$emit('close')
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		resetState() {
 			this.selectedRules = []
 			this.saving = false
@@ -161,6 +168,7 @@ export default {
 			this.error = ''
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		async fetchRules() {
 			this.loadingRules = true
 			try {
@@ -193,6 +201,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-5 */
 		async onSave() {
 			if (!this.canSave || !this.endpointId) return
 			this.saving = true

--- a/src/modals/v2/JobFormFields.vue
+++ b/src/modals/v2/JobFormFields.vue
@@ -260,6 +260,7 @@ export default {
 		isSynchronizationJob() {
 			return this.formData?.jobClass === SYNCHRONIZATION_ACTION_CLASS
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		hasArgumentsField() {
 			// True when the schema-derived field list includes an `arguments`
 			// field — drives whether the Synchronization picker renders
@@ -267,9 +268,11 @@ export default {
 			// block after the loop. See template for the wire-up.
 			return Array.isArray(this.fields) && this.fields.some((f) => f.key === 'arguments')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		jobClassOptions() {
 			return JOB_CLASS_OPTIONS
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		selectedJobClassOption() {
 			const current = this.formData?.jobClass
 			if (!current) return null
@@ -278,6 +281,7 @@ export default {
 				label: current,
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		selectedSynchronization() {
 			const args = this.formData?.arguments
 			const id = args && typeof args === 'object' ? args.synchronizationId : null
@@ -292,6 +296,7 @@ export default {
 	watch: {
 		isSynchronizationJob: {
 			immediate: true,
+			/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 			handler(value) {
 				if (value && this.synchronizationOptions.length === 0) {
 					this.fetchSynchronizations()
@@ -301,6 +306,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		textFieldType(field) {
 			if (field.widget === 'email') return 'email'
 			if (field.widget === 'url') return 'url'
@@ -309,10 +315,12 @@ export default {
 			return 'text'
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		onJobClassPick(option) {
 			this.updateField('jobClass', option?.id ?? null)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		onSynchronizationPick(option) {
 			const current = this.formData?.arguments
 			const next = (current && typeof current === 'object' && !Array.isArray(current))
@@ -326,6 +334,7 @@ export default {
 			this.updateField('arguments', next)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		async fetchSynchronizations() {
 			this.synchronizationsLoading = true
 			try {
@@ -355,6 +364,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		jsonStringFor(field) {
 			if (this.jsonDrafts[field.key] !== undefined) {
 				return this.jsonDrafts[field.key]
@@ -369,6 +379,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-endpoint-job-editor-ui/tasks.md#task-2 */
 		onJsonInput(field, raw) {
 			this.$set(this.jsonDrafts, field.key, raw)
 			const trimmed = raw.trim()

--- a/src/modals/v2/ModalHost.vue
+++ b/src/modals/v2/ModalHost.vue
@@ -55,26 +55,32 @@ export default {
 		}
 	},
 
+	/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-2 */
 	mounted() {
 		modalBus.$on(EVENT_OPEN_TEST_MAPPING, this.openTestMapping)
 		modalBus.$on(EVENT_OPEN_ADD_ENDPOINT_RULE, this.openAddEndpointRule)
 	},
 
+	/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-2 */
 	beforeDestroy() {
 		modalBus.$off(EVENT_OPEN_TEST_MAPPING, this.openTestMapping)
 		modalBus.$off(EVENT_OPEN_ADD_ENDPOINT_RULE, this.openAddEndpointRule)
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-2 */
 		openTestMapping(payload) {
 			this.testMapping = { open: true, mapping: payload?.mapping ?? null }
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-2 */
 		closeTestMapping() {
 			this.testMapping = { open: false, mapping: null }
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-2 */
 		openAddEndpointRule(payload) {
 			this.addEndpointRule = { open: true, endpoint: payload?.endpoint ?? null }
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-2 */
 		closeAddEndpointRule() {
 			this.addEndpointRule = { open: false, endpoint: null }
 		},

--- a/src/modals/v2/TestMappingModal.vue
+++ b/src/modals/v2/TestMappingModal.vue
@@ -146,18 +146,22 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		mappingName() {
 			return this.mapping?.name || ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		placeholder() {
 			return '{\n  "key": "value"\n}'
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		canRun() {
 			return !!this.mapping && this.inputJson.trim().length > 0
 		},
 		hasResult() {
 			return this.result !== null
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		resultJson() {
 			try {
 				return JSON.stringify(this.result, null, 2)
@@ -168,6 +172,7 @@ export default {
 	},
 
 	watch: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		open(value) {
 			if (value) {
 				this.resetState()
@@ -177,10 +182,12 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		onClose() {
 			this.$emit('close')
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		resetState() {
 			this.runError = ''
 			this.inputError = ''
@@ -188,6 +195,7 @@ export default {
 			this.validation = { isValid: true, errors: [] }
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		async fetchSchemas() {
 			this.schemasLoading = true
 			try {
@@ -214,6 +222,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		async runTest() {
 			this.resetState()
 			let parsedInput = null
@@ -259,6 +268,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		formatValidationError(err) {
 			if (typeof err === 'string') return err
 			return err?.message || err?.error || JSON.stringify(err)

--- a/src/views/Rule/RuleActionConfig.vue
+++ b/src/views/Rule/RuleActionConfig.vue
@@ -191,22 +191,28 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		actionType() {
 			return this.configuration?.type || ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		typeOptions() {
 			return ACTION_TYPES.map((entry) => ({ id: entry.id, label: this.t('openconnector', entry.label) }))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedTypeOption() {
 			return this.typeOptions.find((option) => option.id === this.actionType) || null
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		formComponent() {
 			return ACTION_FORM_MAP[this.actionType] || null
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		slotValue() {
 			const raw = this.configuration?.[this.actionType]
 			return raw && typeof raw === 'object' ? raw : {}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		rawDraft() {
 			const draft = this.rawDrafts[this.actionType]
 			if (draft !== undefined) return draft
@@ -215,23 +221,27 @@ export default {
 			if (typeof raw === 'string') return raw
 			try { return JSON.stringify(raw, null, 2) } catch (_e) { return String(raw) }
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		rawEditorLabel() {
 			return this.t('openconnector', 'Raw configuration for {type}', { type: this.actionType })
 		},
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onTypePick(option) {
 			if (!option) return
 			const next = { ...(this.configuration || {}), type: option.id }
 			this.$emit('update', next)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onSlotUpdate(next) {
 			const merged = { ...(this.configuration || {}), [this.actionType]: next }
 			this.$emit('update', merged)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onMappingIdUpdate(id) {
 			const next = { ...(this.configuration || {}) }
 			if (id) {
@@ -242,11 +252,13 @@ export default {
 			this.$emit('update', next)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onJavascriptCodeUpdate(code) {
 			const next = { ...(this.configuration || {}), javascript: code }
 			this.$emit('update', next)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onRawInput(value) {
 			this.$set(this.rawDrafts, this.actionType, value)
 			const trimmed = value.trim()

--- a/src/views/Rule/RuleConditionGroup.vue
+++ b/src/views/Rule/RuleConditionGroup.vue
@@ -132,25 +132,30 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		currentOperator() {
 			const keys = Object.keys(this.node || {})
 			const found = keys.find((key) => GROUP_OPERATORS.includes(key))
 			return found || 'and'
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		children() {
 			const value = this.node?.[this.currentOperator]
 			return Array.isArray(value) ? value : []
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		operatorOptions() {
 			return [
 				{ id: 'and', label: this.t('openconnector', 'ALL of (AND)') },
 				{ id: 'or', label: this.t('openconnector', 'ANY of (OR)') },
 			]
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		selectedOperator() {
 			return this.operatorOptions.find((option) => option.id === this.currentOperator)
 				?? this.operatorOptions[0]
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		operatorHint() {
 			return this.currentOperator === 'and'
 				? this.t('openconnector', 'Every child below must match.')
@@ -159,30 +164,36 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		isGroup(child) {
 			if (!child || typeof child !== 'object' || Array.isArray(child)) return false
 			const keys = Object.keys(child)
 			return keys.length === 1 && GROUP_OPERATORS.includes(keys[0]) && Array.isArray(child[keys[0]])
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		onOperatorPick(option) {
 			if (!option) return
 			this.$emit('update', { [option.id]: this.children.slice() })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		updateChild(index, value) {
 			const next = this.children.slice()
 			next[index] = value
 			this.$emit('update', { [this.currentOperator]: next })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		removeChild(index) {
 			const next = this.children.slice()
 			next.splice(index, 1)
 			this.$emit('update', { [this.currentOperator]: next })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		addLeaf() {
 			const next = this.children.slice()
 			next.push({ '==': [{ var: '' }, ''] })
 			this.$emit('update', { [this.currentOperator]: next })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		addGroup() {
 			const next = this.children.slice()
 			next.push({ and: [] })

--- a/src/views/Rule/RuleConditionLeaf.vue
+++ b/src/views/Rule/RuleConditionLeaf.vue
@@ -227,6 +227,7 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		operatorOptions() {
 			return OPERATORS.map((op) => ({
 				id: op.id,
@@ -234,18 +235,22 @@ export default {
 				group: op.group ? this.t('openconnector', op.group) : '',
 			}))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		currentOperator() {
 			const keys = Object.keys(this.node || {})
 			const op = keys.find((key) => OPERATORS.some((entry) => entry.id === key))
 			return op || '=='
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		schema() {
 			return OPERATORS.find((entry) => entry.id === this.currentOperator) || OPERATORS[0]
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		selectedOperator() {
 			return this.operatorOptions.find((option) => option.id === this.currentOperator)
 				?? this.operatorOptions[0]
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		args() {
 			const value = this.node?.[this.currentOperator]
 			if (Array.isArray(value)) return value
@@ -255,6 +260,7 @@ export default {
 			}
 			return []
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		varPath() {
 			const first = this.args[0]
 			if (first && typeof first === 'object' && Object.prototype.hasOwnProperty.call(first, 'var')) {
@@ -263,6 +269,7 @@ export default {
 			if (typeof first === 'string') return first
 			return ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		varOnlyPath() {
 			// For top-level `var` ops, args[0] is the dotted-path string.
 			const first = this.args[0]
@@ -272,28 +279,34 @@ export default {
 			}
 			return ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		mergeJson() {
 			try { return JSON.stringify(this.args, null, 2) } catch (_e) { return '[]' }
 		},
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		onVarInput(value) {
 			this.emitUpdate({ varPath: value })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		onVarOnlyInput(value) {
 			// Emit `{ "var": [<path>] }` — jsonlogic-php accepts both
 			// `{ var: "a" }` and `{ var: ["a"] }`; we use the array form
 			// here for shape parity with other ops in the tree.
 			this.$emit('update', { var: [value] })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		onOperatorPick(option) {
 			if (!option) return
 			this.emitUpdate({ operator: option.id })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		onSlotInput(slot, value) {
 			this.emitUpdate({ slot, slotValue: this.coerce(value) })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		onJsonSlotInput(slot, value) {
 			const trimmed = value.trim()
 			if (trimmed.length === 0) {
@@ -309,6 +322,7 @@ export default {
 				this.parseError = this.t('openconnector', 'Invalid JSON: {message}', { message: parseErr.message })
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		onMergeInput(value) {
 			const trimmed = value.trim()
 			if (trimmed.length === 0) {
@@ -328,6 +342,7 @@ export default {
 				this.parseError = this.t('openconnector', 'Invalid JSON: {message}', { message: parseErr.message })
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		slotString(index) {
 			const raw = this.args[index]
 			if (raw === null || raw === undefined) return ''
@@ -336,6 +351,7 @@ export default {
 			}
 			return String(raw)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2 */
 		slotJson(index, { fallback = '' } = {}) {
 			const raw = this.args[index]
 			if (raw === undefined) return fallback
@@ -351,6 +367,8 @@ export default {
 		 *
 		 * @param {string} raw User-entered text.
 		 * @return {*} Coerced value.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2
 		 */
 		coerce(raw) {
 			if (raw === '') return ''
@@ -369,6 +387,8 @@ export default {
 		 * @param {{ varPath?: string, operator?: string, slot?: number, slotValue?: * }} patch
 		 *   Partial change — fields omitted come from current state.
 		 * @return {void}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2
 		 */
 		emitUpdate(patch) {
 			const operator = patch.operator ?? this.currentOperator
@@ -411,6 +431,8 @@ export default {
 		 * @param {{ carryVar: string, carryValue: * }} carry Best-effort
 		 *   reuse of the current var/value across an op change.
 		 * @return {Array} Initial args array.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-2
 		 */
 		argsForKind(schema, { carryVar = '', carryValue = '' } = {}) {
 			switch (schema.kind) {

--- a/src/views/Rule/RuleDetailPage.vue
+++ b/src/views/Rule/RuleDetailPage.vue
@@ -190,6 +190,7 @@ export default {
 		schema: { type: String, default: 'rule' },
 	},
 
+	/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 	setup(props) {
 		const objectStore = useObjectStore()
 		if (typeof objectStore.registerObjectType === 'function') {
@@ -214,10 +215,12 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		pageTitle() {
 			if (!this.draft) return this.t('openconnector', 'Rule')
 			return this.draft.name ? `${this.t('openconnector', 'Rule')}: ${this.draft.name}` : this.t('openconnector', 'Rule')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		errorMessage() {
 			if (!this.error) return ''
 			if (typeof this.error === 'string') return this.error
@@ -229,11 +232,14 @@ export default {
 		 * stored conditions as a string (CodeMirror text), an array,
 		 * or a single leaf — all of those normalise here so the visual
 		 * builder always has a group to render.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1
 		 */
 		rootConditionGroup() {
 			const raw = this.draft?.conditions
 			return this.normaliseConditions(raw)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		dirty() {
 			if (!this.draft || !this.pristine) return false
 			try {
@@ -247,10 +253,12 @@ export default {
 	watch: {
 		id: {
 			immediate: true,
+			/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 			handler(value) {
 				if (value) this.load()
 			},
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		rawConditions(value) {
 			if (value) {
 				try {
@@ -279,6 +287,8 @@ export default {
 		 *
 		 * @param {*} raw The persisted conditions value.
 		 * @return {object} A JsonLogic group node.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1
 		 */
 		normaliseConditions(raw) {
 			if (raw === null || raw === undefined || raw === '') {
@@ -300,6 +310,7 @@ export default {
 			return { ...EMPTY_ROOT_GROUP }
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		async load() {
 			this.loading = true
 			this.error = null
@@ -319,21 +330,25 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		updateField(key, value) {
 			if (!this.draft) return
 			this.$set(this.draft, key, value)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		onConditionsUpdate(node) {
 			if (!this.draft) return
 			this.$set(this.draft, 'conditions', node)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		onConfigurationUpdate(next) {
 			if (!this.draft) return
 			this.$set(this.draft, 'configuration', next)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		onRawConditionsInput(value) {
 			this.rawConditionsDraft = value
 			const trimmed = value.trim()
@@ -351,6 +366,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		async onSave() {
 			if (!this.draft || this.saving) return
 			this.saving = true
@@ -371,6 +387,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		onCancel() {
 			if (!this.pristine) return
 			this.draft = JSON.parse(JSON.stringify(this.pristine))
@@ -382,6 +399,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-1 */
 		onRetry() {
 			this.load()
 		},

--- a/src/views/Rule/actionForms/AuthenticationForm.vue
+++ b/src/views/Rule/actionForms/AuthenticationForm.vue
@@ -62,21 +62,26 @@ export default {
 	components: { NcSelect, NcTextField },
 	props: { ...valueProp },
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		typeOptions() {
 			return AUTH_TYPES.map((row) => ({ id: row.id, label: this.t('openconnector', row.label) }))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedTypeOption() {
 			return this.typeOptions.find((opt) => opt.id === this.value.type) || null
 		},
 	},
 	methods: {
 		patch: patchMethod(),
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onTypePick(option) {
 			this.patch('type', option?.id || '')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		csv(value) {
 			return Array.isArray(value) ? value.join(',') : (value || '')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		toArray(text) {
 			return (text || '').split(',').map((entry) => entry.trim()).filter(Boolean)
 		},

--- a/src/views/Rule/actionForms/DownloadForm.vue
+++ b/src/views/Rule/actionForms/DownloadForm.vue
@@ -36,6 +36,7 @@ export default {
 	props: { ...valueProp },
 	methods: {
 		patch: patchMethod(),
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onFileIdInput(raw) {
 			if (raw === '' || raw == null) {
 				const next = { ...(this.value || {}) }

--- a/src/views/Rule/actionForms/ErrorForm.vue
+++ b/src/views/Rule/actionForms/ErrorForm.vue
@@ -50,6 +50,7 @@ export default {
 	data() { return { uid: ++uidCounter } },
 	methods: {
 		patch: patchMethod(),
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onCodeInput(raw) {
 			if (raw === '' || raw == null) {
 				const next = { ...(this.value || {}) }

--- a/src/views/Rule/actionForms/ExtendExternalInputForm.vue
+++ b/src/views/Rule/actionForms/ExtendExternalInputForm.vue
@@ -55,6 +55,7 @@ export default {
 	components: { NcButton, NcCheckboxRadioSwitch, NcTextField, Close, Plus },
 	props: { ...valueProp },
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		rows() {
 			const props = Array.isArray(this.value?.properties) ? this.value.properties : []
 			return props.map((entry) => ({
@@ -64,28 +65,34 @@ export default {
 		},
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		emitRows(rows) {
 			const next = { ...(this.value || {}), properties: rows.filter((row) => row.property) }
 			this.$emit('update:value', next)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onValidateToggle(checked) {
 			this.$emit('update:value', { ...(this.value || {}), validate: !!checked })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onPropertyInput(index, value) {
 			const rows = this.rows.slice()
 			rows[index] = { ...rows[index], property: value }
 			this.emitRows(rows)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onSchemaInput(index, value) {
 			const rows = this.rows.slice()
 			rows[index] = { ...rows[index], schema: value }
 			this.emitRows(rows)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		addRow() {
 			const rows = this.rows.slice()
 			rows.push({ property: '', schema: '' })
 			this.emitRows(rows)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		removeRow(index) {
 			const rows = this.rows.slice()
 			rows.splice(index, 1)

--- a/src/views/Rule/actionForms/ExtendInputForm.vue
+++ b/src/views/Rule/actionForms/ExtendInputForm.vue
@@ -54,6 +54,7 @@ export default {
 	components: { NcButton, NcTextField, Close, Plus },
 	props: { ...valueProp },
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		rows() {
 			const props = Array.isArray(this.value?.properties) ? this.value.properties : []
 			const extendsMap = (this.value?.extends && typeof this.value.extends === 'object') ? this.value.extends : {}
@@ -64,6 +65,7 @@ export default {
 		},
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		emitRows(rows) {
 			const properties = rows.map((row) => row.property).filter(Boolean)
 			const extendsMap = {}
@@ -80,11 +82,13 @@ export default {
 			}
 			this.$emit('update:value', next)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onPropertyInput(index, value) {
 			const rows = this.rows.slice()
 			rows[index] = { ...rows[index], property: value }
 			this.emitRows(rows)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onExtendsInput(index, value) {
 			const rows = this.rows.slice()
 			rows[index] = {
@@ -93,11 +97,13 @@ export default {
 			}
 			this.emitRows(rows)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		addRow() {
 			const rows = this.rows.slice()
 			rows.push({ property: '', extends: [] })
 			this.emitRows(rows)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		removeRow(index) {
 			const rows = this.rows.slice()
 			rows.splice(index, 1)

--- a/src/views/Rule/actionForms/FetchFileForm.vue
+++ b/src/views/Rule/actionForms/FetchFileForm.vue
@@ -108,6 +108,7 @@ export default {
 		}
 	},
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedSource() {
 			const id = String(this.value?.source || '')
 			if (!id) return null
@@ -124,6 +125,7 @@ export default {
 			}
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 	async mounted() {
 		this.sourcesLoading = true
 		this.sourceOptions = await fetchOpenRegisterCollection('source')
@@ -132,20 +134,25 @@ export default {
 	},
 	methods: {
 		patch: patchMethod(),
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onSourcePick(option) {
 			this.patch('source', option?.id ? String(option.id) : '')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		csv(value) {
 			return Array.isArray(value) ? value.join(',') : (value || '')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		toArray(text) {
 			return (text || '').split(',').map((entry) => entry.trim()).filter(Boolean)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		serialiseSourceConfig(value) {
 			if (value === undefined || value === null) return ''
 			if (typeof value === 'string') return value
 			try { return JSON.stringify(value, null, 2) } catch (_e) { return String(value) }
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onSourceConfigInput(event) {
 			const raw = event.target.value
 			this.sourceConfigDraft = raw

--- a/src/views/Rule/actionForms/FilepartUploadForm.vue
+++ b/src/views/Rule/actionForms/FilepartUploadForm.vue
@@ -38,17 +38,20 @@ export default {
 	props: { ...valueProp },
 	data() { return { mappingOptions: [], loading: false } },
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedInbound() {
 			const id = String(this.value?.mappingId || '')
 			if (!id) return null
 			return this.mappingOptions.find((opt) => opt.id === id) ?? { id, label: id }
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedOutbound() {
 			const id = String(this.value?.mappingOutId || '')
 			if (!id) return null
 			return this.mappingOptions.find((opt) => opt.id === id) ?? { id, label: id }
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 	async mounted() {
 		this.loading = true
 		this.mappingOptions = await fetchOpenRegisterCollection('mapping')

--- a/src/views/Rule/actionForms/FilepartsCreateForm.vue
+++ b/src/views/Rule/actionForms/FilepartsCreateForm.vue
@@ -57,17 +57,20 @@ export default {
 		}
 	},
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedSchema() {
 			const id = String(this.value?.schemaId || '')
 			if (!id) return null
 			return this.schemaOptions.find((opt) => opt.id === id) ?? { id, label: id }
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedMapping() {
 			const id = String(this.value?.mappingId || '')
 			if (!id) return null
 			return this.mappingOptions.find((opt) => opt.id === id) ?? { id, label: id }
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 	async mounted() {
 		this.schemasLoading = true
 		this.mappingsLoading = true

--- a/src/views/Rule/actionForms/LockingForm.vue
+++ b/src/views/Rule/actionForms/LockingForm.vue
@@ -40,18 +40,22 @@ export default {
 	components: { NcSelect, NcTextField },
 	props: { ...valueProp },
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		actionOptions() {
 			return LOCK_ACTIONS.map((row) => ({ id: row.id, label: this.t('openconnector', row.label) }))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedAction() {
 			return this.actionOptions.find((opt) => opt.id === this.value.action) || null
 		},
 	},
 	methods: {
 		patch: patchMethod(),
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onActionPick(option) {
 			this.patch('action', option?.id || '')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onDurationInput(raw) {
 			if (raw === '' || raw == null) {
 				const next = { ...(this.value || {}) }

--- a/src/views/Rule/actionForms/MappingForm.vue
+++ b/src/views/Rule/actionForms/MappingForm.vue
@@ -38,18 +38,21 @@ export default {
 	},
 	data() { return { options: [], loading: false } },
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selected() {
 			const idStr = String(this.id || '')
 			if (!idStr) return null
 			return this.options.find((opt) => opt.id === idStr) ?? { id: idStr, label: idStr }
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 	async mounted() {
 		this.loading = true
 		this.options = await fetchOpenRegisterCollection('mapping')
 		this.loading = false
 	},
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onPick(option) {
 			this.$emit('update:id', option?.id ? String(option.id) : '')
 		},

--- a/src/views/Rule/actionForms/SaveObjectForm.vue
+++ b/src/views/Rule/actionForms/SaveObjectForm.vue
@@ -52,22 +52,26 @@ export default {
 		}
 	},
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedRegister() {
 			const id = String(this.value?.register || '')
 			if (!id) return null
 			return this.registerOptions.find((opt) => opt.id === id) ?? { id, label: id }
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedSchema() {
 			const id = String(this.value?.schema || '')
 			if (!id) return null
 			return this.schemaOptions.find((opt) => opt.id === id) ?? { id, label: id }
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedMapping() {
 			const id = String(this.value?.mapping || '')
 			if (!id) return null
 			return this.mappingOptions.find((opt) => opt.id === id) ?? { id, label: id }
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 	async mounted() {
 		this.loading = true
 		const [registers, schemas, mappings] = await Promise.all([

--- a/src/views/Rule/actionForms/SynchronizationForm.vue
+++ b/src/views/Rule/actionForms/SynchronizationForm.vue
@@ -70,15 +70,18 @@ export default {
 	computed: {
 		// Both shapes round-trip — legacy `synchronization` was sometimes
 		// a bare id, sometimes nested under `synchronization.synchronization`.
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		syncId() {
 			return this.value?.synchronization || ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		selectedSync() {
 			const id = String(this.syncId)
 			if (!id) return null
 			return this.syncOptions.find((opt) => opt.id === id) ?? { id, label: id }
 		},
 	},
+	/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 	async mounted() {
 		this.loading = true
 		this.syncOptions = await fetchOpenRegisterCollection('synchronization')
@@ -86,6 +89,7 @@ export default {
 	},
 	methods: {
 		patch: patchMethod(),
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		patchNumber(key, raw) {
 			if (raw === '' || raw == null) {
 				const next = { ...(this.value || {}) }
@@ -97,6 +101,7 @@ export default {
 			if (Number.isNaN(num)) return
 			this.patch(key, num)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onSyncPick(option) {
 			const next = { ...(this.value || {}) }
 			if (option?.id) {

--- a/src/views/Rule/actionForms/UploadForm.vue
+++ b/src/views/Rule/actionForms/UploadForm.vue
@@ -41,6 +41,7 @@ export default {
 	props: { ...valueProp },
 	methods: {
 		patch: patchMethod(),
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		onMaxSizeInput(raw) {
 			if (raw === '' || raw == null) {
 				const next = { ...(this.value || {}) }

--- a/src/views/Rule/actionForms/WriteFileForm.vue
+++ b/src/views/Rule/actionForms/WriteFileForm.vue
@@ -43,9 +43,11 @@ export default {
 	props: { ...valueProp },
 	methods: {
 		patch: patchMethod(),
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		csv(value) {
 			return Array.isArray(value) ? value.join(',') : (value || '')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-rule-editor-ui/tasks.md#task-3 */
 		toArray(text) {
 			return (text || '').split(',').map((entry) => entry.trim()).filter(Boolean)
 		},

--- a/src/views/Synchronization/SyncConfigWidget.vue
+++ b/src/views/Synchronization/SyncConfigWidget.vue
@@ -250,26 +250,33 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		kindLabel() {
 			return this.kind === 'source'
 				? t('openconnector', 'Source')
 				: t('openconnector', 'Target')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		apiSourceId() {
 			return `sync-config-${this.widgetUid}-api-source`
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		registerSelectId() {
 			return `sync-config-${this.widgetUid}-register`
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		schemaSelectId() {
 			return `sync-config-${this.widgetUid}-schema`
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		filePathId() {
 			return `sync-config-${this.widgetUid}-file-path`
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		sourceIdValue() {
 			return this.sourceId != null ? String(this.sourceId) : ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		selectedSource() {
 			if (!this.sourceIdValue) return null
 			return this.sourceOptions.find((opt) => opt.id === this.sourceIdValue) ?? {
@@ -277,11 +284,13 @@ export default {
 				label: this.sourceIdValue,
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		selectedRegister() {
 			const [registerId] = this.sourceIdValue.split('/')
 			if (!registerId) return null
 			return this.registerOptions.find((opt) => String(opt.id) === String(registerId)) ?? null
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		schemaOptions() {
 			const reg = this.selectedRegister || this.selectedRegisterRecord
 			if (!reg) return []
@@ -291,6 +300,7 @@ export default {
 				label: schema.title || schema.name || schema.slug || String(schema),
 			}))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		selectedSchema() {
 			const parts = this.sourceIdValue.split('/')
 			if (parts.length < 2) return null
@@ -302,6 +312,7 @@ export default {
 	watch: {
 		type: {
 			immediate: true,
+			/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 			handler(value) {
 				if (value === 'api' && this.sourceOptions.length === 0) {
 					this.fetchSources()
@@ -314,12 +325,14 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		configValue(key) {
 			if (!this.config || typeof this.config !== 'object') return ''
 			const v = this.config[key]
 			if (v == null) return ''
 			return typeof v === 'string' ? v : String(v)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		onConfigUpdate(key, value) {
 			const next = (this.config && typeof this.config === 'object' && !Array.isArray(this.config))
 				? { ...this.config }
@@ -331,9 +344,11 @@ export default {
 			}
 			this.$emit('update:config', next)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		onSourcePick(option) {
 			this.$emit('update:sourceId', option?.id ? String(option.id) : '')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		onRegisterPick(option) {
 			if (!option?.id) {
 				this.$emit('update:sourceId', '')
@@ -347,6 +362,7 @@ export default {
 			// the user picks a schema below.
 			this.$emit('update:sourceId', String(option.id) + '/')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		onSchemaPick(option) {
 			const reg = this.selectedRegister || this.selectedRegisterRecord
 			if (!reg || !option?.id) {
@@ -355,6 +371,7 @@ export default {
 			}
 			this.$emit('update:sourceId', String(reg.id) + '/' + String(option.id))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		async fetchSources() {
 			this.sourcesLoading = true
 			try {
@@ -387,6 +404,8 @@ export default {
 		 * mime-type filter so all files are reachable — sync source files
 		 * are commonly XML/CSV/JSON without consistent mime detection on
 		 * server uploads.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2
 		 */
 		async openFilePicker() {
 			this.pickerError = ''
@@ -418,6 +437,7 @@ export default {
 				this.pickingFile = false
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-2 */
 		async fetchRegisters() {
 			this.registersLoading = true
 			try {

--- a/src/views/Synchronization/SyncMappingPicker.vue
+++ b/src/views/Synchronization/SyncMappingPicker.vue
@@ -115,15 +115,21 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		primaryId() { return `sync-mapping-${this.pickerUid}-primary` },
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		reverseId() { return `sync-mapping-${this.pickerUid}-reverse` },
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		hashId() { return `sync-mapping-${this.pickerUid}-hash` },
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		selectedPrimary() {
 			return this.resolveOption(this.value)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		selectedReverse() {
 			return this.resolveOption(this.targetSourceValue)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		selectedHash() {
 			return this.resolveOption(this.hashValue)
 		},
@@ -134,6 +140,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		resolveOption(id) {
 			if (!id) return null
 			return this.mappingOptions.find((opt) => opt.id === String(id)) ?? {
@@ -141,6 +148,7 @@ export default {
 				label: String(id),
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		async fetchMappings() {
 			this.loading = true
 			try {

--- a/src/views/Synchronization/SyncMappingPreview.vue
+++ b/src/views/Synchronization/SyncMappingPreview.vue
@@ -141,9 +141,11 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		inputId() {
 			return `sync-mapping-preview-${this.previewUid}-input`
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		resultJson() {
 			if (this.result === null) return ''
 			try {
@@ -157,6 +159,7 @@ export default {
 	watch: {
 		mappingId: {
 			immediate: true,
+			/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 			handler(newId, oldId) {
 				if (newId === oldId) return
 				// Clear stale state before loading the new mapping.
@@ -172,6 +175,7 @@ export default {
 				}
 			},
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		expanded(value) {
 			if (value && this.mappingId && !this.mapping) {
 				this.loadAndRun()
@@ -179,6 +183,7 @@ export default {
 		},
 	},
 
+	/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 	beforeDestroy() {
 		if (this.debounceTimer) {
 			window.clearTimeout(this.debounceTimer)
@@ -186,10 +191,12 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		onInput(value) {
 			this.inputJson = value
 			this.scheduleRun()
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		scheduleRun() {
 			if (this.debounceTimer) {
 				window.clearTimeout(this.debounceTimer)
@@ -199,6 +206,7 @@ export default {
 				this.runPreview()
 			}, DEBOUNCE_MS)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		async loadAndRun() {
 			this.loadError = ''
 			try {
@@ -224,6 +232,7 @@ export default {
 					|| t('openconnector', 'Failed to load mapping.')
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		async runPreview() {
 			if (!this.mapping) {
 				// If the panel was just expanded without a cached mapping,

--- a/src/views/Synchronization/SyncReferenceList.vue
+++ b/src/views/Synchronization/SyncReferenceList.vue
@@ -80,9 +80,11 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		inputId() {
 			return `sync-ref-list-${this.listUid}`
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		selectedOptions() {
 			if (!Array.isArray(this.value)) return []
 			return this.value.map((id) => this.options.find((opt) => opt.id === String(id)) ?? {
@@ -95,6 +97,7 @@ export default {
 	watch: {
 		schema: {
 			immediate: true,
+			/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 			handler() {
 				this.fetchOptions()
 			},
@@ -102,10 +105,12 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		onChange(picked) {
 			const list = Array.isArray(picked) ? picked : []
 			this.$emit('input', list.map((option) => option?.id).filter(Boolean).map(String))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-3 */
 		async fetchOptions() {
 			this.loading = true
 			try {

--- a/src/views/Synchronization/SynchronizationDetailPage.vue
+++ b/src/views/Synchronization/SynchronizationDetailPage.vue
@@ -409,6 +409,7 @@ export default {
 		schema: { type: String, default: SCHEMA_SLUG },
 	},
 
+	/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 	setup(props) {
 		const objectStore = useObjectStore()
 		// Register the type so objectStore.fetchObject/saveObject can resolve
@@ -437,37 +438,47 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		objectIdString() {
 			return this.id != null ? String(this.id) : ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		registerSlug() {
 			return this.register || REGISTER_SLUG
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		schemaSlug() {
 			return this.schema || SCHEMA_SLUG
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		title() {
 			if (this.draft?.name) return this.draft.name
 			return this.original?.name || t('openconnector', 'Synchronization')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		description() {
 			return this.original?.description || ''
 		},
 		hasError() {
 			return Boolean(this.loadError) && !this.draft
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		errorMessage() {
 			return this.loadError || t('openconnector', 'Failed to load synchronization')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		typeOptions() {
 			return TYPE_OPTIONS
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		selectedSourceType() {
 			return TYPE_OPTIONS.find((opt) => opt.id === this.draft?.sourceType) || TYPE_OPTIONS[0]
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		selectedTargetType() {
 			return TYPE_OPTIONS.find((opt) => opt.id === this.draft?.targetType) || TYPE_OPTIONS[1]
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		dirty() {
 			if (!this.draft || !this.original) return false
 			// `normalizeForDiff` shapes both sides identically (conditions
@@ -476,6 +487,7 @@ export default {
 			// stores conditions as `array<object>`.
 			return JSON.stringify(this.draft) !== JSON.stringify(this.normalizeForDiff(this.original))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		canSave() {
 			return Boolean(this.draft?.name && this.draft.name.trim().length > 0)
 		},
@@ -485,6 +497,8 @@ export default {
 		 * `normaliseConditions` helper in RuleDetailPage — same legacy shapes
 		 * (string, array, single leaf, group) end up as `{and:[...]}` /
 		 * `{or:[...]}`.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1
 		 */
 		rootConditionGroup() {
 			return this.normaliseConditions(this.draft?.conditions)
@@ -494,10 +508,12 @@ export default {
 	watch: {
 		id: {
 			immediate: true,
+			/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 			handler() {
 				this.loadObject()
 			},
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		rawConditions(value) {
 			if (value) {
 				try {
@@ -511,6 +527,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		async loadObject() {
 			if (!this.objectIdString) {
 				// New-create surface — start with empty draft.
@@ -546,6 +563,8 @@ export default {
 		 *
 		 * @param {object} obj Raw object from the store.
 		 * @return {object} Plain draft with all editable fields filled.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1
 		 */
 		normalizeForDiff(obj) {
 			const base = emptyDraft()
@@ -585,6 +604,8 @@ export default {
 		 *
 		 * @param {*} raw Persisted conditions value.
 		 * @return {object} JsonLogic group node.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1
 		 */
 		normaliseConditions(raw) {
 			if (raw === null || raw === undefined || raw === '') {
@@ -619,6 +640,8 @@ export default {
 		 *
 		 * @param {object} group JsonLogic group node from the builder.
 		 * @return {Array} Schema-conformant `array<object>` for persistence.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1
 		 */
 		serializeConditions(group) {
 			if (!group || typeof group !== 'object') return []
@@ -629,13 +652,16 @@ export default {
 			}
 			return [group]
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		onConditionsUpdate(node) {
 			if (!this.draft) return
 			this.$set(this.draft, 'conditions', node)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		toggleRawConditions() {
 			this.rawConditions = !this.rawConditions
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		onRawConditionsInput(value) {
 			this.rawConditionsDraft = value
 			const trimmed = value.trim()
@@ -652,10 +678,12 @@ export default {
 				this.rawConditionsError = t('openconnector', 'Invalid JSON: {message}', { message: parseErr.message })
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		updateDraft(key, value) {
 			if (!this.draft) return
 			this.$set(this.draft, key, value)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		onSourceTypeChange(option) {
 			if (!option?.id || !this.draft) return
 			// Type changed — clear the kind-specific blob + id so we don't
@@ -664,12 +692,14 @@ export default {
 			this.$set(this.draft, 'sourceId', '')
 			this.$set(this.draft, 'sourceConfig', {})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		onTargetTypeChange(option) {
 			if (!option?.id || !this.draft) return
 			this.$set(this.draft, 'targetType', option.id)
 			this.$set(this.draft, 'targetId', '')
 			this.$set(this.draft, 'targetConfig', {})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		async save() {
 			if (!this.draft || this.saving) return
 			this.saving = true
@@ -696,6 +726,7 @@ export default {
 				this.saving = false
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-sync-editor-ui/tasks.md#task-1 */
 		resetEdits() {
 			if (!this.original) return
 			this.draft = this.normalizeForDiff(this.original)

--- a/src/views/wrappers/EditMappingRuleDialog.vue
+++ b/src/views/wrappers/EditMappingRuleDialog.vue
@@ -159,9 +159,11 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		castTypeOptions() {
 			return CAST_TYPE_OPTIONS
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		templatePlaceholder() {
 			// Built outside the template so the embedded `{{ … }}` Twig
 			// markers don't collide with Vue's mustache parser.
@@ -169,6 +171,7 @@ export default {
 			const closeBrace = '}}'
 			return `${openBrace} originalProperty ${closeBrace} or ${openBrace} source.field|default('-') ${closeBrace}`
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		templateHelp() {
 			// See `templatePlaceholder`: avoid embedding `{{` directly in
 			// the template literal that becomes Vue parser input.
@@ -180,6 +183,7 @@ export default {
 				{ open: openBrace, close: closeBrace },
 			)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		castSelectValue() {
 			return this.castTypeOptions.find((option) => option.id === this.valueDraft)
 				|| this.castTypeOptions[0]
@@ -187,6 +191,7 @@ export default {
 		isNew() {
 			return this.property == null
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		dialogTitle() {
 			if (this.kind === 'mapping') {
 				return this.isNew
@@ -202,21 +207,25 @@ export default {
 				? this.t('openconnector', 'Add unset rule')
 				: this.t('openconnector', 'Edit unset rule')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		submitLabel() {
 			return this.isNew
 				? this.t('openconnector', 'Add rule')
 				: this.t('openconnector', 'Save rule')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		propertyLabel() {
 			if (this.kind === 'mapping') return this.t('openconnector', 'Target property')
 			return this.t('openconnector', 'Property')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		propertyPlaceholder() {
 			if (this.kind === 'mapping') {
 				return this.t('openconnector', 'e.g. firstName')
 			}
 			return this.t('openconnector', 'JSON path or property name')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		propertyError() {
 			const trimmed = this.propertyDraft.trim()
 			if (!trimmed) return ''
@@ -225,6 +234,7 @@ export default {
 			}
 			return ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		canSubmit() {
 			const property = this.propertyDraft.trim()
 			if (!property || this.propertyError) return false
@@ -239,10 +249,12 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		onCastTypeInput(selected) {
 			if (!selected) return
 			this.valueDraft = selected.id
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-3 */
 		onSubmit() {
 			if (!this.canSubmit) return
 			const property = this.propertyDraft.trim()

--- a/src/views/wrappers/LogIndex.vue
+++ b/src/views/wrappers/LogIndex.vue
@@ -79,24 +79,31 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		config() {
 			return LOG_TYPE_CONFIG[this.logType]
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		title() {
 			return t('openconnector', this.config.titleKey)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		description() {
 			return t('openconnector', this.config.descriptionKey)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		rows() {
 			return this.config.list()
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		total() {
 			return this.config.total()
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		loading() {
 			return logStore.loading || false
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		paginationProp() {
 			return {
 				page: this.page,
@@ -108,6 +115,8 @@ export default {
 		/**
 		 * Manual column definitions. CnIndexPage uses these when no `schema`
 		 * is provided (openconnector log records are not OpenRegister-backed).
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3
 		 */
 		columns() {
 			return [
@@ -153,17 +162,21 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		refresh() {
 			return this.config.fetch(logStore.logFilters || {})
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		openDetail(row) {
 			logStore.setViewLogItem(row)
 			navigationStore.setModal(this.config.modalName)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		onPageChanged(page) {
 			this.page = page
 			this.refresh()
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-app-shell-and-logs-ui/tasks.md#task-3 */
 		onPageSizeChanged(limit) {
 			this.limit = limit
 			this.page = 1

--- a/src/views/wrappers/MappingDetailPage.vue
+++ b/src/views/wrappers/MappingDetailPage.vue
@@ -275,13 +275,19 @@ export default {
 	},
 
 	computed: {
-		/** Pinia store instance. */
+		/**
+		 * Pinia store instance.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1
+		 */
 		store() {
 			return useObjectStore()
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		resolvedId() {
 			return this.id != null ? String(this.id) : ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		mapping() {
 			if (!this.resolvedId) return {}
 			return this.store.getObject(this.objectType, this.resolvedId) || {}
@@ -289,29 +295,36 @@ export default {
 		hasMapping() {
 			return !!this.mapping && Object.keys(this.mapping).length > 0
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		loading() {
 			return !!this.store.loading?.[this.objectType] && !this.hasMapping
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		loadError() {
 			return this.store.errors?.[this.objectType] || null
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		errorMessage() {
 			const err = this.loadError
 			if (!err) return ''
 			return err.message
 				|| this.t('openconnector', 'Failed to load mapping')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		title() {
 			return this.mapping?.name || this.t('openconnector', 'Mapping')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		description() {
 			return this.mapping?.description || ''
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		passThroughLabel() {
 			return this.mapping?.passThrough
 				? this.t('openconnector', 'Pass through enabled')
 				: this.t('openconnector', 'Pass through disabled')
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		sidebarConfig() {
 			return {
 				enabled: true,
@@ -321,18 +334,23 @@ export default {
 				showMetadata: true,
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		mappingRules() {
 			return asObjectMap(this.mapping?.mapping)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		castRules() {
 			return asObjectMap(this.mapping?.cast)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		unsetRules() {
 			return asUnsetList(this.mapping?.unset)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		samplePlaceholder() {
 			return '{\n  "name": "hello"\n}'
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4 */
 		formattedPreview() {
 			try {
 				return JSON.stringify(this.previewOutput, null, 2)
@@ -344,6 +362,8 @@ export default {
 		 * Combined reactivity key for the preview watcher. Recomputing this
 		 * forces the debounced preview to refire whenever the rule shape or
 		 * sample input changes.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1
 		 */
 		previewSignal() {
 			return JSON.stringify({
@@ -359,12 +379,14 @@ export default {
 	watch: {
 		previewSignal: {
 			immediate: false,
+			/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 			handler() {
 				this.schedulePreview()
 			},
 		},
 	},
 
+	/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 	mounted() {
 		this.ensureRegistered()
 		const fetch = this.reload()
@@ -372,12 +394,14 @@ export default {
 		Promise.resolve(fetch).finally(() => this.schedulePreview())
 	},
 
+	/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 	beforeDestroy() {
 		if (this.schedulePreview && this.schedulePreview.cancel) {
 			this.schedulePreview.cancel()
 		}
 	},
 
+	/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 	created() {
 		// Bind the debounced function on the instance so each component gets
 		// its own timer and `.cancel()` works on teardown.
@@ -390,6 +414,8 @@ export default {
 		 * time this page mounts. Idempotent — registering twice with the
 		 * same arguments is a no-op modulo Vue reactivity churn, but we
 		 * gate on `objectTypeRegistry` anyway.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1
 		 */
 		ensureRegistered() {
 			const registry = this.store.objectTypeRegistry || {}
@@ -406,7 +432,11 @@ export default {
 			)
 		},
 
-		/** Force a server-side re-fetch of the current mapping. */
+		/**
+		 * Force a server-side re-fetch of the current mapping.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1
+		 */
 		reload() {
 			if (!this.resolvedId) return Promise.resolve(null)
 			return this.store.fetchObject(this.objectType, this.resolvedId)
@@ -415,6 +445,8 @@ export default {
 		/**
 		 * Emit the bus event picked up by ModalHost (`src/modals/v2/ModalHost.vue`)
 		 * to mount TestMappingModal with the current mapping pre-loaded.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4
 		 */
 		openTestModal() {
 			if (!this.hasMapping) return
@@ -427,6 +459,8 @@ export default {
 		 * the existing values for unchanged fields stay intact.
 		 *
 		 * @param {object} patch Fields to merge over the current mapping.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1
 		 */
 		async persistPatch(patch) {
 			if (!this.hasMapping) return
@@ -446,15 +480,19 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		onUpdateMapping(nextRules) {
 			return this.persistPatch({ mapping: nextRules })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		onUpdateCast(nextRules) {
 			return this.persistPatch({ cast: nextRules })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		onUpdateUnset(nextList) {
 			return this.persistPatch({ unset: nextList })
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-1 */
 		onTogglePassThrough(value) {
 			return this.persistPatch({ passThrough: !!value })
 		},
@@ -463,6 +501,8 @@ export default {
 		 * Issue the live-preview request against `/api/mappings/test`. The
 		 * inflight indicator is shown next to the Output label so it
 		 * doesn't block edits in the rules table on the left.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4
 		 */
 		async runPreview() {
 			if (!this.hasMapping) return
@@ -505,7 +545,11 @@ export default {
 			}
 		},
 
-		/** Clear sample input + output and cancel any pending request. */
+		/**
+		 * Clear sample input + output and cancel any pending request.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-4
+		 */
 		resetPreview() {
 			if (this.schedulePreview && this.schedulePreview.cancel) {
 				this.schedulePreview.cancel()

--- a/src/views/wrappers/MappingRulesEditor.vue
+++ b/src/views/wrappers/MappingRulesEditor.vue
@@ -397,6 +397,7 @@ export default {
 	},
 
 	computed: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		tabs() {
 			return [
 				{
@@ -416,12 +417,14 @@ export default {
 				},
 			]
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		mappingRowList() {
 			return Object.keys(this.mappingRules).map((key) => ({
 				key,
 				value: this.mappingRules[key],
 			}))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		castRowList() {
 			return Object.keys(this.castRules).map((key) => ({
 				key,
@@ -432,18 +435,21 @@ export default {
 
 	watch: {
 		mappingRules: {
+			/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 			handler(next) {
 				this.mappingDraft = objectToRowList(next)
 			},
 			deep: true,
 		},
 		castRules: {
+			/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 			handler(next) {
 				this.castDraft = objectToRowList(next)
 			},
 			deep: true,
 		},
 		unsetRules: {
+			/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 			handler(next) {
 				this.unsetDraft = [...next]
 			},
@@ -452,6 +458,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		formatTemplate(value) {
 			if (value == null) return ''
 			if (typeof value === 'string') return value
@@ -461,6 +468,7 @@ export default {
 				return String(value)
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		existingKeysFor(kind, currentProperty) {
 			let keys = []
 			if (kind === 'mapping') keys = Object.keys(this.mappingRules)
@@ -472,6 +480,7 @@ export default {
 			return keys
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		openCreate(kind) {
 			this.editing = {
 				kind,
@@ -479,6 +488,7 @@ export default {
 				value: kind === 'cast' ? 'string' : '',
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		openEdit(kind, property) {
 			const source = kind === 'mapping' ? this.mappingRules : this.castRules
 			this.editing = {
@@ -487,6 +497,7 @@ export default {
 				value: source[property] ?? (kind === 'cast' ? 'string' : ''),
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		openEditUnset(property) {
 			this.editing = {
 				kind: 'unset',
@@ -495,6 +506,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		onSubmitDialog(payload) {
 			const { kind, property, value } = payload
 			if (kind === 'mapping') {
@@ -507,6 +519,7 @@ export default {
 			this.editing = null
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		commitMapping(oldKey, newKey, newValue) {
 			const next = { ...this.mappingRules }
 			if (oldKey && oldKey !== newKey) {
@@ -515,6 +528,7 @@ export default {
 			next[newKey] = newValue
 			this.$emit('update-mapping', next)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		commitCast(oldKey, newKey, newValue) {
 			const next = { ...this.castRules }
 			if (oldKey && oldKey !== newKey) {
@@ -523,6 +537,7 @@ export default {
 			next[newKey] = newValue
 			this.$emit('update-cast', next)
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		commitUnset(oldProperty, newProperty) {
 			const next = [...this.unsetRules]
 			if (oldProperty) {
@@ -547,6 +562,7 @@ export default {
 			this.$emit('update-unset', deduped)
 		},
 
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		deleteRule(kind, key) {
 			if (kind === 'mapping') {
 				const next = { ...this.mappingRules }
@@ -558,18 +574,25 @@ export default {
 				this.$emit('update-cast', next)
 			}
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		deleteUnset(property) {
 			const next = this.unsetRules.filter((entry) => entry !== property)
 			this.$emit('update-unset', next)
 		},
 
-		/** Drag-end handler: emit a rebuilt object in the new order. */
+		/**
+		 * Drag-end handler: emit a rebuilt object in the new order.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2
+		 */
 		onMappingReorder() {
 			this.$emit('update-mapping', rowListToObject(this.mappingDraft))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		onCastReorder() {
 			this.$emit('update-cast', rowListToObject(this.castDraft))
 		},
+		/** @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2 */
 		onUnsetReorder() {
 			this.$emit('update-unset', [...this.unsetDraft])
 		},
@@ -582,6 +605,8 @@ export default {
 		 * @param {'mapping'|'cast'|'unset'} kind Which collection.
 		 * @param {number} index Current row index.
 		 * @param {number} direction -1 to move up, 1 to move down.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-mapping-editor-ui/tasks.md#task-2
 		 */
 		moveRow(kind, index, direction) {
 			let list


### PR DESCRIPTION
## Retrofit — Spec Coverage to Zero

Closes all 415 spec-coverage (gate-16 `@spec`) gaps in openconnector: 45 backend + 370 frontend methods. PRODUCTION app; this is annotation-only — no behavior changes.

### Backend (45)
- **29 excluded** — SPA-shell route handlers (`UiController` 22 + per-controller `page()` 7) marked `@spec exclude` (framework lifecycle, return the index template only, no domain behavior).
- **16 annotated** to existing capabilities: `PdokController` → `add-pdok-adapter`; `StUFFieldMapper` → `stuf-adapter`; `IBabsConnectorService` → `ibabs-notubiz-connector`; `ConfigurationHandlerInterface` → `configuration-export-import`; `LegacyToRegisterMigrator` → `openconnector-register-storage`.

### Frontend (370) — 5 new reverse-spec capabilities, 23 REQs total
- `rule-editor-ui` (5 REQs / 144 methods) — rule detail page, JsonLogic condition tree, action-type forms, edit modal, endpoint-attach dialogs.
- `mapping-editor-ui` (5 REQs / 95) — mapping detail page, rule editor, edit dialog, test modals, result/save.
- `sync-editor-ui` (5 REQs / 84) — sync detail page, config widget, mapping picker/preview, reference list, edit/run/test modals.
- `endpoint-job-editor-ui` (5 REQs / 27) — endpoint editor, job form fields, run/test job, test source.
- `app-shell-and-logs-ui` (3 REQs / 20) — App.vue permissions/translate, ModalHost event bus, LogIndex viewer.

Each capability is a ghost change under `openspec/changes/retrofit-2026-05-25-*-ui/` with `proposal.md` + `specs/<cap>/spec.md` (`retrofit: true`) + `tasks.md` (all `[x]`). REQ language describes observed behavior, not aspiration.

### Verification
`python3 csc.py <worktree> --mode report` → **0 uncovered** (from 415).

### Notes (observed, not fixed)
- `IBabsConnectorService::pushVoorstel` / `pollBesluiten` ship placeholder bodies ("not yet implemented" / `return []`); REQs flag this in notes rather than over-specifying.

### Tally
- annotated: 16 backend + 370 frontend
- reverse-spec'd: 5 capabilities / 23 REQs
- excluded: 29 (SPA-shell plumbing)