### PR TITLE
retrofit: spec-cover preferences API + synced-from tab

### DIFF
--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -60,6 +60,8 @@ class PreferencesController extends Controller
      *
      * @return JSONResponse `{value: string|null}`.
      *
+     * @spec openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md#task-1
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      */
@@ -98,6 +100,8 @@ class PreferencesController extends Controller
      * @param string $value The value to store (empty string clears it).
      *
      * @return JSONResponse `{value: string|null}`.
+     *
+     * @spec openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md#task-2
      *
      * @NoAdminRequired
      * @NoCSRFRequired

--- a/openspec/changes/retrofit-2026-05-26-integration-synced-from/proposal.md
+++ b/openspec/changes/retrofit-2026-05-26-integration-synced-from/proposal.md
@@ -1,0 +1,16 @@
+# retrofit-2026-05-26-integration-synced-from
+
+## Why
+
+OpenConnector ships a bespoke "Synced from" integration leaf (`SyncedFromTab.vue`, registry id `sync-contract`) that renders the synchronization provenance chain for any OpenRegister object. Two non-trivial frontend members — the `endpoint` computed (resolves the per-object sub-resource URL) and the `fetchRows` method (loads the provenance rows, degrading quietly on failure) — are a real capability lacking a written spec; this change reverse-specs it.
+
+## What Changes
+
+- Document how the synced-from tab resolves its source sub-resource endpoint and fetches provenance rows (including AD-23 quiet-degrade on 5xx/network error).
+- No code changes — annotation-only retrofit.
+
+## Impact
+
+- **Affected specs**: new capability `synced-from-tab`
+- **Affected code**: `src/integration/SyncedFromTab.vue` (JSDoc `@spec` annotations only)
+- **Risk**: none — comment-only.

--- a/openspec/changes/retrofit-2026-05-26-integration-synced-from/specs/synced-from-tab/spec.md
+++ b/openspec/changes/retrofit-2026-05-26-integration-synced-from/specs/synced-from-tab/spec.md
@@ -1,0 +1,29 @@
+# Capability: synced-from-tab
+
+## ADDED Requirements
+
+### Requirement: Resolve synced-from source endpoint (REQ-SYNC-001)
+The system SHALL resolve the per-object synchronization sub-resource endpoint for the synced-from tab, preferring an injected `apiBase` when present and otherwise falling back to the OpenRegister API path, scoped to the current object's register, schema, and id under the `sync-contract` integration.
+
+#### Scenario: apiBase is honoured when provided
+- **GIVEN** an injected `apiBase`
+- **WHEN** the endpoint is resolved
+- **THEN** the endpoint MUST be built from that `apiBase` and the object's register/schema/id
+
+#### Scenario: Falls back to OpenRegister API path
+- **GIVEN** no injected `apiBase`
+- **WHEN** the endpoint is resolved
+- **THEN** the endpoint MUST be built from the OpenRegister API base path
+
+### Requirement: Fetch synced-from rows (REQ-SYNC-002)
+The system SHALL fetch the synchronization provenance rows for the current object from the resolved endpoint, normalize the response into a list of rows, and on a 5xx or network failure degrade quietly by flagging the surface unavailable rather than throwing.
+
+#### Scenario: Successful fetch populates rows
+- **GIVEN** an endpoint returning provenance data
+- **WHEN** rows are fetched
+- **THEN** the rows MUST be populated from the response
+
+#### Scenario: Failure degrades quietly
+- **GIVEN** an endpoint returning a 5xx or network error
+- **WHEN** rows are fetched
+- **THEN** the unavailable flag MUST be set and no error MUST propagate

--- a/openspec/changes/retrofit-2026-05-26-integration-synced-from/tasks.md
+++ b/openspec/changes/retrofit-2026-05-26-integration-synced-from/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — retrofit-2026-05-26-integration-synced-from
+
+## 1. Annotate synced-from tab members
+
+- [x] task-1 Annotate `SyncedFromTab.endpoint` against REQ-SYNC-001
+- [x] task-2 Annotate `SyncedFromTab.fetchRows` against REQ-SYNC-002
+
+## 2. Validate
+
+- [x] task-3 `python3 /tmp/csc.py . --mode report` shows this app at zero uncovered

