### PR TITLE
feat(nav): add Features & roadmap item + roadmap page (three-item nav)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ The OpenConnector Nextcloud app provides a ESB-framework to work together in an 
 
 **Support:** For support, contact support@conduction.nl. For a Service Level Agreement (SLA), contact sales@conduction.nl.
     ]]></description>
-	<version>0.2.9</version>
+	<version>0.2.10</version>
 	<licence>agpl</licence>
 	<category>integration</category>
 	<author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^1.0.0-beta.97",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.101",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@mdi/js": "^7.4.47",
@@ -2045,9 +2045,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.97",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.97.tgz",
-      "integrity": "sha512-jlRpA1tjIX3ysP8a42S6lrbrcZfN63yHDzgWMBNaf9Ofs0jvVqqkYawLuEj8vGMU1H4hwvyb0lEOHIsNRmHP6g==",
+      "version": "1.0.0-beta.101",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.101.tgz",
+      "integrity": "sha512-UVxKWUU7pf6oHr7Oly5HWPC1e8OK3z2lmdS5xgs28+sYZPNj53co9+xs3tb0mqCGXZ8Oqit9NMapI8ir0fy2iA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^1.0.0-beta.97",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.101",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@mdi/js": "^7.4.47",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -90,9 +90,26 @@
       "route": "AppSettings",
       "section": "settings",
       "order": 20
+    },
+    {
+      "id": "FeaturesRoadmapMenu",
+      "label": "Features & roadmap",
+      "icon": "icon-toggle",
+      "route": "FeaturesRoadmap",
+      "section": "footer",
+      "order": 16
     }
   ],
   "pages": [
+    {
+      "id": "FeaturesRoadmap",
+      "route": "/features-roadmap",
+      "type": "roadmap",
+      "title": "Features & roadmap",
+      "config": {
+        "documentationUrl": "https://openconnector.conduction.nl"
+      }
+    },
     {
       "id": "Dashboard",
       "route": "/",


### PR DESCRIPTION
Completes the three-item nav set on openconnector: adds the **Features & roadmap** footer entry + its `type:"roadmap"` page, alongside the existing Documentation footer link and the (now always-on) Settings foldout. Bumps `@conduction/nextcloud-vue` → `1.0.0-beta.101`. Version → 0.2.10.