### PR TITLE
fix(deps): bump @conduction/nextcloud-vue to beta.108 — fix table view em-dash (#996)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^1.0.0-beta.107",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.108",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@mdi/js": "^7.4.47",


### PR DESCRIPTION
## Summary

- Bumps `@conduction/nextcloud-vue` from `^1.0.0-beta.107` to `^1.0.0-beta.108`
- beta.107 has a bug in `CnDataTable.effectiveColumns()` where string keys from manifest `config.columns` (e.g. `["name", "type", "status"]`) are not normalised to `{ key, label }` objects, causing every table cell to render as `—` (em-dash) because `col.key` is `undefined` on a bare string
- beta.108 contains the fix from ConductionNL/nextcloud-vue#454 (commit `739955fe`)

## Root cause

`CnPageRenderer.resolvedProps` spreads the manifest page `config` directly onto `CnIndexPage`, so `config.columns = ["name", "type"]` becomes the `columns` prop. The `CnDataTable.effectiveColumns` computed (in beta.107) returned this raw string array unchanged, and the template called `col.key` on each entry — `undefined` for bare strings, rendering every cell as `—`.

The fix in nc-vue maps string entries to `{ key, label }` objects on both return paths of `effectiveColumns`.

## Affected sections (all table views)
Sources, Mappings, Synchronizations, Jobs, Rules, Endpoints, Consumers, Webhooks, Cloud events

## Test plan
- [ ] `npm install && npm run build`
- [ ] Navigate to Sources in table view — should show column headers and real data instead of `—`
- [ ] Verify Cards view still works (unaffected, was the workaround)
- [ ] Verify at least 2 other sections (Endpoints, Rules)

Closes #996