### PR TITLE
fix: resolve hydra mechanical gates (spdx, nc-input-labels, modal-isolation)

### DIFF
--- a/lib/Repair/InitializeRegister.php
+++ b/lib/Repair/InitializeRegister.php
@@ -16,13 +16,12 @@
  * @package  OCA\OpenConnector\Repair
  *
  * @author  Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
  * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://www.OpenConnector.nl
  */
 
-// SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>.
-// SPDX-License-Identifier: EUPL-1.2.
 declare(strict_types=1);
 
 namespace OCA\OpenConnector\Repair;

--- a/src/dialogs/EditMappingRuleDialog.vue
+++ b/src/dialogs/EditMappingRuleDialog.vue
@@ -59,6 +59,7 @@
 					<NcSelect :value="castSelectValue"
 						:options="castTypeOptions"
 						:clearable="false"
+						:aria-label-combobox="t('openconnector', 'Cast type')"
 						input-id="cn-rule-dialog-cast-type"
 						@input="onCastTypeInput" />
 				</label>

--- a/src/modals/Endpoint/EditEndpoint.vue
+++ b/src/modals/Endpoint/EditEndpoint.vue
@@ -51,11 +51,13 @@ import { translate as t } from '@nextcloud/l10n'
 
 					<div>
 						<NcSelect v-bind="methodOptions"
+							:input-label="t('openconnector', 'Method')"
 							v-model="methodOptions.value" />
 					</div>
 
 					<div>
 						<NcSelect v-bind="targetTypeOptions"
+							:input-label="t('openconnector', 'Target Type')"
 							v-model="targetTypeOptions.value" />
 					</div>
 

--- a/src/modals/README.md
+++ b/src/modals/README.md
@@ -40,5 +40,5 @@ fresh bespoke component, the legacy file gets removed in the same PR.
 | File | Removed in | Replacement |
 |---|---|---|
 | `Mapping/EditMapping.vue` | #874 | `src/views/wrappers/MappingDetailPage.vue` + `MappingRulesEditor.vue` + `EditMappingRuleDialog.vue` (3-tab transformation-rules editor on CnDetailPage) |
-| `Mapping/mappingItem/EditMappingItem.vue` | #874 | `src/views/wrappers/EditMappingRuleDialog.vue` |
+| `Mapping/mappingItem/EditMappingItem.vue` | #874 | `src/dialogs/EditMappingRuleDialog.vue` |
 | `Mapping/mappingItem/DeleteMappingItem.vue` | #874 | CnDetailPage's built-in delete action on the rule row |

--- a/src/modals/Rule/EditRule.vue
+++ b/src/modals/Rule/EditRule.vue
@@ -126,9 +126,9 @@ import { translate as t } from '@nextcloud/l10n'
 					:input-label="t('openconnector', 'Action')" />
 
 				<NcSelect v-bind="typeOptions"
+					:input-label="t('openconnector', 'Type')"
 					v-model="typeOptions.value"
-					:selectable="(option) => option.label === 'Fileparts Create' || option.label === 'Filepart Upload' ? openRegister?.isInstalled : true"
-					:input-label="t('openconnector', 'Type')" />
+					:selectable="(option) => option.label === 'Fileparts Create' || option.label === 'Filepart Upload' ? openRegister?.isInstalled : true" />
 
 				<!-- Add mapping select -->
 				<NcSelect v-if="typeOptions.value?.id === 'mapping' || typeOptions.value?.id === 'save_object'"
@@ -263,6 +263,7 @@ import { translate as t } from '@nextcloud/l10n'
 							<div class="extendItemProperty">
 								<label>{{ t('openconnector', 'Extends (dot array)') }}</label>
 								<NcSelect
+									:aria-label-combobox="t('openconnector', 'Extends (dot array)')"
 									v-model="item.extends"
 									:taggable="true"
 									:multiple="true"

--- a/src/modals/Synchronization/EditSynchronization.vue
+++ b/src/modals/Synchronization/EditSynchronization.vue
@@ -94,11 +94,11 @@ import { translate as t } from '@nextcloud/l10n'
 						<!-- Source Type -->
 						<div class="form-group">
 							<NcSelect v-bind="typeOptions"
+								:input-label="t('openconnector', 'Source type')"
 								v-model="typeOptions.value"
 								:selectable="(option) => {
 									return option.id === 'register/schema' ? openRegisterInstalled : true
-								}"
-								:input-label="t('openconnector', 'Source type')" />
+								}" />
 						</div>
 
 						<!-- Source ID -->
@@ -252,11 +252,11 @@ import { translate as t } from '@nextcloud/l10n'
 						<!-- Target Type -->
 						<div class="form-group">
 							<NcSelect v-bind="targetTypeOptions"
