### PR TITLE
fix(gate19): add @e2e exclude to 4 backend retrofit specs

### DIFF
--- a/openspec/specs/endpoint-runtime/spec.md
+++ b/openspec/specs/endpoint-runtime/spec.md
@@ -19,6 +19,8 @@ already exists, and these REQs document it. Target resolution follows the
 polymorphic `targetType` / `targetId` contract in ADR-008. Rule processing
 itself is specified separately under the `rule-pipeline` capability.
 
+@e2e exclude backend endpoint dispatch runtime — covered by Newman/PHPUnit, no browser UI
+
 ## Requirements
 
 ### REQ-EP-001: Generic Path Dispatch and CORS

--- a/openspec/specs/prometheus-metrics/spec.md
+++ b/openspec/specs/prometheus-metrics/spec.md
@@ -8,6 +8,8 @@ status: implemented
 
 Expose application metrics in Prometheus text exposition format at `GET /api/metrics` for monitoring, alerting, and operational dashboards. Provide a health check endpoint at `GET /api/health` for liveness/readiness probes in container orchestration environments.
 
+@e2e exclude metrics and health-check endpoints — no browser UI, verified by Newman/API tests
+
 ## Requirements
 
 ### REQ-PROM-001: Metrics Endpoint

--- a/openspec/specs/rule-pipeline/spec.md
+++ b/openspec/specs/rule-pipeline/spec.md
@@ -17,6 +17,8 @@ exists today. It is a retrofit spec: the code already exists, and these REQs
 document it rather than prescribe new work. Per ADR-002 the rule engine is an
 openconnector-local concept with no OpenRegister equivalent.
 
+@e2e exclude rule pipeline engine — backend only, covered by PHPUnit, no browser UI
+
 ## Requirements
 
 ### REQ-RULE-001: Ordered Rule Pipeline Execution

--- a/openspec/specs/synchronization-engine/spec.md
+++ b/openspec/specs/synchronization-engine/spec.md
@@ -20,6 +20,8 @@ This spec retroactively describes 97 existing methods across
 behavioral retrofit — REQ language matches observed code, and the Notes sections
 flag observed-but-suspicious behavior rather than silently correcting it.
 
+@e2e exclude synchronization engine — backend/Newman, no browser UI; 97 methods covered by PHPUnit
+
 ## Requirements
 
 ### REQ-001: Synchronization orchestration and direction routing


### PR DESCRIPTION
## Summary

Gate-19's enhanced alt-format (`**Scenarios:**` numbered) scenario counting exposed 105 previously-uncounted uncovered scenarios across 4 retrofit/backend specs. All four are pure backend/API/runtime specs with no browser UI — verified by Newman/PHPUnit.

Adds one `@e2e exclude <reason>` line immediately after `## Purpose` in each spec:

| Spec | Scenarios | Reason |
|------|-----------|--------|
| `endpoint-runtime` | 25 | Backend endpoint dispatch runtime — covered by Newman/PHPUnit, no browser UI |
| `prometheus-metrics` | 30 | Metrics and health-check HTTP endpoints — no browser UI, verified by Newman/API tests |
| `rule-pipeline` | 19 | Rule pipeline engine — backend only, covered by PHPUnit, no browser UI |
| `synchronization-engine` | 31 | Synchronization engine — backend/Newman, no browser UI; 97 methods covered by PHPUnit |

**Gate-19 result after fix:** scenarios=149, excluded=149, uncovered=**0**

## Test plan

- [x] `python3 check_e2e_coverage.py --mode report` → `uncovered: 0` verified locally before commit