### PR TITLE
fix(jobs): per-job error handling + restore session user across cron pass (#1005, #1006)

### DIFF
--- a/lib/Service/JobService.php
+++ b/lib/Service/JobService.php
@@ -352,10 +352,32 @@ class JobService
         }
 
         // Set user session if job has a specific user configured.
-        $userId = ($jobData['userId'] ?? null);
-        if (empty($userId) === false && $this->userSession->getUser() === null) {
+        // Capture the prior session user so we can restore it after the job runs
+        // — without restoration, the first user-scoped job's identity sticks
+        // for every subsequent job in the same cron pass (#1006).
+        $userId               = ($jobData['userId'] ?? null);
+        $priorSessionUser     = $this->userSession->getUser();
+        $sessionUserOverridden = false;
+        if (empty($userId) === false) {
             $user = $this->userManager->get($userId);
+            if ($user === null) {
+                // Deleted/missing user — skip the job with a WARNING log entry
+                // rather than crashing setUser(null) inside the try/finally below.
+                return $this->saveJobLog(
+                    job: $job,
+                    jobData: $jobData,
+                    logData: [
+                        'level'   => 'WARNING',
+                        'message' => sprintf(
+                            'Configured userId "%s" does not exist; skipping job.',
+                            $userId
+                        ),
+                    ]
+                );
+            }
+
             $this->userSession->setUser($user);
+            $sessionUserOverridden = true;
         }
 
         // Record execution start time for performance tracking.
@@ -368,7 +390,15 @@ class JobService
             $arguments = [];
         }
 
-        $result = $action->run($arguments);
+        try {
+            $result = $action->run($arguments);
+        } finally {
+            // Always restore the prior session user so identity does not bleed
+            // across jobs in the same cron pass (#1006).
+            if ($sessionUserOverridden === true) {
+                $this->userSession->setUser($priorSessionUser);
+            }
+        }
 
         // Calculate execution time in milliseconds.
         $timeEnd       = microtime(true);
@@ -543,11 +573,85 @@ class JobService
                 continue;
             }
 
-            $log = $this->executeJob(job: $job);
-            if ($log !== null) {
-                $results[] = $log;
-            }
-        }
+            // Per-job isolation (#1005): a throw inside executeJob must NOT
+            // skip remaining due jobs in this cron pass, and must NOT leave
+            // the failing job's nextRun unchanged (otherwise it stays "due
+            // immediately" and re-blocks every subsequent tick).
+            try {
+                $log = $this->executeJob(job: $job);
+                if ($log !== null) {
+                    $results[] = $log;
+                }
+            } catch (\Throwable $e) {
+                // Build a stack trace for the error log (truncate per-frame to
+                // avoid pathological size).
+                $stackTrace = [];
+                foreach ($e->getTrace() as $frame) {
+                    if (isset($frame['file']) === true) {
+                        $location = $frame['file'].':'.($frame['line'] ?? '?');
+                    } else if (isset($frame['class']) === true) {
+                        $location = $frame['class'].($frame['type'] ?? '::').($frame['function'] ?? '?');
+                    } else {
+                        $location = ($frame['function'] ?? '?');
+                    }
+
+                    $stackTrace[] = $location;
+                    if (count($stackTrace) >= 50) {
+                        break;
+                    }
+                }
+
+                // Advance nextRun by the job's configured interval so the failing
+                // job no longer blocks siblings on the next cron tick.
+                try {
+                    $intervalSeconds = (int) ($jobData['interval'] ?? 0);
+                    $nextRunDt       = new DateTime('now + '.$intervalSeconds.' seconds');
+                    $nextRunDt->setTime(
+                        hour: (int) $nextRunDt->format('H'),
+                        minute: (int) $nextRunDt->format('i')
+                    );
+                    $jobData['lastRun'] = (new DateTime())->format('c');
+                    $jobData['nextRun'] = $nextRunDt->format('c');
+                    $this->objectService->saveObject(
+                        object: $jobData,
+                        register: 'openconnector',
+                        schema: 'job',
+                        uuid: $job->getUuid()
+                    );
+                } catch (\Throwable $advanceError) {
+                    // Don't let nextRun advancement failure mask the original exception
+                    // — fall through to the error log below.
+                    unset($advanceError);
+                }
+
+                // Write an error-level job_log so operators can see the failure.
+                try {
+                    $errorLog = $this->saveJobLog(
+                        job: $job,
+                        jobData: $jobData,
+                        logData: [
+                            'level'      => 'ERROR',
+                            'message'    => $this->truncateMessage(
+                                message: sprintf(
+                                    '%s: %s',
+                                    get_class($e),
+                                    $e->getMessage()
+                                )
+                            ),
+                            'stackTrace' => $stackTrace,
+                        ]
+                    );
+                    if ($errorLog !== null) {
+                        $results[] = $errorLog;
+                    }
+                } catch (\Throwable $logError) {
+                    // Swallow logging failure — we must continue to the next job.
+                    unset($logError);
+                }
+
+                continue;
+            }//end try
+        }//end foreach
 
         return $results;
 

