### PR TITLE
test: align ConfigurationService + SynchronizationContractProvider tests with current implementation (#1024)

### DIFF
--- a/tests/Unit/Service/ConfigurationServiceTest.php
+++ b/tests/Unit/Service/ConfigurationServiceTest.php
@@ -169,35 +169,54 @@ class ConfigurationServiceTest extends TestCase
 
 
     /**
-     * Test that exportConfiguration returns a JSON-serialisable array with known keys.
+     * Test that exportConfiguration returns a JSON-serialisable array with the
+     * OAS-style 'components' envelope.
+     *
+     * Since `retrofit-2026-05-25-configuration-export-import` the export wraps
+     * the entity-type buckets under a top-level `components` key (so the export
+     * matches the OAS Components Object shape consumers expect). The previous
+     * test asserted the legacy flat shape; this asserts the current contract.
      *
      * @return void
      */
     public function testExportConfigurationReturnsStructuredArray(): void
     {
-        // Arrange — no objects, so export is essentially empty
+        // Arrange — no objects, so export is essentially empty.
         $this->orObjectService->method('findAll')
             ->willReturn(['results' => [], 'total' => 0]);
 
-        // Act
+        // Act.
         $result = $this->service->exportConfiguration('export-config-id');
 
-        // Assert — minimal structural check
+        // Assert — top-level OAS-style envelope.
         $this->assertIsArray($result);
-        // The export should include at minimum the entity type buckets
-        $this->assertArrayHasKey('sources', $result);
-        $this->assertArrayHasKey('synchronizations', $result);
+        $this->assertArrayHasKey('components', $result);
+        $this->assertIsArray($result['components']);
+
+        // Each entity type bucket lives inside `components` and is an array
+        // (empty here because no matching objects, but the keys must exist).
+        foreach (['sources', 'endpoints', 'mappings', 'rules', 'jobs', 'synchronizations'] as $bucket) {
+            $this->assertArrayHasKey($bucket, $result['components'], "missing bucket: $bucket");
+            $this->assertIsArray($result['components'][$bucket], "bucket not array: $bucket");
+        }
     }//end testExportConfigurationReturnsStructuredArray()
 
 
     /**
      * Test that getEntitiesByConfiguration indexes matching entities by slug.
      *
+     * Uses `willReturnCallback` keyed on the schema filter — `getEntitiesByConfiguration`
+     * issues six separate `findAll()` calls (one per schema). PHPUnit's
+     * `->method()->willReturn()` queues a fresh return per invocation, so a
+     * naive `willReturn([$source])` would have the source land in whichever
+     * bucket happens to be the second call (see ObjectServiceMockBuilder's
+     * matcher-queueing note — that was the original test drift).
+     *
      * @return void
      */
     public function testGetEntitiesByConfigurationIndexesBySlug(): void
     {
-        // Arrange — a source whose 'configurations' array contains our config ID
+        // Arrange — a source whose 'configurations' array contains our config ID.
         $targetConfigId = 'config-id-3';
         $sourceEntity   = ObjectServiceMockBuilder::objectEntity(
             $this,
@@ -209,16 +228,50 @@ class ConfigurationServiceTest extends TestCase
             'source-uuid-2'
         );
 
+        // Rebuild the OR mock so we can install a callback-based findAll
+        // without colliding with the empty-default queued in setUp().
+        $this->orObjectService = ObjectServiceMockBuilder::make($this);
         $this->orObjectService->method('findAll')
-            ->willReturn(['results' => [$sourceEntity], 'total' => 1]);
+            ->willReturnCallback(static function (array $config) use ($sourceEntity): array {
+                $schema = ($config['filters']['schema'] ?? '');
+                if ($schema === 'source') {
+                    return ['results' => [$sourceEntity], 'total' => 1];
+                }
 
-        // Act
+                return ['results' => [], 'total' => 0];
+            });
+
+        // Rewire the service with the fresh mock.
+        $endpointHandler        = new EndpointHandler($this->orObjectService);
+        $synchronizationHandler = new SynchronizationHandler($this->orObjectService);
+        $mappingHandler         = new MappingHandler($this->orObjectService);
+        $jobHandler             = new JobHandler($this->orObjectService);
+        $sourceHandler          = new SourceHandler($this->orObjectService);
+        $ruleHandler            = new RuleHandler($this->orObjectService);
+
+        $this->service = new ConfigurationService(
+            $this->orObjectService,
+            $this->registerMapper,
+            $this->schemaMapper,
+            $endpointHandler,
+            $synchronizationHandler,
+            $mappingHandler,
+            $jobHandler,
+            $sourceHandler,
+            $ruleHandler,
+        );
+
+        // Act.
         $result = $this->service->getEntitiesByConfiguration($targetConfigId);
 
-        // Assert — entity indexed under its slug
+        // Assert — entity indexed under its slug in the sources bucket only.
         $this->assertArrayHasKey('source-a', $result['sources']);
         $this->assertSame('Source A', $result['sources']['source-a']['name']);
-    }//end testGetEntitiesByConfigurationIndexesBySlug()
 
+        // Sanity: it must NOT have been mis-bucketed elsewhere.
+        foreach (['endpoints', 'mappings', 'rules', 'jobs', 'synchronizations'] as $otherBucket) {
+            $this->assertArrayNotHasKey('source-a', $result[$otherBucket], "source-a leaked into $otherBucket");
+        }
+    }//end testGetEntitiesByConfigurationIndexesBySlug()
 
 }//end class

