### PR TITLE
fix: real bugs from fleet quality sweep (phpcs, Exception guard, undeclared prop, publiccode)

### DIFF
--- a/lib/Service/AuthenticationService.php
+++ b/lib/Service/AuthenticationService.php
@@ -76,6 +76,13 @@ class AuthenticationService
     ];
 
     /**
+     * Twig environment used for template rendering in authentication flows.
+     *
+     * @var Environment
+     */
+    private Environment $twig;
+
+    /**
      * Setting up the class with required service.
      *
      * @param ArrayLoader $loader The ArrayLoader for Twig.

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -1504,7 +1504,7 @@ class SynchronizationService
                     // a contract's `targetId` UUID accidentally collides with an object in a
                     // foreign register/schema.
                     //
-                    // _rbac / _multitenancy are off because the previous SQL-level guard this
+                    // Note: _rbac / _multitenancy are off because the previous SQL-level guard this
                     // replaces (the JOIN against `openregister_objects` in the pre-cutover code)
                     // did not apply RBAC either — the safety property being restored is scope, not
                     // permission. Ported from #733 (author @rjzondervan).
@@ -4986,6 +4986,15 @@ class SynchronizationService
                 mutationType: $mutationType
             );
 
+            if ($synchronizationContractResult instanceof \Exception) {
+                $this->logger->error(
+                    'synchronizeContract failed (new contract): '.$synchronizationContractResult->getMessage(),
+                    ['exception' => $synchronizationContractResult]
+                );
+                $result['objects']['invalid']++;
+                return ['result' => $result, 'targetId' => null];
+            }
+
             $synchronizationContract = ($synchronizationContractResult['contract'] ?? []);
             $result['contracts'][]   = ($synchronizationContract['uuid'] ?? null);
             if (isset($synchronizationContractResult['log']) === true) {
@@ -5010,6 +5019,15 @@ class SynchronizationService
                 log: $log,
                 mutationType: $mutationType
             );
+
+            if ($synchronizationContractResult instanceof \Exception) {
+                $this->logger->error(
+                    'synchronizeContract failed (existing contract): '.$synchronizationContractResult->getMessage(),
+                    ['exception' => $synchronizationContractResult]
+                );
+                $result['objects']['invalid']++;
+                return ['result' => $result, 'targetId' => null];
+            }
 
             $synchronizationContract = $synchronizationContractResult['contract'];
             if (isset($synchronizationContractResult['contract']['uuid']) === true) {

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,66 @@
+publiccodeYmlVersion: '0.4'
+
+name: Open Connector
+url: https://github.com/ConductionNL/openconnector
+softwareVersion: '0.2.10'
+releaseDate: '2026-05-26'
+developmentStatus: stable
+softwareType: softwareAddon
+
+platforms:
+  - nextcloud
+
+categories:
+  - data-collection
+
+description:
+  en:
+    shortDescription: >-
+      Gateway and service bus for Nextcloud: synchronise data sources,
+      send cloud events, and map API calls.
+    longDescription: >-
+      OpenConnector brings gateway and service bus functionality to Nextcloud.
+      It provides an ESB-framework for working together in an open data
+      ecosystem: synchronise external data sources, emit cloud events,
+      and translate API calls through configurable mappings.
+    features:
+      - Data source synchronisation
+      - Cloud event publishing
+      - API mapping and translation
+  nl:
+    shortDescription: >-
+      Gateway en servicebus voor Nextcloud: synchroniseer databronnen,
+      verstuur cloud events en vertaal API-aanroepen.
+    longDescription: >-
+      OpenConnector biedt gateway- en servicebusfunctionaliteit voor Nextcloud.
+      Het levert een ESB-raamwerk voor samenwerking in een open data-ecosysteem:
+      synchroniseer externe databronnen, publiceer cloud events en vertaal
+      API-aanroepen via configureerbare mappings.
+    features:
+      - Synchronisatie van databronnen
+      - Publiceren van cloud events
+      - API-mapping en -vertaling
+
+legal:
+  license: EUPL-1.2
+  mainCopyrightOwner: Conduction B.V.
+  repoOwner: ConductionNL
+
+maintenance:
+  type: internal
+  contacts:
+    - name: Conduction Development Team
+      email: info@conduction.nl
+      affiliation: Conduction B.V.
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - en
+    - nl
+
+dependsOn:
+  open:
+    - name: OpenRegister
+      url: https://github.com/ConductionNL/openregister
+      version-min: '0.2.0'


### PR DESCRIPTION
## Summary

Fleet quality sweep surfaced four real findings in this PRODUCTION app. All are surgical, non-behavioural-breaking fixes:

- **PHPCS `Squiz.Commenting.InlineComment.NotCapital`** (`SynchronizationService.php:~1507`): An inline comment paragraph started with `// _rbac / _multitenancy are off…` — underscore is not a capital letter. Prefixed with `// Note:` to satisfy the rule while keeping the explanation intact.

- **Type-safety bug — `synchronizeContract()` Exception path** (`SynchronizationService.php`, `processSynchronizationObject`): `synchronizeContract()` is declared `ObjectEntity|Exception|array`. It returns `new Exception(…)` when a `sourceTargetMapping` is not found (line 1733). Both call sites inside `processSynchronizationObject` then array-subscripted the result without checking for `Exception` first — a fatal `TypeError` at runtime for any sync with a missing source-target mapping. Fix: added `instanceof \Exception` guard at each call site; on failure the error is logged via `$this->logger->error(…)`, `invalid` counter is incremented, and the method returns early with `['result' => $result, 'targetId' => null]` — consistent with the method's contract.

- **Undeclared property `AuthenticationService::$twig`** (`AuthenticationService.php:~86`): `$this->twig` was assigned in the constructor but the property was never declared. Added `private Environment $twig;` with a brief docblock above the constructor.

- **`publiccode.yml` added at repo root**: Minimal valid PublicCode v0.4 file (name, url, version/releaseDate from `appinfo/info.xml`, `developmentStatus: stable`, `platforms: [nextcloud]`, `categories: [data-collection]`, `legal.license: EUPL-1.2`, `localisation: nl+en`, short descriptions in both languages).

## Test plan

- [ ] `php -l lib/Service/SynchronizationService.php` → `No syntax errors detected` ✓
- [ ] `php -l lib/Service/AuthenticationService.php` → `No syntax errors detected` ✓
- [ ] Run a synchronization that has a `sourceTargetMapping` pointing to a non-existent mapping: previously fatal TypeError; now logs an error and marks the object invalid instead of crashing.
- [ ] PHPCS on `SynchronizationService.php` — no `InlineComment.NotCapital` error.
- [ ] Psalm/PHPStan on `AuthenticationService.php` — `UndefinedThisPropertyAssignment` gone.

**PRODUCTION app — awaiting review before merge.**