--- a/openspec/changes/retrofit-2026-05-26-preferences-api/proposal.md
+++ b/openspec/changes/retrofit-2026-05-26-preferences-api/proposal.md
@@ -1,0 +1,16 @@
+# retrofit-2026-05-26-preferences-api
+
+## Why
+
+This app exposes a generic per-user preferences endpoint (read/write a small key/value flag, backed by Nextcloud `IConfig` user values) consumed by shared `@conduction/nextcloud-vue` widgets that need to persist a cross-device UI flag without a bespoke endpoint per feature. This is a real backend capability lacking a written spec; this change reverse-specs it.
+
+## What Changes
+
+- Document the get/set preference endpoints (authentication, key sanitization to a `pref_` namespace, empty-value-clears semantics).
+- No code changes — annotation-only retrofit.
+
+## Impact
+
+- **Affected specs**: new capability `preferences-api`
+- **Affected code**: `lib/Controller/PreferencesController.php` (docblock `@spec` annotations only)
+- **Risk**: none — comment-only.

--- a/openspec/changes/retrofit-2026-05-26-preferences-api/specs/preferences-api/spec.md
+++ b/openspec/changes/retrofit-2026-05-26-preferences-api/specs/preferences-api/spec.md
@@ -1,0 +1,24 @@
+# Capability: preferences-api
+
+## ADDED Requirements
+
+### Requirement: Get user preference (REQ-PREF-001)
+The system SHALL return a stored per-user preference value for a given key (scoped to the current user), or a default when unset. The get-preference endpoint MUST require an authenticated user, MUST sanitize the requested key to a safe charset within the `pref_` namespace, and MUST return the stored value (or null when unset). An unauthenticated request MUST be rejected and an invalid key MUST yield a bad-request response.
+
+#### Scenario: Unauthenticated read rejected
+- **GIVEN** no logged-in user
+- **WHEN** get-preference is called
+- **THEN** the response MUST be 401 Unauthorized
+
+#### Scenario: Key is sanitized
+- **GIVEN** a key containing unsafe characters
+- **WHEN** the value is read
+- **THEN** only the sanitized key within the `pref_` namespace MUST be consulted
+
+### Requirement: Set user preference (REQ-PREF-002)
+The system SHALL persist a per-user preference value for a given key scoped to the authenticated user. The set-preference endpoint MUST require an authenticated user, MUST sanitize the key, MUST store a non-empty value, and MUST clear the value when an empty string is supplied; an unauthenticated request MUST be rejected and an invalid key MUST yield a bad-request response.
+
+#### Scenario: Empty value clears the preference
+- **GIVEN** an existing stored preference
+- **WHEN** set-preference is called with an empty value
+- **THEN** the preference MUST be deleted and null returned

--- a/openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md
+++ b/openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — retrofit-2026-05-26-preferences-api
+
+## 1. Annotate preferences endpoints
+
+- [x] task-1 Annotate `PreferencesController::getPreference` against REQ-PREF-001
+- [x] task-2 Annotate `PreferencesController::setPreference` against REQ-PREF-002
+
+## 2. Validate
+
+- [x] task-3 `python3 /tmp/csc.py . --mode report` shows this app at zero uncovered

--- a/src/integration/SyncedFromTab.vue
+++ b/src/integration/SyncedFromTab.vue
@@ -107,6 +107,8 @@ export default {
 		 * when present, else the OpenRegister API path.
 		 *
 		 * @return {string} The integration list endpoint.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-26-integration-synced-from/tasks.md#task-1
 		 */
 		endpoint() {
 			const base = this.apiBase || generateUrl('/apps/openregister/api')
@@ -127,6 +129,8 @@ export default {
 		 * throwing — the surface degrades quietly.
 		 *
 		 * @return {Promise<void>}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-26-integration-synced-from/tasks.md#task-2
 		 */
 		async fetchRows() {
 			this.loading = true


### PR DESCRIPTION
## Why

Gate-16 spec coverage flagged 4 uncovered methods on `development`, all true capabilities (so they get real reverse-specs, not excludes):

- `lib/Controller/PreferencesController.php::getPreference` / `setPreference` — the generic per-user preferences endpoint.
- `src/integration/SyncedFromTab.vue::endpoint` / `fetchRows` — the 'Synced from' integration leaf's endpoint resolver and provenance-row fetch.

## What

- New change `retrofit-2026-05-26-preferences-api` → capability `preferences-api` (REQ-PREF-001 get / REQ-PREF-002 set).
- New change `retrofit-2026-05-26-integration-synced-from` → capability `synced-from-tab` (REQ-SYNC-001 resolve endpoint / REQ-SYNC-002 fetch rows, incl. AD-23 quiet-degrade).
- `@spec` docblock/JSDoc annotations on all 4 members.
- Both changes `openspec validate --strict` green; `python3 /tmp/csc.py . --mode report` → uncovered_count == 0; `php -l` + `node --check` clean.

Comment-only; no behaviour change. Production app — left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)