--- a/tests/Unit/Service/JobServiceTest.php
+++ b/tests/Unit/Service/JobServiceTest.php
@@ -20,6 +20,7 @@ use OCA\OpenRegister\Service\ObjectService;
 use OCP\BackgroundJob\IJobList;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
@@ -46,6 +47,21 @@ class JobServiceTest extends TestCase
      */
     private $jobList;
 
+    /**
+     * @var ContainerInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $container;
+
+    /**
+     * @var IUserSession|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $session;
+
+    /**
+     * @var IUserManager|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $userMgr;
+
 
     /**
      * Set up test fixtures.
@@ -59,20 +75,20 @@ class JobServiceTest extends TestCase
         $this->objectService = ObjectServiceMockBuilder::make($this);
         $this->jobList       = $this->createMock(IJobList::class);
 
-        $connection = $this->createMock(IDBConnection::class);
-        $container  = $this->createMock(ContainerInterface::class);
-        $session    = $this->createMock(IUserSession::class);
-        $userMgr    = $this->createMock(IUserManager::class);
-        $appConfig  = $this->createMock(IAppConfig::class);
+        $connection      = $this->createMock(IDBConnection::class);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->session   = $this->createMock(IUserSession::class);
+        $this->userMgr   = $this->createMock(IUserManager::class);
+        $appConfig       = $this->createMock(IAppConfig::class);
         $appConfig->method('hasKey')->willReturn(false);
 
         $this->service = new JobService(
             $this->jobList,
             $this->objectService,
             $connection,
-            $container,
-            $session,
-            $userMgr,
+            $this->container,
+            $this->session,
+            $this->userMgr,
             $appConfig,
         );
     }//end setUp()
@@ -195,6 +211,222 @@ class JobServiceTest extends TestCase
         // Assert
         $this->assertSame([], $results);
     }//end testRunReturnsEmptyArrayWhenNoJobsDue()
+
+
+    /**
+     * #1005 regression test — a throwing job MUST NOT abort the cron pass.
+     *
+     * Two due jobs in a single run() pass: the first throws RuntimeException
+     * during $action->run(), the second runs to completion. After the pass
+     * the failing job's nextRun MUST have advanced (saveObject called for
+     * its job schema) and an ERROR job_log MUST have been written. The
+     * second job must still execute normally.
+     *
+     * @return void
+     */
+    public function testRunIsolatesThrowingJobAndContinues(): void
+    {
+        // Arrange — two due jobs.
+        $now           = (new \DateTime('-1 hour'))->format('c');
+        $throwingJob   = ObjectServiceMockBuilder::objectEntity(
+            $this,
+            [
+                'isEnabled' => true,
+                'jobClass'  => 'OCA\\OpenConnector\\Action\\ThrowingAction',
+                'interval'  => 300,
+                'nextRun'   => $now,
+                'arguments' => [],
+            ],
+            'job-throwing'
+        );
+        $healthyJob    = ObjectServiceMockBuilder::objectEntity(
+            $this,
+            [
+                'isEnabled' => true,
+                'jobClass'  => 'OCA\\OpenConnector\\Action\\HealthyAction',
+                'interval'  => 300,
+                'nextRun'   => $now,
+                'arguments' => [],
+            ],
+            'job-healthy'
+        );
+
+        $this->objectService->method('findAll')
+            ->willReturn(['results' => [$throwingJob, $healthyJob], 'total' => 2]);
+
+        // Configure container to return a throwing action then a healthy one.
+        $throwingAction = new class {
+            public function run(array $args): array
+            {
+                throw new \RuntimeException('boom from action');
+            }
+        };
+        $healthyCalled = false;
+        $healthyAction = new class($healthyCalled) {
+            private bool $called;
+
+            public function __construct(bool &$called)
+            {
+                $this->called =& $called;
+            }
+
+            public function run(array $args): array
+            {
+                $this->called = true;
+                return ['level' => 'SUCCESS', 'message' => 'ok'];
+            }
+        };
+
+        $this->container->method('get')->willReturnCallback(
+            static function (string $class) use ($throwingAction, $healthyAction) {
+                if ($class === 'OCA\\OpenConnector\\Action\\ThrowingAction') {
+                    return $throwingAction;
+                }
+                return $healthyAction;
+            }
+        );
+
+        // Track saveObject calls so we can assert both nextRun-advance and the
+        // error job_log were written for the failing job.
+        $savedSchemas      = [];
+        $savedErrorLevels  = [];
+        $defaultEntity     = ObjectServiceMockBuilder::objectEntity($this, [], 'saved');
+        $this->objectService->method('saveObject')->willReturnCallback(
+            static function (array $object, string $register, string $schema, ?string $uuid=null) use (
+                &$savedSchemas,
+                &$savedErrorLevels,
+                $defaultEntity
+            ) {
+                $savedSchemas[] = $schema.($uuid !== null ? ':'.$uuid : '');
+                if ($schema === 'job_log' && isset($object['level']) === true) {
+                    $savedErrorLevels[] = $object['level'];
+                }
+                return $defaultEntity;
+            }
+        );
+
+        // Act
+        $results = $this->service->run();
+
+        // Assert — healthy job executed.
+        $this->assertTrue($healthyCalled, 'Healthy job MUST run even when the prior job threw');
+
+        // Assert — failing job's `job` schema record was written (nextRun advance).
+        $this->assertContains(
+            'job:job-throwing',
+            $savedSchemas,
+            'Failing job must have its nextRun advanced via saveObject(schema=job, uuid=throwing-uuid)'
+        );
+
+        // Assert — an ERROR-level job_log was written for the failing job.
+        $this->assertContains(
+            'ERROR',
+            $savedErrorLevels,
+            'A throwing job must produce an ERROR-level job_log entry'
+        );
+    }//end testRunIsolatesThrowingJobAndContinues()
+
+
+    /**
+     * #1006 regression test — the session user MUST be restored after a job
+     * runs in a user context, so the next job in the cron pass does NOT
+     * inherit that identity.
+     *
+     * @return void
+     */
+    public function testExecuteJobRestoresPriorSessionUser(): void
+    {
+        // Arrange — a job configured with userId=alice.
+        $jobBody = [
+            'isEnabled' => true,
+            'jobClass'  => 'OCA\\OpenConnector\\Action\\HealthyAction',
+            'interval'  => 300,
+            'userId'    => 'alice',
+            'arguments' => [],
+        ];
+        $jobEntity = ObjectServiceMockBuilder::objectEntity($this, $jobBody, 'job-user');
+
+        // Prior session user is null (cron starts as system).
+        $alice = $this->createMock(IUser::class);
+        $this->session->method('getUser')->willReturn(null);
+        $this->userMgr->method('get')->with('alice')->willReturn($alice);
+
+        // Capture setUser calls in order.
+        $setUserCalls = [];
+        $this->session->method('setUser')->willReturnCallback(
+            static function ($user) use (&$setUserCalls) {
+                $setUserCalls[] = $user;
+            }
+        );
+
+        // Healthy action.
+        $this->container->method('get')->willReturn(new class {
+            public function run(array $args): array
+            {
+                return ['level' => 'SUCCESS', 'message' => 'ok'];
+            }
+        });
+
+        // Act
+        $this->service->executeJob($jobEntity);
+
+        // Assert — setUser was called twice: first with alice, then with the
+        // prior user (null) to restore the session.
+        $this->assertCount(
+            2,
+            $setUserCalls,
+            'setUser must be called twice (set + restore) for a user-scoped job'
+        );
+        $this->assertSame($alice, $setUserCalls[0], 'First setUser must apply the configured user');
+        $this->assertNull($setUserCalls[1], 'Second setUser must restore the prior (null) session user');
+    }//end testExecuteJobRestoresPriorSessionUser()
+
+
+    /**
+     * #1006 regression test — a job whose configured userId no longer exists
+     * MUST be skipped with a WARNING log, NOT crash via setUser(null).
+     *
+     * @return void
+     */
+    public function testExecuteJobSkipsJobWhenConfiguredUserMissing(): void
+    {
+        // Arrange — job references a deleted user.
+        $jobBody = [
+            'isEnabled' => true,
+            'jobClass'  => 'OCA\\OpenConnector\\Action\\HealthyAction',
+            'interval'  => 300,
+            'userId'    => 'deleted-user',
+            'arguments' => [],
+        ];
+        $jobEntity = ObjectServiceMockBuilder::objectEntity($this, $jobBody, 'job-missing-user');
+
+        $this->session->method('getUser')->willReturn(null);
+        $this->userMgr->method('get')->with('deleted-user')->willReturn(null);
+
+        // setUser must NEVER be called when the user resolves to null.
+        $this->session->expects($this->never())->method('setUser');
+
+        // container->get must NEVER be invoked because the job was skipped early.
+        $this->container->expects($this->never())->method('get');
+
+        // saveObject is invoked to write the WARNING log entry.
+        $logLevels = [];
+        $this->objectService->method('saveObject')->willReturnCallback(
+            function (array $object, string $register, string $schema, ?string $uuid=null) use (&$logLevels) {
+                if ($schema === 'job_log') {
+                    $logLevels[] = $object['level'] ?? null;
+                }
+                return ObjectServiceMockBuilder::objectEntity($this, $object, 'log-uuid');
+            }
+        );
+
+        // Act
+        $result = $this->service->executeJob($jobEntity);
+
+        // Assert
+        $this->assertNotNull($result, 'Skipped-due-to-missing-user must still return a log entity');
+        $this->assertContains('WARNING', $logLevels, 'Skipped job must produce a WARNING job_log');
+    }//end testExecuteJobSkipsJobWhenConfiguredUserMissing()
 
 
 }//end class


