### PR TITLE
test: align Endpoint/IBabsConnector/Job tests with current implementation (#1025)

### DIFF
--- a/tests/Unit/Service/CallServiceTest.php
+++ b/tests/Unit/Service/CallServiceTest.php
@@ -20,6 +20,7 @@ use OCA\OpenConnector\Tests\Helpers\ObjectServiceMockBuilder;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Twig\Loader\ArrayLoader;
 
 /**
@@ -52,15 +53,24 @@ class CallServiceTest extends TestCase
 
         $authService = $this->createMock(AuthenticationService::class);
         $appConfig   = $this->createMock(IAppConfig::class);
+        $logger      = $this->createMock(LoggerInterface::class);
 
         // IAppConfig::hasKey defaults to false so no retention config is applied.
         $appConfig->method('hasKey')->willReturn(false);
 
+        // CallService constructor signature (5 args): ORObjectService,
+        // ArrayLoader, AuthenticationService, IAppConfig, LoggerInterface.
+        // The previous version passed only 4 — the LoggerInterface arg was
+        // added by #1011 (security-policy warnings) but the test wasn't
+        // updated, causing 5 ArgumentCountErrors that only surfaced once
+        // #1023 unblocked setUp() and the post-#1024 Service-suite peel
+        // (#1026) brought the remaining 3 cited #1025 suites to green.
         $this->service = new CallService(
             $this->objectService,
             new ArrayLoader([]),
             $authService,
             $appConfig,
+            $logger,
         );
     }//end setUp()
 


### PR DESCRIPTION
Closes #1025.

After PR #1026 closed #1024, re-running the full `tests/Unit/Service/` suite against development tip (`5e34f71`) shows the **4 failures cited in #1025 are GREEN**: the impl behaviours that #1025 listed as 'drift' were all landed by earlier PRs and the matching test files in dev tip already assert against the current behaviour. The 3 suites named in #1025 are already at 0/0 on dev tip — no further changes to them are needed in this PR.

What surfaced instead, once the suite ran to completion, are 5 `ArgumentCountError`s in `CallServiceTest` — same test-drift pattern as #1024 (constructor signature drift, test side, never weaken).

## Per-#1025-failure diagnosis (status against dev tip 5e34f71)

### 1. `EndpointServiceTest::testHandleRequestReturns404WhenEndpointObjectMissing`
- **Status:** **already green** on dev tip — no change in this PR.
- **Rationale:** `EndpointService::getPathParameters` (`lib/Service/EndpointService.php:397-433`) now normalises `$endpointArray` and `$pathParts` to the SHORTER length before `array_combine`, with an empty-input early-return at line 425. The legacy `try/catch + array_pop` fallback (which only handled a 1-element delta) was replaced. The fix is in dev tip; test reproduction failed only in the local bind-mount which carried a stale `lib/Service/EndpointService.php`. Confirmed by deploying dev-tip `lib/` files into the container and re-running the test.

### 2. `EndpointServiceTest::testHandleRequestWithProxyTargetTypeReturnsResponse`
- **Status:** **already green** on dev tip — same root cause as #1, same fix already merged.

### 3. `IBabsConnectorServiceTest::testTestConnectionFailsWithoutOrganisatieId`
- **Status:** **already green** on dev tip — no change in this PR.
- **Rationale:** `IBabsConnectorService::testConnection` (`lib/Service/IBabsConnectorService.php:76-79`) returns `'message' => 'Organisation ID not configured'` when `$config['organisatieId']` is null. The test asserts `assertStringContainsString('Organisation ID', $result['message'])` (`tests/Unit/Service/IBabsConnectorServiceTest.php:139`) — matches.

### 4. `JobServiceTest::testScheduleJobSkipsAlreadyScheduledJob`
- **Status:** **already green** on dev tip — no change in this PR.
- **Rationale:** `JobService::scheduleJob` (`lib/Service/JobService.php:212-216`) now early-returns the unmodified `$job` when `jobListId !== null` and `isEnabled !== false`, BEFORE either `objectService->saveObject` or `jobList->add`. The test's `expects($this->never())->method('saveObject')` and `assertSame($jobEntity, $result)` (`tests/Unit/Service/JobServiceTest.php:182-189`) now hold.

## New drift surfaced by the broader Service-suite run

`CallServiceTest` (5 errors, all `ArgumentCountError` at `tests/Unit/Service/CallServiceTest.php:59`):
- `testConstructorWiresDependencies`
- `testApplyConfigDotExpandsDotKeys`
- `testApplyConfigDotLeavesNonDotKeysUntouched`
- `testRemoveFilesHandlesEmptyConfig`
- `testGetCertificatePassesThroughWhenNoCertKey`

**Verdict:** test-update (impl correct, test still asserts old 4-arg shape).

**Root cause:** `CallService::__construct` (`lib/Service/CallService.php:122-128`) takes 5 args:
`ORObjectService, ArrayLoader, AuthenticationService, IAppConfig, LoggerInterface`.
The `LoggerInterface` arg was added by #1011 (security-policy warnings — `lib/Service/CallService.php:120` comment) but the test was still calling `new CallService(..., $appConfig)` (4 args). Same exact pattern as #1024's `ConfigurationServiceTest` constructor-signature drift.

### Before
```php
$this->service = new CallService(
    $this->objectService,
    new ArrayLoader([]),
    $authService,
    $appConfig,
);
```

### After
```php
$logger = $this->createMock(LoggerInterface::class);

$this->service = new CallService(
    $this->objectService,
    new ArrayLoader([]),
    $authService,
    $appConfig,
    $logger,
);
```

Not weakened — the constructor invocation now matches the impl exactly; no assertion strength changes elsewhere.

## Verification

Local (Nextcloud docker dev, PHP 8.3.30, PHPUnit 10.5.63):

Three #1025-cited suites (no change to these files in this PR):
```text
EndpointServiceTest + IBabsConnectorServiceTest + JobServiceTest
  Tests: 18, Assertions: 38, Errors: 0, Failures: 0
```

`CallServiceTest` only (after this PR):
```text
Tests: 5, Assertions: 8, Errors: 0, Failures: 0
```

Full `tests/Unit/Service/` suite (after this PR):
```text
Before this PR (dev tip 5e34f71): Tests: 109, Assertions: 354, Errors: 5, Failures: 0
After  this PR                  : Tests: 109, Assertions: 362, Errors: 0, Failures: 0
```

Remaining noise (not addressed here — both pre-existing, not in this PR's scope):
- 1 PHP warning at `lib/Service/RuleService.php:927` "Undefined array key 'path'" triggered by `RuleServiceTest::testProcessCustomRuleDispatchesConnectRelationsType`
- 1 PHP deprecation at the same line "explode(): Passing null to parameter #2 ($string) of type string is deprecated"

Both are impl-side defensive-coding issues in `RuleService::processCustomRule`, not test drift — should be peeled in a follow-up.

- `php -l tests/Unit/Service/CallServiceTest.php`: clean.
- Style: existing file uses aligned `=` columns in setUp() locals, this PR preserves that; phpcs style matches surrounding lines.

## Test-deployment hygiene

Bind-mounted dev environment had stale `lib/` files from a personal-branch checkout (`feat/synced-from-leaf`). To reproduce the test against dev-tip code, dev-tip `lib/` + `tests/Helpers/` files were copied into the container, the failing tests reproduced as listed in #1025, then the cited tests were re-run against the dev-tip impl (all green). After committing the test fix, the container was restored to the host bind-mount's pristine state — sha256 verified against the host workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)