+								:input-label="t('openconnector', 'Target type')"
 								v-model="targetTypeOptions.value"
 								:selectable="(option) => {
 									return option.id === 'register/schema' ? openRegisterInstalled : true
-								}"
-								:input-label="t('openconnector', 'Target type')" />
+								}" />
 						</div>
 
 						<!-- Target ID -->

--- a/src/modals/TestSource/TestSource.vue
+++ b/src/modals/TestSource/TestSource.vue
@@ -17,11 +17,13 @@ import { sourceStore, navigationStore } from '../../store/store.js'
 						<NcSelect
 							id="method"
 							v-bind="methodOptions"
+							:input-label="t('openconnector', 'Method')"
 							v-model="methodOptions.value" />
 
 						<NcSelect
 							id="type"
 							v-bind="typeOptions"
+							:input-label="t('openconnector', 'Type')"
 							v-model="typeOptions.value" />
 
 						<NcTextField

--- a/src/modals/v2/AddEndpointRuleModal.vue
+++ b/src/modals/v2/AddEndpointRuleModal.vue
@@ -41,6 +41,7 @@
 				</label>
 				<NcSelect
 					id="cn-add-endpoint-rule-select"
+					:aria-label-combobox="t('openconnector', 'Select rules to add')"
 					v-model="selectedRules"
 					:options="availableRules"
 					:loading="loadingRules"

--- a/src/modals/v2/JobFormFields.vue
+++ b/src/modals/v2/JobFormFields.vue
@@ -39,6 +39,7 @@
 				</label>
 				<NcSelect
 					:input-id="'cn-job-form-' + field.key"
+					:aria-label-combobox="t('openconnector', 'Synchronization')"
 					:value="selectedSynchronization"
 					:options="synchronizationOptions"
 					:loading="synchronizationsLoading"
@@ -66,6 +67,7 @@
 					</label>
 					<NcSelect
 						:input-id="'cn-job-form-' + field.key"
+						:aria-label-combobox="field.label || t('openconnector', 'Action class')"
 						:value="selectedJobClassOption"
 						:options="jobClassOptions"
 						:clearable="!field.required"
@@ -168,6 +170,7 @@
 			</label>
 			<NcSelect
 				input-id="cn-job-form-arguments"
+				:aria-label-combobox="t('openconnector', 'Synchronization')"
 				:value="selectedSynchronization"
 				:options="synchronizationOptions"
 				:loading="synchronizationsLoading"

--- a/src/modals/v2/TestMappingModal.vue
+++ b/src/modals/v2/TestMappingModal.vue
@@ -47,6 +47,7 @@
 						{{ t('openconnector', 'Validate against schema (optional)') }}
 					</label>
 					<NcSelect id="cn-test-mapping-schema"
+						:aria-label-combobox="t('openconnector', 'Validate against schema (optional)')"
 						v-model="selectedSchema"
 						:options="schemaOptions"
 						:loading="schemasLoading"

--- a/src/views/Rule/RuleActionConfig.vue
+++ b/src/views/Rule/RuleActionConfig.vue
@@ -26,6 +26,7 @@
 			</label>
 			<NcSelect
 				:input-id="'rule-action-type-' + uid"
+				:aria-label-combobox="t('openconnector', 'Action type')"
 				:value="selectedTypeOption"
 				:options="typeOptions"
 				:clearable="false"

--- a/src/views/Rule/RuleConditionGroup.vue
+++ b/src/views/Rule/RuleConditionGroup.vue
@@ -22,6 +22,7 @@
 			<NcSelect
 				class="rule-condition-group__op"
 				:input-id="'rule-condition-group-op-' + uid"
+				:input-label="t('openconnector', 'Group operator')"
 				:value="selectedOperator"
 				:options="operatorOptions"
 				:clearable="false"

--- a/src/views/Rule/RuleConditionLeaf.vue
+++ b/src/views/Rule/RuleConditionLeaf.vue
@@ -36,6 +36,7 @@
 		<NcSelect
 			class="rule-condition-leaf__op"
 			:input-id="'rule-condition-op-' + uid"
+			:input-label="t('openconnector', 'Operator')"
 			:value="selectedOperator"
 			:options="operatorOptions"
 			:clearable="false"

--- a/src/views/Rule/actionForms/AuthenticationForm.vue
+++ b/src/views/Rule/actionForms/AuthenticationForm.vue
@@ -11,6 +11,7 @@
 	<div class="action-form">
 		<label class="action-form__label">{{ t('openconnector', 'Authentication type') }}</label>
 		<NcSelect
+			:aria-label-combobox="t('openconnector', 'Authentication type')"
 			:value="selectedTypeOption"
 			:options="typeOptions"
 			:clearable="false"

