### PR TITLE
refactor: migrate deprecated IConfig app-values to IAppConfig

### DIFF
--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -22,6 +22,7 @@ namespace OCA\OpenConnector\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TextPlainResponse;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IRequest;
@@ -49,16 +50,18 @@ class MetricsController extends Controller
     /**
      * MetricsController constructor.
      *
-     * @param string          $appName The name of the app
-     * @param IRequest        $request Request object
-     * @param IConfig         $config  The config service
-     * @param IDBConnection   $db      The database connection
-     * @param LoggerInterface $logger  Logger for error handling
+     * @param string          $appName   The name of the app
+     * @param IRequest        $request   Request object
+     * @param IConfig         $config    The config service (retained for getSystemValueString)
+     * @param IAppConfig      $appConfig The typed app config service
+     * @param IDBConnection   $db        The database connection
+     * @param LoggerInterface $logger    Logger for error handling
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly IConfig $config,
+        private readonly IAppConfig $appConfig,
         private readonly IDBConnection $db,
         private readonly LoggerInterface $logger
     ) {
@@ -81,7 +84,7 @@ class MetricsController extends Controller
     {
         $lines = [];
 
-        $appVersion = $this->config->getAppValue('openconnector', 'installed_version', '0.0.0');
+        $appVersion = $this->appConfig->getValueString('openconnector', 'installed_version', '0.0.0');
         $phpVersion = PHP_VERSION;
         $ncVersion  = $this->config->getSystemValueString('version', '0.0.0');
 


### PR DESCRIPTION
## Summary

Behaviour-preserving migration of deprecated `IConfig::getAppValue` calls to the modern typed `OCP\IAppConfig` API (deprecated since NC26).

## Call sites migrated

### `lib/Controller/MetricsController.php`
| Old call | New call |
|---|---|
| `$this->config->getAppValue('openconnector', 'installed_version', '0.0.0')` | `$this->appConfig->getValueString('openconnector', 'installed_version', '0.0.0')` |

`IAppConfig $appConfig` added as a new constructor injection. `IConfig $config` is retained because `getSystemValueString` is still used on line 86 (that accessor is not deprecated).

## User-values left on IConfig
None in the modified file. Other files (`PreferencesController`, `UserService`) use `getUserValue/setUserValue/deleteUserValue` on `IConfig` and are **intentionally left unchanged** — `OCP\IUserConfig` requires NC ≥ 31, and this app's `min-version` is **28**.

## Verification
- `php -l lib/Controller/MetricsController.php` → **No syntax errors**
- Hydra gate-16 spec-coverage (`HYDRA_GATE_BASE_REF=origin/development`) → **exit 0**
- phpstan: deferred to CI (vendor not installed in clone)

**Do NOT merge — leave open for review.**