### PR DESCRIPTION
## Summary

Two HIGH-severity reliability bugs in `JobService` that together caused the OpenConnector cron pass to wedge every 5 minutes and bleed user identities between jobs.

| Issue | Surface | Bug | Result |
| --- | --- | --- | --- |
| #1005 | `JobService::run()` + `executeJob()` | No `try/catch` around `executeJob`; `$action->run()` is unguarded; the failing job's `nextRun` advance lives below the throw | One throwing job skipped every later due job AND re-blocked the next tick (no log trail) |
| #1006 | `JobService::executeJob()` user-session setup | `$userSession->setUser($user)` is never restored; guard is `getUser() === null` so the first user-scoped job's identity sticks for every subsequent job. `userManager->get()` can also return `null` and crash `setUser`. | OR writes / ownership / RBAC attributed to the wrong user; cron pass crashes on deleted user |

## Fix

### #1005 — per-job isolation in `run()`
Wrap each `executeJob` call in `try { ... } catch (\Throwable $e)`. On exception:
1. Advance the failing job's `nextRun` by its configured interval so it stops blocking siblings.
2. Write an ERROR-level `job_log` (exception class + message + truncated trace).
3. `continue` to the next due job.

### #1006 — restore session user, null-check
In `executeJob`:
- Capture prior session user before override.
- Null-check the resolved user; missing → skip with WARNING `job_log` (no crash).
- Wrap `$action->run()` in `try { ... } finally { restore }` so identity does not bleed.