--- a/tests/Unit/Service/SynchronizationContractProviderTest.php
+++ b/tests/Unit/Service/SynchronizationContractProviderTest.php
@@ -123,6 +123,12 @@ class SynchronizationContractProviderTest extends TestCase
     /**
      * Test that list queries OR with targetId filter when enabled.
      *
+     * The impl calls `$this->objectService->setRegister(...)->setSchema(...)->findAll(...)`.
+     * PHPUnit's auto-stubbing does NOT return $this for chainable setters with a
+     * `: static` return type — it produces a fresh mock per call — so the test
+     * must explicitly wire setRegister/setSchema to returnSelf, otherwise the
+     * configured findAll() never fires and the result is an empty array.
+     *
      * @return void
      */
     public function testListQueriesORWithTargetIdWhenEnabled(): void
@@ -145,6 +151,12 @@ class SynchronizationContractProviderTest extends TestCase
         );
 
         $this->objectService = ObjectServiceMockBuilder::make($this);
+
+        // The impl chains setRegister(...)->setSchema(...)->findAll(...).
+        // PHPUnit does not auto-returnSelf these mocks; wire it explicitly.
+        $this->objectService->method('setRegister')->willReturnSelf();
+        $this->objectService->method('setSchema')->willReturnSelf();
+
         $this->objectService->expects($this->once())
             ->method('findAll')
             ->with(


### PR DESCRIPTION
Closes #1024.

After #1023 unblocked the Service test suite (the `getUuid` magic-method mock crash), 3 pre-existing test/impl drifts surfaced. This PR aligns the tests with the **current intended implementation** behaviour. **All three are test-side drift** — the impl is correct in each case.

> Per scope of #1024: no impl changes in this PR. Other pre-existing failures in the Service suite (EndpointService array_combine, IBabsConnector message text, JobService scheduleJob skip path) are tracked separately as **#1025**.

## Per-failure diagnosis

### 1. `ConfigurationServiceTest::testExportConfigurationReturnsStructuredArray`
- **File:** `tests/Unit/Service/ConfigurationServiceTest.php:188` (old assertion)
- **Verdict:** test-updated
- **Rationale:** `ConfigurationService::exportConfiguration` wraps its output under a top-level `components` key (lines 432–442 in `lib/Service/ConfigurationService.php`, "Organize entities by components" — the [retrofit-2026-05-25-configuration-export-import](https://github.com/ConductionNL/openconnector/tree/development/openspec/changes/retrofit-2026-05-25-configuration-export-import) spec specifies an OAS Components Object shape). The test still asserted the legacy flat shape (`sources` / `synchronizations` at the top level).
- **Before:**
  ```php
  $this->assertArrayHasKey('sources', $result);
  $this->assertArrayHasKey('synchronizations', $result);
  ```
- **After:**
  ```php
  $this->assertArrayHasKey('components', $result);
  $this->assertIsArray($result['components']);
  foreach (['sources', 'endpoints', 'mappings', 'rules', 'jobs', 'synchronizations'] as $bucket) {
      $this->assertArrayHasKey($bucket, $result['components'], "missing bucket: $bucket");
      $this->assertIsArray($result['components'][$bucket], "bucket not array: $bucket");
  }
  ```
- **Not weakened:** the new assertion covers all six buckets (not just two) and verifies each is array-typed.

### 2. `ConfigurationServiceTest::testGetEntitiesByConfigurationIndexesBySlug`
- **File:** `tests/Unit/Service/ConfigurationServiceTest.php:219` (old assertion)
- **Verdict:** test-updated
- **Rationale:** `getEntitiesByConfiguration` issues six separate `findAll()` calls (one per schema: source, endpoint, mapping, rule, job, synchronization). PHPUnit's `->method()->willReturn()` *queues* a return per invocation — and the test's `setUp()` already queued an empty-default first. The result: the test's source entity landed in whichever bucket happened to be the second findAll (endpoints), not in `sources`. The `ObjectServiceMockBuilder` docstring explicitly warns about this matcher-queueing trap (see lines 67–76 there). The previous test passed only when the broken-helper crashed `setUp()` first.
- **Before:** `->willReturn(['results' => [$sourceEntity], 'total' => 1])` (queued on top of setUp's empty default).
- **After:** rebuilds the OR mock and installs `->willReturnCallback($cfg)` keyed on `$cfg['filters']['schema']`, returning the source only when `schema === 'source'`. Also asserts the source is **not** mis-bucketed in any of the other five buckets (catches the original drift if it ever regresses).
- **Not weakened:** assertion now verifies both the positive case (source in `sources` bucket) and five negative cases (source not in the other buckets) — strictly stronger than the original.

### 3. `SynchronizationContractProviderTest::testListQueriesORWithTargetIdWhenEnabled`
- **File:** `tests/Unit/Service/SynchronizationContractProviderTest.php:165` (old assertion)
- **Verdict:** test-updated
- **Rationale:** The impl calls `$this->objectService->setRegister(...)->setSchema(...)->findAll(...)` (lines 197–206 in `lib/Service/Integration/SynchronizationContractProvider.php`). PHPUnit does **not** auto-`returnSelf` for chainable setters declared with `: static` — it produces a fresh stub mock per call. So `setRegister(...)` returned a different mock instance, on which the test's expected `findAll(...)` was never configured, and the impl got an empty result. Confirmed by a probe test: `setRegister returns self: NO`, chained findAll returns `[]`.
- **Before:** chain not wired; `findAll` expectation set only on `$this->objectService`.
- **After:**
  ```php
  $this->objectService->method('setRegister')->willReturnSelf();
  $this->objectService->method('setSchema')->willReturnSelf();
  ```
- **Not weakened:** the rest of the test (single-call `expects($this->once())`, the `targetId` filter `with(callback)` constraint, and the three field assertions on the returned summary) is unchanged.

## Verification

Local (Nextcloud docker dev, PHP 8.3.30, PHPUnit 10.5.63):

```text
tests/Unit/Service/ConfigurationServiceTest.php + SynchronizationContractProviderTest.php
  Tests: 11, Assertions: 41, Errors: 0, Failures: 0
```

Broader `tests/Unit/Service/` suite:

```text
Before this PR (dev tip 5231ae8): Tests: 109, Assertions: 336, Errors: 2, Failures: 5
After  this PR                  : Tests: 109, Assertions: 358, Errors: 2, Failures: 2
```

The 3 named failures are gone. The remaining `2 errors + 2 failures` are entirely **pre-existing** in `EndpointServiceTest`, `IBabsConnectorServiceTest`, `JobServiceTest` — they were on `development` before this PR and are tracked in #1025 (out of scope for #1024).

- `php -l` clean on both edited files.
- `phpcs --standard=phpcs.xml` on both files: my changes add 8 line-style errors to a file that already has 50+ pre-existing violations of the same kinds (the project style copy-pasted from setUp; CI is diff-scoped — flagged for review but not introducing new patterns). No semantic violations.
- phpstan deferred to CI (psl hangs locally per project convention).

## Test-deployment hygiene

The bind-mounted test files were backed up before deployment and verified with `sha256sum` after restoration; the live container is back to pristine `development` state for the unrelated test files.