--- a/src/views/Rule/actionForms/FetchFileForm.vue
+++ b/src/views/Rule/actionForms/FetchFileForm.vue
@@ -13,6 +13,7 @@
 		<label class="action-form__label">{{ t('openconnector', 'Source') }}</label>
 		<NcSelect
 			data-testid="action-form-fetch-source"
+			:aria-label-combobox="t('openconnector', 'Source')"
 			:value="selectedSource"
 			:options="sourceOptions"
 			:loading="sourcesLoading"

--- a/src/views/Rule/actionForms/FilepartUploadForm.vue
+++ b/src/views/Rule/actionForms/FilepartUploadForm.vue
@@ -9,6 +9,7 @@
 		<label class="action-form__label">{{ t('openconnector', 'Inbound mapping (required)') }}</label>
 		<NcSelect
 			data-testid="action-form-filepart-upload-mapping"
+			:aria-label-combobox="t('openconnector', 'Inbound mapping (required)')"
 			:value="selectedInbound"
 			:options="mappingOptions"
 			:loading="loading"
@@ -17,6 +18,7 @@
 
 		<label class="action-form__label">{{ t('openconnector', 'Outbound mapping (optional)') }}</label>
 		<NcSelect
+			:aria-label-combobox="t('openconnector', 'Outbound mapping (optional)')"
 			:value="selectedOutbound"
 			:options="mappingOptions"
 			:loading="loading"

--- a/src/views/Rule/actionForms/FilepartsCreateForm.vue
+++ b/src/views/Rule/actionForms/FilepartsCreateForm.vue
@@ -15,6 +15,7 @@
 		<label class="action-form__label">{{ t('openconnector', 'Schema') }}</label>
 		<NcSelect
 			data-testid="action-form-fileparts-schema"
+			:aria-label-combobox="t('openconnector', 'Schema')"
 			:value="selectedSchema"
 			:options="schemaOptions"
 			:loading="schemasLoading"
@@ -32,6 +33,7 @@
 			@update:value="(next) => patch('filePartLocation', next)" />
 		<label class="action-form__label">{{ t('openconnector', 'Mapping (optional)') }}</label>
 		<NcSelect
+			:aria-label-combobox="t('openconnector', 'Mapping (optional)')"
 			:value="selectedMapping"
 			:options="mappingOptions"
 			:loading="mappingsLoading"

--- a/src/views/Rule/actionForms/LockingForm.vue
+++ b/src/views/Rule/actionForms/LockingForm.vue
@@ -10,6 +10,7 @@
 	<div class="action-form">
 		<label class="action-form__label">{{ t('openconnector', 'Lock action') }}</label>
 		<NcSelect
+			:aria-label-combobox="t('openconnector', 'Lock action')"
 			:value="selectedAction"
 			:options="actionOptions"
 			:clearable="false"

--- a/src/views/Rule/actionForms/MappingForm.vue
+++ b/src/views/Rule/actionForms/MappingForm.vue
@@ -13,6 +13,7 @@
 		<label class="action-form__label">{{ t('openconnector', 'Mapping') }}</label>
 		<NcSelect
 			data-testid="action-form-mapping"
+			:aria-label-combobox="t('openconnector', 'Mapping')"
 			:value="selected"
 			:options="options"
 			:loading="loading"

--- a/src/views/Rule/actionForms/SaveObjectForm.vue
+++ b/src/views/Rule/actionForms/SaveObjectForm.vue
@@ -10,6 +10,7 @@
 		<label class="action-form__label">{{ t('openconnector', 'Register (required)') }}</label>
 		<NcSelect
 			data-testid="action-form-save-register"
+			:aria-label-combobox="t('openconnector', 'Register (required)')"
 			:value="selectedRegister"
 			:options="registerOptions"
 			:loading="loading"
@@ -19,6 +20,7 @@
 		<label class="action-form__label">{{ t('openconnector', 'Schema (required)') }}</label>
 		<NcSelect
 			data-testid="action-form-save-schema"
+			:aria-label-combobox="t('openconnector', 'Schema (required)')"
 			:value="selectedSchema"
 			:options="schemaOptions"
 			:loading="loading"
@@ -27,6 +29,7 @@
 
 		<label class="action-form__label">{{ t('openconnector', 'Mapping (optional)') }}</label>
 		<NcSelect
+			:aria-label-combobox="t('openconnector', 'Mapping (optional)')"
 			:value="selectedMapping"
 			:options="mappingOptions"
 			:loading="loading"

--- a/src/views/Rule/actionForms/SynchronizationForm.vue
+++ b/src/views/Rule/actionForms/SynchronizationForm.vue
@@ -14,6 +14,7 @@
 		<label class="action-form__label">{{ t('openconnector', 'Synchronization') }}</label>
 		<NcSelect
 			data-testid="action-form-sync"
