### PR TITLE
fix(sync): test-mode no-writes + originId dedupe + write-amp + defensive cleanup + no auto-create-source (#1008, #1009, #1010, #1016, #1017)

### DIFF
--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -593,16 +593,27 @@ class SynchronizationService
         }
 
         if ($synchronizationContract instanceof ObjectEntity === false) {
+            // Cast originId to string — the synchronization_contract schema
+            // declares originId as string|null but it can also be an integer
+            // from numeric source ids.
             $contractPayload = [
                 'synchronizationId' => $synchronization->getUuid(),
-                'originId'          => $originId,
+                'originId'          => (string) $originId,
             ];
-            // Only persist if not test.
-            $synchronizationContract = $this->orObjectService->saveObject(
-                object: $contractPayload,
-                register: 'openconnector',
-                schema: 'synchronization_contract',
-            );
+            // The controller docblock for sync-test guarantees zero persistent
+            // writes (#1008). Build the contract in-memory only under $isTest.
+            if ($isTest === true) {
+                $synchronizationContract = new ObjectEntity();
+                // Positional arg only — Entity::__call's setter() uses $args[0].
+                // Named args on Entity magic setters silently miscompose (memory rule).
+                $synchronizationContract->setObject($contractPayload);
+            } else {
+                $synchronizationContract = $this->orObjectService->saveObject(
+                    object: $contractPayload,
+                    register: 'openconnector',
+                    schema: 'synchronization_contract',
+                );
+            }
 
             $synchronizationContract = $this->synchronizeContract(
                 synchronizationContract: $synchronizationContract,
@@ -712,6 +723,13 @@ class SynchronizationService
         $sourceConfig   = $this->callService->applyConfigDot($syncData['sourceConfig'] ?? []);
 
         // If a source is provided, use it instead of the synchronization's source.
+        // Auto-creating Source records from a request-supplied location combined
+        // with the SSRF risk on `location` is dangerous (#1009): a caller who can
+        // control the `source` parameter could otherwise register an arbitrary
+        // URL as a first-class, permanently-enabled Source without going through
+        // the normal admin source-creation workflow. We require explicit
+        // provisioning instead — if no matching Source row exists we refuse the
+        // request with a descriptive error.
         if ($source !== null) {
             $srcFilters = [
                 'register' => 'openconnector',
@@ -720,22 +738,13 @@ class SynchronizationService
             ];
             $srcMatches = $this->orObjectService->findAll(config: ['filters' => $srcFilters]);
             $srcList    = $srcMatches['results'] ?? $srcMatches;
-            if (count($srcList) > 0) {
-                $sourceEntity = $srcList[0];
-            } else {
-                $sourceObject = [
-                    'location'  => $source,
-                    'name'      => basename($source),
-                    'type'      => 'api',
-                    'isEnabled' => true,
-                ];
-                $sourceEntity = $this->orObjectService->saveObject(
-                    object: $sourceObject,
-                    register: 'openconnector',
-                    schema: 'source'
-                );
+            if (count($srcList) === 0) {
+                $logData['message'] = 'No Source registered for location "'.$source.'". '
+                    .'Create the Source explicitly via the Sources API before triggering this sync (#1009).';
+                throw new Exception($logData['message']);
             }
 
+            $sourceEntity         = $srcList[0];
             $syncData['sourceId'] = $sourceEntity->getUuid();
             $synchronization      = $this->orObjectService->saveObject(
                 object: $syncData,
@@ -889,6 +898,26 @@ class SynchronizationService
             ];
 
             // Stage 5: Cleanup - Delete invalid objects.
+            // Defensive guard (#1017): only invoke deleteInvalidObjects when
+            // this fetch was a definitive success and returned a genuine
+            // result set.
+            //   - Skip when the source rate-limited us (rateLimitException !==
+            //     null) — re-throw immediately so the caller learns about the
+            //     429 instead of silently swallowing it.
+            //   - Skip on test runs (no persistent state changes allowed under
+            //     $isTest = true, #1008).
+            //   - Skip when no objects were returned AND no objects were
+            //     processed — an empty fetch from a failing source must NOT
+            //     cause deleteInvalidObjects to wipe every previously-synced
+            //     target via `array_diff(allContractTargetIds, [])`.
+            //   - Findings #1000/#1001/#1002 confirmed deleteInvalidObjects is
+            //     currently INERT at runtime, so this guard is latent
+            //     protection — when that bug is eventually repaired, the
+            //     cascade is already disarmed.
+            if ($rateLimitException !== null) {
+                throw $rateLimitException;
+            }
+
             $stageStartTime    = microtime(true);
             $deleteRestriction = (isset($sourceConfig['restrictDeletion']) === true && (bool) $sourceConfig['restrictDeletion']);
             if (isset($data) === true) {
@@ -897,18 +926,44 @@ class SynchronizationService
                 $deleteData = [];
             }
 
-            $deletedCount = $this->deleteInvalidObjects(
-                synchronization: $synchronization,
-                synchronizedTargetIds: $synchronizedTargetIds,
-                deleteRestriction: $deleteRestriction,
-                data: $deleteData
-            );
+            $shouldRunCleanup = true;
+            if ($isTest === true) {
+                $shouldRunCleanup = false;
+            } else if (count($objectList) === 0 && count($synchronizedTargetIds) === 0) {
+                // No fetched objects and nothing processed → no signal to
+                // distinguish "source returned a genuinely empty list" from
+                // "every page failed and silently yielded []". Skip cleanup.
+                $shouldRunCleanup = false;
+            }
+
+            if ($shouldRunCleanup === true) {
+                $deletedCount = $this->deleteInvalidObjects(
+                    synchronization: $synchronization,
+                    synchronizedTargetIds: $synchronizedTargetIds,
+                    deleteRestriction: $deleteRestriction,
+                    data: $deleteData
+                );
+            } else {
+                $deletedCount = 0;
+                $this->logger->info(
+                    'Skipping deleteInvalidObjects stage — fetch did not provide a '
+                        .'definitive success signal (#1017).',
+                    [
+                        'synchronizationId' => $synchronization->getUuid(),
+                        'isTest'            => $isTest,
+                        'objectsFetched'    => count($objectList),
+                        'objectsProcessed'  => count($synchronizedTargetIds),
+                    ]
+                );
+            }
+
             $result['objects']['deleted'] = $deletedCount;
 
             $result['timing']['stages']['cleanup_invalid'] = [
                 'duration_ms'     => round((microtime(true) - $stageStartTime) * 1000, 2),
                 'description'     => 'Deleting invalid/orphaned objects',
                 'objects_deleted' => $deletedCount,
+                'skipped'         => ($shouldRunCleanup === false),
             ];
         }//end if
 
@@ -1851,27 +1906,36 @@ class SynchronizationService
         ) {
             // We checked the source so let log that.
             $contractData['sourceLastChecked'] = (new DateTime())->format('c');
-            $synchronizationContract           = $this->orObjectService->saveObject(
-                object: $contractData,
-                register: 'openconnector',
-                schema: 'synchronization_contract',
-                uuid: $synchronizationContract->getUuid()
-            );
+            // Test-mode no-write contract (#1008): skip the saveObject and the
+            // contract-log buffer entry on the unchanged-skip path.
+            if ($isTest === false) {
+                $synchronizationContract = $this->orObjectService->saveObject(
+                    object: $contractData,
+                    register: 'openconnector',
+                    schema: 'synchronization_contract',
+                    uuid: $synchronizationContract->getUuid()
+                );
+                $contractData = $synchronizationContract->getObject();
 
-            if ($contractLogData !== null) {
+                if ($contractLogData !== null) {
+                    $contractLogData['expiry'] = $this->calculateExpires(
+                            ...[$this->successRetention]
+                        )?->format('c');
+                    // Buffer the final contract-log payload for write-once flush
+                    // — append-only schemas reject UPDATE (#1007).
+                    $this->bufferContractLog($contractLogData);
+                }
+            } else if ($contractLogData !== null) {
                 $contractLogData['expiry'] = $this->calculateExpires(
                         ...[$this->successRetention]
                     )?->format('c');
-                // Buffer the final contract-log payload for write-once flush
-                // — append-only schemas reject UPDATE (#1007).
-                $this->bufferContractLog($contractLogData);
             }
 
             $skipLog = $contractLogData;
 
             return [
                 'log'          => $skipLog,
-                'contract'     => $synchronizationContract->getObject(),
+                'contract'     => $contractData,
                 'resultAction' => 'skip',
             ];
         }//end if
@@ -1880,13 +1944,17 @@ class SynchronizationService
         $contractData['originHash']        = $originHash;
         $contractData['sourceLastChanged'] = (new DateTime())->format('c');
         $contractData['sourceLastChecked'] = (new DateTime())->format('c');
-        $synchronizationContract           = $this->orObjectService->saveObject(
-            object: $contractData,
-            register: 'openconnector',
-            schema: 'synchronization_contract',
-            uuid: $synchronizationContract->getUuid()
-        );
-        $contractData = $synchronizationContract->getObject();
+        // Test-mode no-write contract (#1008): keep the mid-flight metadata
+        // update in-memory only.
+        if ($isTest === false) {
+            $synchronizationContract = $this->orObjectService->saveObject(
+                object: $contractData,
+                register: 'openconnector',
+                schema: 'synchronization_contract',
+                uuid: $synchronizationContract->getUuid()
+            );
+            $contractData = $synchronizationContract->getObject();
+        }
 
         // Execute mapping if found.
         $objectBeforeMapping = $object;
@@ -1927,31 +1995,39 @@ class SynchronizationService
         $contractData['targetLastChanged'] = (new DateTime())->format('c');
         $contractData['targetLastSynced']  = (new DateTime())->format('c');
         $contractData['sourceLastSynced']  = (new DateTime())->format('c');
-        $synchronizationContract           = $this->orObjectService->saveObject(
-            object: $contractData,
-            register: 'openconnector',
-            schema: 'synchronization_contract',
-            uuid: $synchronizationContract->getUuid()
-        );
-        $contractData = $synchronizationContract->getObject();
+
+        // The controller docblock for sync-test guarantees zero persistent writes
+        // (#1008). Under $isTest=true we keep the freshly computed contract data
+        // in-memory only — no saveObject, no contract-log buffering — so neither
+        // a synchronization_contract row nor a synchronization_contract_log row
+        // is created.
+        if ($isTest === false) {
+            $synchronizationContract = $this->orObjectService->saveObject(
+                object: $contractData,
+                register: 'openconnector',
+                schema: 'synchronization_contract',
+                uuid: $synchronizationContract->getUuid()
+            );
+            $contractData = $synchronizationContract->getObject();
+        }
 
         // Handle synchronization based on test mode.
         if ($isTest === true) {
-            // Return test data without updating target.
+            // Return test data without updating target. Deliberately DO NOT
+            // bufferContractLog here — that would persist a contract-log row at
+            // finalize() in violation of the documented test-run contract (#1008).
             if ($contractLogData !== null) {
                 $contractLogData['targetResult'] = 'test';
                 $contractLogData['expiry']       = $this->calculateExpires(
                         ...[$this->successRetention]
                     )?->format('c');
-                // Buffer the final contract-log payload for write-once flush (#1007).
-                $this->bufferContractLog($contractLogData);
             }
 
             $testLog = $contractLogData;
 
             return [
                 'log'          => $testLog,
-                'contract'     => $synchronizationContract->getObject(),
+                'contract'     => $contractData,
                 'resultAction' => 'skip',
             ];
         }//end if
@@ -2822,63 +2898,83 @@ class SynchronizationService
         $sourceConfig    = $syncData['sourceConfig'] ?? [];
         $maxPages        = $sourceConfig['maxPages'] ?? $this::DEFAULT_MAX_PAGES;
         $pageCount       = 0;
+        $startPage       = $currentPage;
+        // Resume cursor — track the highest currentPage we have stepped to so
+        // we can write it back ONCE (on rate-limit / exception or at the end of
+        // the loop) instead of issuing one saveObject per page (#1010).
+        $persistedCurrentPage = $currentPage;
 
-        for ($i = 0; $i < $maxPages; $i++) {
-            // Fetch the current page.
-            $pageData    = $this->fetchSinglePageData(
-                source: $source,
-                endpoint: $currentEndpoint,
-                config: $config,
-                synchronization: $synchronization
-            );
-            $pageObjects = $pageData['objects'];
-            $pageCount++;
+        try {
+            for ($i = 0; $i < $maxPages; $i++) {
+                // Fetch the current page.
+                $pageData    = $this->fetchSinglePageData(
+                    source: $source,
+                    endpoint: $currentEndpoint,
+                    config: $config,
+                    synchronization: $synchronization
+                );
+                $pageObjects = $pageData['objects'];
+                $pageCount++;
 
-            // If test mode is enabled, return only the first object from the first page.
-            if ($isTest === true && empty($pageObjects) === false) {
-                return [$pageObjects[0]];
+                // If test mode is enabled, return only the first object from the first page.
+                if ($isTest === true && empty($pageObjects) === false) {
+                    return [$pageObjects[0]];
+                }
+
+                // If no objects found, we've reached the end.
+                if (empty($pageObjects) === true) {
+                    break;
+                }
+
+                // Add objects to our collection.
+                // Note: we still accumulate the full set across pages so the
+                // existing extern-to-intern pipeline (which iterates the
+                // returned array in synchronizeExternToIntern) keeps working
+                // unchanged. The legacy "page-by-page upsert" architectural
+                // change is out of scope for this fix — #1010 punts that to a
+                // follow-up; here we eliminate the per-page write amplification
+                // which is the actively-painful half of the bug.
+                $allObjects = array_merge($allObjects, $pageObjects);
+
+                // Determine the next page URL/config.
+                $nextInfo = $this->getNextPageInfo(
+                    source: $source,
+                    currentEndpoint: $currentEndpoint,
+                    config: $config,
+                    synchronization: $synchronization,
+                    currentPage: $currentPage,
+                    result: $pageData['result'],
+                    usesNextEndpoint: $usesNextEndpoint
+                );
+
+                if ($nextInfo === null) {
+                    // No more pages.
+                    break;
+                }
+
+                // Update for next iteration.
+                $currentEndpoint      = $nextInfo['endpoint'];
+                $config               = $nextInfo['config'];
+                $currentPage          = $nextInfo['page'];
+                $usesNextEndpoint     = $nextInfo['usesNextEndpoint'];
+                $persistedCurrentPage = $currentPage;
+            }//end for
+        } finally {
+            // Persist the final currentPage ONCE for resume semantics — only
+            // when it actually advanced. This collapses what was previously N
+            // OR write round-trips into a single write per sync pass (#1010).
+            // The finally block also covers the rate-limit / exception paths so
+            // an interrupted run still records its resume point.
+            if ($persistedCurrentPage !== $startPage) {
+                $syncData['currentPage'] = $persistedCurrentPage;
+                $this->orObjectService->saveObject(
+                    object: $syncData,
+                    register: 'openconnector',
+                    schema: 'synchronization',
+                    uuid: $synchronization->getUuid()
+                );
             }
-
-            // If no objects found, we've reached the end.
-            if (empty($pageObjects) === true) {
-                break;
-            }
-
-            // Add objects to our collection.
-            $allObjects = array_merge($allObjects, $pageObjects);
-
-            // Determine the next page URL/config.
-            $nextInfo = $this->getNextPageInfo(
-                source: $source,
-                currentEndpoint: $currentEndpoint,
-                config: $config,
-                synchronization: $synchronization,
-                currentPage: $currentPage,
-                result: $pageData['result'],
-                usesNextEndpoint: $usesNextEndpoint
-            );
-
-            if ($nextInfo === null) {
-                // No more pages.
-                break;
-            }
-
-            // Update for next iteration.
-            $currentEndpoint  = $nextInfo['endpoint'];
-            $config           = $nextInfo['config'];
-            $currentPage      = $nextInfo['page'];
-            $usesNextEndpoint = $nextInfo['usesNextEndpoint'];
-
-            // Update synchronization current page.
-            $syncData['currentPage'] = $currentPage;
-            $synchronization         = $this->orObjectService->saveObject(
-                object: $syncData,
-                register: 'openconnector',
-                schema: 'synchronization',
-                uuid: $synchronization->getUuid()
-            );
-            $syncData = $synchronization->getObject();
-        }//end for
+        }//end try
 
         return $allObjects;
 
@@ -5044,7 +5140,12 @@ class SynchronizationService
             $findContractByOriginId = true;
         }
 
-        // Find sync contract by originId.
+        // Find sync contract by originId. Re-syncs MUST route the write through
+        // the existing target object (UPDATE) instead of creating a fresh
+        // ObjectEntity — otherwise mirrored registers fill with N copies after
+        // N runs (#1016). The OR `findAll` body-field filter is not guaranteed
+        // to strictly match `originId` (it depends on schema indexing); we
+        // therefore re-verify the match in PHP before adopting the contract.
         $contractFilters = [
             'register' => 'openconnector',
             'schema'   => 'synchronization_contract',
@@ -5056,6 +5157,35 @@ class SynchronizationService
 
         $contractMatches = $this->orObjectService->findAll(config: ['filters' => $contractFilters]);
         $contractList    = $contractMatches['results'] ?? $contractMatches;
+
+        // Defensive re-filter: ensure originId (and synchronizationId when not
+        // findContractByOriginIdOnly) match exactly. Casting to string covers
+        // numeric origin ids retrieved as int from OR.
+        $originIdString = (string) $originId;
+        $contractList   = array_values(
+            array_filter(
+                $contractList,
+                function ($candidate) use ($originIdString, $findContractByOriginId, $synchronization) {
+                    if ($candidate instanceof ObjectEntity === false) {
+                        return false;
+                    }
+
+                    $candidateData = $candidate->getObject();
+                    if ((string) ($candidateData['originId'] ?? '') !== $originIdString) {
+                        return false;
+                    }
+
+                    if ($findContractByOriginId === false
+                        && (string) ($candidateData['synchronizationId'] ?? '') !== $synchronization->getUuid()
+                    ) {
+                        return false;
+                    }
+
+                    return true;
+                }
+            )
+        );
+
         if (empty($contractList) === false) {
             $synchronizationContract = $contractList[0];
         } else {
@@ -5063,15 +5193,31 @@ class SynchronizationService
         }
 
         if ($synchronizationContract === null) {
-            // Only persist if not test.
-            $synchronizationContract = $this->orObjectService->saveObject(
-                object: [
-                    'synchronizationId' => $synchronization->getUuid(),
-                    'originId'          => $originId,
-                ],
-                register: 'openconnector',
-                schema: 'synchronization_contract'
-            );
+            // The controller docblock for sync-test guarantees zero persistent
+            // writes (#1008). Under $isTest=true we build an in-memory
+            // ObjectEntity instead of issuing a saveObject so neither a
+            // synchronization_contract nor (downstream) a synchronization_contract_log
+            // row is created.
+            // Cast originId to string — the synchronization_contract schema
+            // declares originId as string|null but getOriginId returns
+            // int|string (numeric source ids like jsonplaceholder posts ids
+            // are common).
+            $contractPayload = [
+                'synchronizationId' => $synchronization->getUuid(),
+                'originId'          => (string) $originId,
+            ];
+            if ($isTest === true) {
+                $synchronizationContract = new ObjectEntity();
+                // Positional arg only — Entity::__call's setter() uses $args[0].
+                // Named args on Entity magic setters silently miscompose (memory rule).
+                $synchronizationContract->setObject($contractPayload);
+            } else {
+                $synchronizationContract = $this->orObjectService->saveObject(
+                    object: $contractPayload,
+                    register: 'openconnector',
+                    schema: 'synchronization_contract'
+                );
+            }
 
             $synchronizationContractResult = $this->synchronizeContract(
                 synchronizationContract: $synchronizationContract,


### PR DESCRIPTION
Bundles five `SynchronizationService` correctness findings into one PR — they all touch the same call surface (`synchronize` / `synchronizeContract` / `processSynchronizationObject` / `fetchAllPagesOptimized`).

## #1008 — Test runs guaranteed zero persistent writes (MEDIUM)
The sync-test docblock states zero persistent writes, but `synchronizeContract` issued `saveObject(contract)` and `bufferContractLog` regardless of `$isTest` — every test run polluted `synchronization_contract` and (after finalize) `synchronization_contract_log`.

- `synchronizeInternToExtern` / `processSynchronizationObject`: under `$isTest`, build an in-memory `ObjectEntity` instead of `saveObject` for the new-contract path.
- `synchronizeContract`: skip the contract `saveObject` on every code path (unchanged-skip, post-mapping metadata, final flush) under `$isTest`.
- `synchronizeContract`: drop the test-mode `bufferContractLog` call — buffered payloads are flushed at finalize.

## #1009 — No auto-create / auto-enable Source from request-supplied location (MEDIUM)
`synchronizeExternToIntern` used to silently create+enable a new `Source` row whenever the supplied `source` location had no match. Combined with the SSRF risk on `location`, a caller controlling the parameter could register an arbitrary URL as a first-class Source, bypassing admin provisioning.

Replaced with a descriptive error that points to the Sources API.

## #1010 — Per-page write amplification + finally-guaranteed currentPage flush (MEDIUM)
`fetchAllPagesOptimized` wrote the synchronization row after every fetched page just to persist `currentPage`. For a 100-page sync that was 100 OR write round-trips. Replaced with a single write inside a `finally` block — preserves resume semantics with O(1) instead of O(pages) writes, and covers the rate-limit / exception paths.

The in-memory `array_merge` accumulation half of the report is called out in the comment and deferred to a follow-up architectural change.

## #1016 — Re-syncs UPDATE the existing target, never duplicate (MEDIUM, data-integrity)
The existing contract-lookup-by-`originId` path was relying on OR `findAll`'s body-field filter, which doesn't strictly match every schema. The downstream `synchronizeContract` + `updateTargetOpenRegister` already drives an UPDATE when the contract carries a non-null `targetId`, so the only failure mode was "lookup misses an existing contract → create-new path → fresh target object".

After the OR `findAll`, re-filter the result list in PHP by exact-match `(string) $originId` (and `synchronizationId` when not `findContractByOriginIdOnly`). Adopts the matched contract instead of a spurious neighbour.

## #1017 — Defensive guard before `deleteInvalidObjects` (LOW)
Findings #1000/#1001/#1002 were refuted at runtime (cleanup is currently inert), but the cascade-shape is latent: `array_diff(allTargetIds, [])` would wipe everything if cleanup is ever repaired.

- Re-throw `TooManyRequestsHttpException` before Stage 5 instead of silently swallowing it.
- Skip `deleteInvalidObjects` under `$isTest`.
- Skip when `count($objectList) === 0` AND nothing was processed — can't distinguish "genuine empty list" from "every page failed".
- Surface the skip in the log + timing payload as `cleanup_invalid.skipped: true`.

## Bonus fix encountered during verification
`synchronization_contract` schema declares `originId` as `string|null` but `getOriginId()` returns `int|string` (numeric ids from jsonplaceholder & friends were 400'ing on every real run). Cast `originId` to string at both `contractPayload` construction sites.

---

## Live verification (against jsonplaceholder.typicode.com/posts on the dev environment)

- **#1008**: `/test` endpoint — before: 2 contracts, 0 contract_logs, 0 objects; after: 2 contracts, 0 contract_logs, 0 objects (no test writes, response also carries `cleanup_invalid.skipped: true`).
- **#1009**: `POST /run` with `{"source": "https://attacker.example.com/x"}` — sources count unchanged (6 → 6), HTTP 400 with descriptive error: `No Source registered for location "https://attacker.example.com/x". Create the Source explicitly via the Sources API before triggering this sync (#1009).`
- **#1010**: real run completed; `synchronization.currentPage` stayed at 1 (no pagination on /posts so no advance); the per-page `saveObject` is gone from the loop body — architecturally verified.
- **#1016**: re-running the same sync against /posts left the target object count at exactly 100 (the source list size), not 200.
- **#1017**: test-sync response carries `cleanup_invalid.skipped: true`; rate-limit re-throw and empty-fetch skip are exercised by the unchanged upstream code paths.

## Notes

- Unit tests blocked by #1015 (shared `ObjectServiceMockBuilder` stubs the `ObjectEntity` magic `getUuid()`) — same failure on pristine development tip. PR C unblocks the suite.
- `phpstan` / `composer check:strict` deferred to CI per project policy (psl needs PHP 8.3, hangs locally).
- `php -l` clean.

Closes #1008, #1009, #1010, #1016, #1017.