## Verification

Live verification against the bind-mounted Nextcloud (one cron pass, four contrived jobs via the real `JobService::run()` with recording stubs for OR ObjectService):

```
saveObject calls (7):
  #0 schema=job          uuid=job-throwing           # nextRun advanced (#1005)
  #1 schema=job_log      level=ERROR msg=RuntimeException: boom-from-throwing
  #2 schema=job          uuid=job-healthy-admin
  #3 schema=job_log      level=SUCCESS msg=ok
  #4 schema=job          uuid=job-after-admin        # later job ran (#1005)
  #5 schema=job_log      level=SUCCESS msg=ok
  #6 schema=job_log      level=WARNING msg=Configured userId "no-such-user-xyz9z" does not exist; skipping job.

GoodAct observed UIDs: ["admin", null]              # admin job ran as admin; next job NOT identity-bled (#1006)
Final session post-run: null                          # prior session restored
```

All six regression assertions PASS:

- `[#1005] failing-job nextRun advanced`            **PASS**
- `[#1005] ERROR job_log written`                   **PASS**
- `[#1005] later job ran post-throw`                **PASS**
- `[#1006] admin-scoped job ran as admin`           **PASS**
- `[#1006] later job not identity-bled`             **PASS**
- `[#1006] missing-user WARN, no crash`             **PASS**

## Tests

`tests/Unit/Service/JobServiceTest.php` gains three regression tests:
- `testRunIsolatesThrowingJobAndContinues` — covers #1005.
- `testExecuteJobRestoresPriorSessionUser` — covers #1006 restoration.
- `testExecuteJobSkipsJobWhenConfiguredUserMissing` — covers #1006 null-check.

Note: all existing JobServiceTest tests currently fail to set up with `MethodCannotBeConfiguredException: getUuid` on `development` tip too — this is the pre-existing #1015 (mock builder uses `getMockBuilder(ObjectEntity::class)` but `ObjectEntity` uses the Nextcloud Entity `__call` magic so `getUuid` is not a directly-configurable method). Live verification covers the assertions until #1015 is fixed.

## Files

- `lib/Service/JobService.php` — `executeJob` (session/user) + `run` (try/catch loop)
- `tests/Unit/Service/JobServiceTest.php` — 3 new tests

Closes #1005
Closes #1006