+			:aria-label-combobox="t('openconnector', 'Synchronization')"
 			:value="selectedSync"
 			:options="syncOptions"
 			:loading="loading"

--- a/src/views/Synchronization/SyncConfigWidget.vue
+++ b/src/views/Synchronization/SyncConfigWidget.vue
@@ -43,6 +43,7 @@
 				</label>
 				<NcSelect
 					:input-id="apiSourceId"
+					:aria-label-combobox="t('openconnector', 'Source (API)')"
 					:value="selectedSource"
 					:options="sourceOptions"
 					:loading="sourcesLoading"
@@ -86,6 +87,7 @@
 				</label>
 				<NcSelect
 					:input-id="registerSelectId"
+					:aria-label-combobox="t('openconnector', 'Register')"
 					:value="selectedRegister"
 					:options="registerOptions"
 					:loading="registersLoading"
@@ -99,6 +101,7 @@
 				</label>
 				<NcSelect
 					:input-id="schemaSelectId"
+					:aria-label-combobox="t('openconnector', 'Schema')"
 					:value="selectedSchema"
 					:options="schemaOptions"
 					:disabled="!selectedRegister"

--- a/src/views/Synchronization/SyncMappingPicker.vue
+++ b/src/views/Synchronization/SyncMappingPicker.vue
@@ -32,6 +32,7 @@
 			</label>
 			<NcSelect
 				:input-id="primaryId"
+				:aria-label-combobox="t('openconnector', 'Source → Target mapping')"
 				:value="selectedPrimary"
 				:options="mappingOptions"
 				:loading="loading"
@@ -49,6 +50,7 @@
 			</label>
 			<NcSelect
 				:input-id="reverseId"
+				:aria-label-combobox="t('openconnector', 'Target → Source mapping')"
 				:value="selectedReverse"
 				:options="mappingOptions"
 				:loading="loading"
@@ -66,6 +68,7 @@
 			</label>
 			<NcSelect
 				:input-id="hashId"
+				:aria-label-combobox="t('openconnector', 'Hash mapping')"
 				:value="selectedHash"
 				:options="mappingOptions"
 				:loading="loading"

--- a/src/views/Synchronization/SyncReferenceList.vue
+++ b/src/views/Synchronization/SyncReferenceList.vue
@@ -22,6 +22,7 @@
 	<div class="sync-ref-list">
 		<NcSelect
 			:input-id="inputId"
+			:input-label="inputLabel"
 			:value="selectedOptions"
 			:options="options"
 			:loading="loading"
@@ -38,6 +39,7 @@
 
 <script>
 import { NcSelect } from '@nextcloud/vue'
+import { translate as t } from '@nextcloud/l10n'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
@@ -68,6 +70,8 @@ export default {
 		excludeId: { type: String, default: '' },
 		placeholder: { type: String, default: '' },
 		emptyLabel: { type: String, default: '' },
+		/** Accessible label for the combobox input. */
+		inputLabel: { type: String, default: () => t('openconnector', 'References') },
 	},
 
 	data() {

--- a/src/views/Synchronization/SynchronizationDetailPage.vue
+++ b/src/views/Synchronization/SynchronizationDetailPage.vue
@@ -93,6 +93,7 @@
 						</label>
 						<NcSelect
 							:input-id="'sync-source-type'"
+							:aria-label-combobox="t('openconnector', 'Source type')"
 							:value="selectedSourceType"
 							:options="typeOptions"
 							:clearable="false"
@@ -170,6 +171,7 @@
 						</label>
 						<NcSelect
 							:input-id="'sync-target-type'"
+							:aria-label-combobox="t('openconnector', 'Target type')"
 							:value="selectedTargetType"
 							:options="typeOptions"
 							:clearable="false"

--- a/src/views/wrappers/MappingRulesEditor.vue
+++ b/src/views/wrappers/MappingRulesEditor.vue
@@ -298,7 +298,7 @@ import DeleteIcon from 'vue-material-design-icons/Delete.vue'
 import DragVerticalIcon from 'vue-material-design-icons/DragVertical.vue'
 import { VueDraggable } from 'vue-draggable-plus'
 
-import EditMappingRuleDialog from './EditMappingRuleDialog.vue'
+import EditMappingRuleDialog from '../../dialogs/EditMappingRuleDialog.vue'
 
 /**
  * Convert a keyed-rules object into an ordered array of `{ key, value }`


### PR DESCRIPTION
Bucket-A safe fixes from the fleet-wide hydra-gates sweep: SPDX docblock tag, accessible labels on NcSelect, and relocating EditMappingRuleDialog into src/dialogs/. No behavior change. Security-semantic findings (route-auth, orphan-auth, no-admin-idor, semantic-auth, route-reachability) tracked in a separate backlog issue.