### PR TITLE
fix: restore CI green — PHPUnit, PHPStan, PHPCS

### DIFF
--- a/lib/Controller/SynchronizationContractsController.php
+++ b/lib/Controller/SynchronizationContractsController.php
@@ -103,9 +103,9 @@ class SynchronizationContractsController extends Controller
         parent::__construct(appName: $appName, request: $request);
 
         $this->orObjectService = $orObjectService;
-        $this->l               = $l;
-        $this->userSession     = $userSession;
-        $this->actionAuth      = $actionAuth;
+        $this->l           = $l;
+        $this->userSession = $userSession;
+        $this->actionAuth  = $actionAuth;
 
     }//end __construct()
 

--- a/lib/Service/ActionAuthService.php
+++ b/lib/Service/ActionAuthService.php
@@ -221,10 +221,6 @@ class ActionAuthService
         // Normalize on write — same shape as getMatrix returns.
         $normalized = [];
         foreach ($matrix as $action => $groups) {
-            if (is_string($action) === false || is_array($groups) === false) {
-                continue;
-            }
-
             $clean = [];
             foreach ($groups as $g) {
                 if (is_string($g) === true && $g !== '') {

--- a/lib/Service/AuthenticationService.php
+++ b/lib/Service/AuthenticationService.php
@@ -276,9 +276,9 @@ class AuthenticationService
         // from process metadata. If the process died between
         // file_put_contents and unlink, the key leaked indefinitely.
         // Use tempnam() + chmod 0600 + try/finally so:
-        //   - the filename is unpredictable,
-        //   - the bytes are never readable to other local users,
-        //   - cleanup runs even when JWKFactory::createFromKeyFile throws.
+        // - the filename is unpredictable,
+        // - the bytes are never readable to other local users,
+        // - cleanup runs even when JWKFactory::createFromKeyFile throws.
         $filename = tempnam(sys_get_temp_dir(), 'oc_privatekey_');
         if ($filename === false) {
             throw new Exception('Could not allocate a temp file for the private key.');

--- a/lib/Service/CallService.php
+++ b/lib/Service/CallService.php
@@ -316,7 +316,7 @@ class CallService
         // Replace escaped new lines with actual new lines for certificates.
         $contents = str_replace('\n', "\n", $contents);
 
-        // chmod BEFORE the contents land so the race window between create and
+        // Chmod BEFORE the contents land so the race window between create and
         // chmod is empty (tempnam creates with 0600 on Linux but we re-assert).
         @chmod($tempLocation, 0600);
         file_put_contents($tempLocation, $contents);
@@ -465,7 +465,7 @@ class CallService
                 'statusCode'    => $statusCode,
                 'statusMessage' => $statusMessage,
                 'created'       => (new \DateTime())->format('c'),
-                'expires'       => $this->formatExpires($expires),
+                'expires'       => $this->formatExpires(expires: $expires),
             ],
             register: 'openconnector',
             schema: 'call_log'
@@ -556,8 +556,9 @@ class CallService
      * Fires the preRequest sub-call synchronously (unless already in a support request),
      * strips both keys from config, and returns the captured postRequest data (if any).
      *
-     * @param ObjectEntity $source               The source ObjectEntity.
-     * @param array        $config               The call configuration (modified in place — preRequest/postRequest removed).
+     * @param ObjectEntity $source                The source ObjectEntity.
+     * @param array        $config                The call configuration (modified in place — preRequest/postRequest
+     *                                            removed).
      * @param boolean      $runningSupportRequest Whether we are already inside a support request.
      *
      * @return array|null The postRequest descriptor array, or null if none was set.
@@ -607,6 +608,7 @@ class CallService
      * @throws LoaderError If there is an error loading a Twig template.
      * @throws SyntaxError If there is a syntax error in a Twig template.
      */
+
     /**
      * Returns true when the source location points at a loopback interface
      * (localhost, 127.x.x.x, ::1 — including http://, https://, with or
@@ -626,9 +628,18 @@ class CallService
         $host = (string) (parse_url($location, PHP_URL_HOST) ?? '');
         if ($host === '') {
             // Some sources carry just `localhost:8080` with no scheme.
-            $location = preg_replace('/^https?:\/\//i', '', $location);
-            $host     = (string) (strstr((string) $location, '/', true) ?: $location);
-            $host     = (string) (strstr($host, ':', true) ?: $host);
+            $location   = preg_replace('/^https?:\/\//i', '', $location);
+            $hostNoPath = strstr((string) $location, '/', true);
+            if ($hostNoPath !== false) {
+                $host = (string) $hostNoPath;
+            } else {
+                $host = (string) $location;
+            }
+
+            $hostNoPort = strstr($host, ':', true);
+            if ($hostNoPort !== false) {
+                $host = (string) $hostNoPort;
+            }
         }
 
         $host = strtolower(trim($host, "[]"));
@@ -651,8 +662,8 @@ class CallService
      * decades in the future could otherwise wedge OpenConnector into a
      * permanent 429 against that source (#1012c).
      *
-     * @param mixed   $rawValue  The raw value pulled from the response header.
-     * @param string  $kind      One of: 'reset', 'limit', 'remaining', 'window'.
+     * @param mixed  $rawValue The raw value pulled from the response header.
+     * @param string $kind     One of: 'reset', 'limit', 'remaining', 'window'.
      *
      * @return integer|null The clamped integer value, or null if the value cannot be sanely cast.
      */
@@ -686,7 +697,6 @@ class CallService
                 if ($value > $maxFuture) {
                     return $maxFuture;
                 }
-
                 return $value;
 
             case 'limit':
@@ -697,15 +707,24 @@ class CallService
                 if ($value > $maxCounter) {
                     return $maxCounter;
                 }
-
                 return $value;
 
             default:
                 return $value;
-        }
+        }//end switch
 
     }//end clampRateLimitHeader()
 
+    /**
+     * Normalise Guzzle request config with TLS and secret-redaction guards.
+     *
+     * @param array $config     Raw Guzzle config array to normalise.
+     * @param array $sourceData Source configuration data.
+     *
+     * @return array The normalised config with TLS and secret guards applied.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-synchronization-engine/tasks.md
+     */
     private function normaliseRequestConfig(array $config, array $sourceData): array
     {
         // #1011: a source can disable TLS certificate verification by setting
@@ -713,12 +732,12 @@ class CallService
         // honours it silently and the connection is exposed to MITM — which
         // also leaks any credentials carried in the request. We refuse
         // `verify: false` unless either:
-        //  - the source location is loopback (localhost / 127.x / [::1]), or
-        //  - the admin has explicitly opted-in via the NC app config flag
-        //    `openconnector.allow_insecure_tls = true`.
+        // - the source location is loopback (localhost / 127.x / [::1]), or
+        // - the admin has explicitly opted-in via the NC app config flag
+        // `openconnector.allow_insecure_tls = true`.
         if (array_key_exists('verify', $config) === true && $config['verify'] === false) {
-            $location           = (string) ($sourceData['location'] ?? '');
-            $isLocalhost        = $this->isLoopbackLocation($location);
+            $location            = (string) ($sourceData['location'] ?? '');
+            $isLocalhost         = $this->isLoopbackLocation(location: $location);
             $allowInsecureTlsRaw = $this->appConfig->getValueString(
                 'openconnector',
                 'allow_insecure_tls',
@@ -736,7 +755,7 @@ class CallService
                     ['location' => $location]
                 );
             }
-        }
+        }//end if
 
         // Check if the config has a Content-Type header and overwrite it if it does.
         if (isset($config['headers']['Content-Type']) === true) {
@@ -840,7 +859,7 @@ class CallService
                     // same eventual response or rejection.
                     // We snapshot the certificate paths NOW because the caller
                     // mutates $config after we return.
-                    $certPaths = $this->snapshotCertPaths($config);
+                    $certPaths = $this->snapshotCertPaths(config: $config);
                     $promise   = $this->client->requestAsync($method, $url, $config);
                     $promise->then(
                         function ($asyncResponse) use ($certPaths) {
@@ -856,15 +875,15 @@ class CallService
                     );
 
                     return $promise;
-                }
+                }//end if
             } catch (BadResponseException $e) {
                 $this->removeFiles(config: $config);
                 $response = $e->getResponse();
             } catch (ConnectException $exception) {
                 $this->removeFiles(config: $config);
                 $response = new Response(status: 503, body: $exception->getMessage());
-            }
-        }
+            }//end try
+        }//end if
 
         $this->removeFiles(config: $config);
 
@@ -905,10 +924,10 @@ class CallService
      * Decodes the response body, determines encoding, resolves remote IP, and
      * assembles the structured $data array that contains both request and response info.
      *
-     * @param \Psr\Http\Message\ResponseInterface $response The HTTP response.
-     * @param string                              $url      The URL that was called.
-     * @param string                              $method   The HTTP method used.
-     * @param array                               $config   The Guzzle request config that was sent.
+     * @param \Psr\Http\Message\ResponseInterface $response  The HTTP response.
+     * @param string                              $url       The URL that was called.
+     * @param string                              $method    The HTTP method used.
+     * @param array                               $config    The Guzzle request config that was sent.
      * @param float                               $timeStart Microtime at request start.
      * @param float                               $timeEnd   Microtime after response received.
      *
@@ -947,10 +966,10 @@ class CallService
         // (which may carry query-string secrets), and from the response body (which can
         // echo the request URL with its query secrets). The actual outbound call has
         // already been dispatched with the REAL secrets before this method runs.
-        $secretValues   = $this->collectSecretValues($config, $url);
-        $redactedConfig = $this->redactSecretsFromConfig($config);
-        $redactedUrl    = $this->redactSecretsFromUrl($url);
-        $bodyForLog     = $this->redactSecretValuesFromString($bodyForLog, $secretValues);
+        $secretValues   = $this->collectSecretValues(config: $config, url: $url);
+        $redactedConfig = $this->redactSecretsFromConfig(config: $config);
+        $redactedUrl    = $this->redactSecretsFromUrl(url: $url);
+        $bodyForLog     = $this->redactSecretValuesFromString(body: $bodyForLog, secretValues: $secretValues);
 
         return [
             'request'  => [
@@ -1009,7 +1028,7 @@ class CallService
 
                 // Also redact any header whose name matches the secret-key pattern
                 // (covers X-Api-Key, X-Auth-Token, Api-Key, etc.).
-                if ($this->isSecretKeyName((string) $headerName) === true) {
+                if ($this->isSecretKeyName(name: (string) $headerName) === true) {
                     $config['headers'][$headerName] = $placeholder;
                 }
             }
@@ -1024,7 +1043,7 @@ class CallService
         foreach (['query', 'form_params'] as $bag) {
             if (isset($config[$bag]) === true && is_array($config[$bag]) === true) {
                 foreach ($config[$bag] as $paramName => $paramValue) {
-                    if ($this->isSecretKeyName((string) $paramName) === true) {
+                    if ($this->isSecretKeyName(name: (string) $paramName) === true) {
                         $config[$bag][$paramName] = $placeholder;
                     }
                 }
@@ -1079,9 +1098,9 @@ class CallService
 
         $changed = false;
         foreach ($params as $paramName => $paramValue) {
-            if ($this->isSecretKeyName((string) $paramName) === true) {
+            if ($this->isSecretKeyName(name: (string) $paramName) === true) {
                 $params[$paramName] = '***REDACTED***';
-                $changed = true;
+                $changed            = true;
             }
         }
 
@@ -1099,7 +1118,7 @@ class CallService
      * reflects the request, or an error page that includes credentials).
      *
      * @param array  $config The Guzzle request config sent for the call.
-     * @param string $url     The full request URL (may contain query-string secrets).
+     * @param string $url    The full request URL (may contain query-string secrets).
      *
      * @return array<int, string> A list of secret string values to redact.
      */
@@ -1112,23 +1131,23 @@ class CallService
             $secretHeaderNames = ['authorization', 'proxy-authorization', 'cookie', 'set-cookie'];
             foreach ($config['headers'] as $headerName => $headerValue) {
                 $lower = strtolower((string) $headerName);
-                if (in_array($lower, $secretHeaderNames, true) === true || $this->isSecretKeyName((string) $headerName) === true) {
-                    $values = array_merge($values, $this->flattenSecretValue($headerValue));
+                if (in_array($lower, $secretHeaderNames, true) === true || $this->isSecretKeyName(name: (string) $headerName) === true) {
+                    $values = array_merge($values, $this->flattenSecretValue(value: $headerValue));
                 }
             }
         }
 
         // Basic-auth credentials.
         if (isset($config['auth']) === true) {
-            $values = array_merge($values, $this->flattenSecretValue($config['auth']));
+            $values = array_merge($values, $this->flattenSecretValue(value: $config['auth']));
         }
 
         // Secret query / form parameters from the config.
         foreach (['query', 'form_params'] as $bag) {
             if (isset($config[$bag]) === true && is_array($config[$bag]) === true) {
                 foreach ($config[$bag] as $paramName => $paramValue) {
-                    if ($this->isSecretKeyName((string) $paramName) === true) {
-                        $values = array_merge($values, $this->flattenSecretValue($paramValue));
+                    if ($this->isSecretKeyName(name: (string) $paramName) === true) {
+                        $values = array_merge($values, $this->flattenSecretValue(value: $paramValue));
                     }
                 }
             }
@@ -1139,8 +1158,8 @@ class CallService
         if ($queryStart !== false) {
             parse_str(substr($url, ($queryStart + 1)), $urlParams);
             foreach ($urlParams as $paramName => $paramValue) {
-                if ($this->isSecretKeyName((string) $paramName) === true) {
-                    $values = array_merge($values, $this->flattenSecretValue($paramValue));
+                if ($this->isSecretKeyName(name: (string) $paramName) === true) {
+                    $values = array_merge($values, $this->flattenSecretValue(value: $paramValue));
                 }
             }
         }
@@ -1263,7 +1282,11 @@ class CallService
             }
         }
 
-        $expiresChosen = ($statusCode < 400) ? $successExpires : $errorExpires;
+        if ($statusCode < 400) {
+            $expiresChosen = $successExpires;
+        } else {
+            $expiresChosen = $errorExpires;
+        }
 
         $callLogData = [
             'source'        => $source->getUuid(),
@@ -1272,7 +1295,7 @@ class CallService
             'request'       => $data['request'],
             'response'      => $responseData,
             'created'       => (new \DateTime())->format('c'),
-            'expires'       => $this->formatExpires($expiresChosen),
+            'expires'       => $this->formatExpires(expires: $expiresChosen),
         ];
 
         $callLog = $this->objectService->saveObject(
@@ -1326,7 +1349,7 @@ class CallService
         $sourceData = $source->getObject();
 
         // Phase 1: Compute expiry values for log retention.
-        $expiries       = $this->buildExpiryValues($sourceData);
+        $expiries       = $this->buildExpiryValues(sourceData: $sourceData);
         $errorExpires   = $expiries['errorExpires'];
         $successExpires = $expiries['successExpires'];
 
@@ -1389,7 +1412,6 @@ class CallService
         // Let's log the call.
         $sourceData['lastCall'] = (new \DateTime())->format('c');
         // @todo: save the source.
-
         // Phase 10: Dispatch the HTTP request.
         $timeStart = microtime(true);
         $response  = $this->dispatchRequest(
@@ -1463,7 +1485,7 @@ class CallService
         // into a permanent 429 (the engine's checkRateLimit guard would refuse
         // every subsequent call until the year 5138).
         if (isset($headers['X-RateLimit-Reset']) === true) {
-            $clampedReset = $this->clampRateLimitHeader($headers['X-RateLimit-Reset'], 'reset');
+            $clampedReset = $this->clampRateLimitHeader(rawValue: $headers['X-RateLimit-Reset'], kind: 'reset');
             if ($clampedReset !== null) {
                 $sourceData['rateLimitReset'] = $clampedReset;
                 $changed = true;
@@ -1488,7 +1510,7 @@ class CallService
 
         // Check if RateLimit-Limit is present in response headers. If so, save it in the source.
         if (isset($headers['X-RateLimit-Limit']) === true) {
-            $clampedLimit = $this->clampRateLimitHeader($headers['X-RateLimit-Limit'], 'limit');
+            $clampedLimit = $this->clampRateLimitHeader(rawValue: $headers['X-RateLimit-Limit'], kind: 'limit');
             if ($clampedLimit !== null) {
                 $sourceData['rateLimitLimit'] = $clampedLimit;
                 $rateLimitLimit = $clampedLimit;
@@ -1498,7 +1520,7 @@ class CallService
 
         // Check if RateLimit-Remaining is present in response headers. If so, save it in the source.
         if (isset($headers['X-RateLimit-Remaining']) === true) {
-            $clampedRemaining = $this->clampRateLimitHeader($headers['X-RateLimit-Remaining'], 'remaining');
+            $clampedRemaining = $this->clampRateLimitHeader(rawValue: $headers['X-RateLimit-Remaining'], kind: 'remaining');
             if ($clampedRemaining !== null) {
                 $sourceData['rateLimitRemaining'] = $clampedRemaining;
                 $rateLimitRemaining = $clampedRemaining;

--- a/lib/Service/IBabsConnectorService.php
+++ b/lib/Service/IBabsConnectorService.php
@@ -68,6 +68,7 @@ class IBabsConnectorService
             if (is_string($config) === true) {
                 $config = json_decode($config, true);
             }
+
             if (is_array($config) === false) {
                 $config = [];
             }

--- a/lib/Service/JobService.php
+++ b/lib/Service/JobService.php
@@ -363,8 +363,8 @@ class JobService
         // Capture the prior session user so we can restore it after the job runs
         // — without restoration, the first user-scoped job's identity sticks
         // for every subsequent job in the same cron pass (#1006).
-        $userId               = ($jobData['userId'] ?? null);
-        $priorSessionUser     = $this->userSession->getUser();
+        $userId           = ($jobData['userId'] ?? null);
+        $priorSessionUser = $this->userSession->getUser();
         $sessionUserOverridden = false;
         if (empty($userId) === false) {
             $user = $this->userManager->get($userId);
@@ -386,7 +386,7 @@ class JobService
 
             $this->userSession->setUser($user);
             $sessionUserOverridden = true;
-        }
+        }//end if
 
         // Record execution start time for performance tracking.
         $timeStart = microtime(true);
@@ -655,7 +655,7 @@ class JobService
                 } catch (\Throwable $logError) {
                     // Swallow logging failure — we must continue to the next job.
                     unset($logError);
-                }
+                }//end try
 
                 continue;
             }//end try

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -63,6 +63,7 @@ class SynchronizationService
      *
      * @var integer
      */
+
     /**
      * In-memory accumulator of contract log payloads for the active synchronize() pass.
      *
@@ -78,6 +79,11 @@ class SynchronizationService
      */
     private array $pendingContractLogs = [];
 
+    /**
+     * Retention period in milliseconds for error logs.
+     *
+     * @var integer
+     */
     private int $errorRetention;
 
     /**
@@ -460,7 +466,7 @@ class SynchronizationService
      *
      * @param ObjectEntity                            $synchronization The synchronization configuration.
      * @param \OCA\OpenRegister\Db\ObjectEntity|array $object          The object to be synchronized, also referenced.
-     * @param ObjectEntity                            $log             The log object recording synchronization details.
+     * @param array                                   $logData         The log data accumulator recording synchronization details.
      * @param FlowToken                               $flowToken       The flow token tracking the operation.
      * @param bool|null                               $isTest          Whether this is a test run (does not persist data).
      * @param bool|null                               $force           Whether to force the synchronization regardless of changes.
@@ -681,7 +687,7 @@ class SynchronizationService
      * If a rate limit error occurs during the external request, a `TooManyRequestsHttpException` is thrown.
      *
      * @param ObjectEntity $synchronization The synchronization configuration and state.
-     * @param ObjectEntity $log             The log object to record synchronization details and results.
+     * @param array        $logData         The log data accumulator to record synchronization details and results.
      * @param FlowToken    $flowToken       The flow token tracking the operation.
      * @param bool|null    $isTest          Optional flag to run the synchronization in test mode (no deletions, no persistence).
      * @param bool|null    $force           Optional flag to bypass change checks and force synchronization of all objects.
@@ -689,7 +695,7 @@ class SynchronizationService
      * @param array|null   $data            The data to add to synchronize, if not provided, the synchronization's data will be used.
      * @param string|null  $mutationType    The current type of mutation we are doing this::VALID_MUTATION_TYPES.
      *
-     * @return ObjectEntity Returns the updated synchronization log with processing results.
+     * @return array Returns the updated synchronization log data with processing results.
      *
      * @throws TooManyRequestsHttpException If the external source responds with a rate limiting error.
      * @throws Exception                    If the source ID is empty or synchronization cannot proceed.
@@ -901,19 +907,19 @@ class SynchronizationService
             // Defensive guard (#1017): only invoke deleteInvalidObjects when
             // this fetch was a definitive success and returned a genuine
             // result set.
-            //   - Skip when the source rate-limited us (rateLimitException !==
-            //     null) — re-throw immediately so the caller learns about the
-            //     429 instead of silently swallowing it.
-            //   - Skip on test runs (no persistent state changes allowed under
-            //     $isTest = true, #1008).
-            //   - Skip when no objects were returned AND no objects were
-            //     processed — an empty fetch from a failing source must NOT
-            //     cause deleteInvalidObjects to wipe every previously-synced
-            //     target via `array_diff(allContractTargetIds, [])`.
-            //   - Findings #1000/#1001/#1002 confirmed deleteInvalidObjects is
-            //     currently INERT at runtime, so this guard is latent
-            //     protection — when that bug is eventually repaired, the
-            //     cascade is already disarmed.
+            // - Skip when the source rate-limited us (rateLimitException !==
+            // null) — re-throw immediately so the caller learns about the
+            // 429 instead of silently swallowing it.
+            // - Skip on test runs (no persistent state changes allowed under
+            // $isTest = true, #1008).
+            // - Skip when no objects were returned AND no objects were
+            // processed — an empty fetch from a failing source must NOT
+            // cause deleteInvalidObjects to wipe every previously-synced
+            // target via `array_diff(allContractTargetIds, [])`.
+            // - Findings #1000/#1001/#1002 confirmed deleteInvalidObjects is
+            // currently INERT at runtime, so this guard is latent
+            // protection — when that bug is eventually repaired, the
+            // cascade is already disarmed.
             if ($rateLimitException !== null) {
                 throw $rateLimitException;
             }
@@ -1120,7 +1126,7 @@ class SynchronizationService
         if (($syncData['sourceType'] ?? '') === 'register/schema' && $object !== null) {
             $logData['result']['type'] = 'internToExtern';
 
-            // synchronizeInternToExtern receives the in-memory log payload
+            // SynchronizeInternToExtern receives the in-memory log payload
             // (no upfront sync_log row) and mutates it directly. Persistence
             // happens once below in finalizeSynchronizationLog() — even on
             // failure (try/finally), to preserve operator visibility (#1007).
@@ -1148,7 +1154,7 @@ class SynchronizationService
 
                 // Single write of the sync log + flush any accumulated contract logs.
                 $this->finalizeSynchronizationLog(logData: $logData);
-            }
+            }//end try
 
             if ($internError !== null) {
                 throw $internError;
@@ -1189,7 +1195,7 @@ class SynchronizationService
                 )?->format('c');
 
             $persisted = $this->finalizeSynchronizationLog(logData: $logData);
-        }
+        }//end try
 
         if ($externError !== null) {
             throw $externError;
@@ -1792,7 +1798,6 @@ class SynchronizationService
      * @param array             $object                  The source object being synchronized.
      * @param bool|null         $isTest                  False by default, currently added for sync-test.
      * @param bool|null         $force                   False by default, force update regardless of changes.
-     * @param ObjectEntity|null $log                     The log to update.
      * @param string|null       $mutationType            Single object mutation type: 'create', 'update' or 'delete'.
      *
      * @return ObjectEntity|Exception|array Returns the updated contract entity, an Exception on mapping failures or the test array.
@@ -1836,7 +1841,7 @@ class SynchronizationService
             }
 
             $contractLogData = [
-                // synchronizationLogId is filled in by finalizeSynchronizationLog()
+                // SynchronizationLogId is filled in by finalizeSynchronizationLog()
                 // once the parent sync_log row is created — see #1007.
                 'synchronizationId'         => $synchronizationId,
                 'synchronizationContractId' => $synchronizationContract->getUuid(),
@@ -1915,7 +1920,7 @@ class SynchronizationService
                     schema: 'synchronization_contract',
                     uuid: $synchronizationContract->getUuid()
                 );
-                $contractData = $synchronizationContract->getObject();
+                $contractData            = $synchronizationContract->getObject();
 
                 if ($contractLogData !== null) {
                     $contractLogData['expiry'] = $this->calculateExpires(
@@ -1923,13 +1928,13 @@ class SynchronizationService
                         )?->format('c');
                     // Buffer the final contract-log payload for write-once flush
                     // — append-only schemas reject UPDATE (#1007).
-                    $this->bufferContractLog($contractLogData);
+                    $this->bufferContractLog(contractLogData: $contractLogData);
                 }
             } else if ($contractLogData !== null) {
                 $contractLogData['expiry'] = $this->calculateExpires(
                         ...[$this->successRetention]
                     )?->format('c');
-            }
+            }//end if
 
             $skipLog = $contractLogData;
 
@@ -1953,7 +1958,7 @@ class SynchronizationService
                 schema: 'synchronization_contract',
                 uuid: $synchronizationContract->getUuid()
             );
-            $contractData = $synchronizationContract->getObject();
+            $contractData            = $synchronizationContract->getObject();
         }
 
         // Execute mapping if found.
@@ -2008,7 +2013,7 @@ class SynchronizationService
                 schema: 'synchronization_contract',
                 uuid: $synchronizationContract->getUuid()
             );
-            $contractData = $synchronizationContract->getObject();
+            $contractData            = $synchronizationContract->getObject();
         }
 
         // Handle synchronization based on test mode.
@@ -2074,7 +2079,7 @@ class SynchronizationService
             $contractLogData['expiry']       = $this->calculateExpires(
                     ...[$this->successRetention]
                 )?->format('c');
-            $this->bufferContractLog($contractLogData);
+            $this->bufferContractLog(contractLogData: $contractLogData);
         }
 
         $synchronizationContract = $this->orObjectService->saveObject(
@@ -2953,10 +2958,10 @@ class SynchronizationService
                 }
 
                 // Update for next iteration.
-                $currentEndpoint      = $nextInfo['endpoint'];
-                $config               = $nextInfo['config'];
-                $currentPage          = $nextInfo['page'];
-                $usesNextEndpoint     = $nextInfo['usesNextEndpoint'];
+                $currentEndpoint  = $nextInfo['endpoint'];
+                $config           = $nextInfo['config'];
+                $currentPage      = $nextInfo['page'];
+                $usesNextEndpoint = $nextInfo['usesNextEndpoint'];
                 $persistedCurrentPage = $currentPage;
             }//end for
         } finally {
@@ -3704,7 +3709,7 @@ class SynchronizationService
         $serializedObject = $object->jsonSerialize();
         $flowToken        = new FlowToken();
 
-        // synchronizeContract no longer accepts a $log arg — it buffers the
+        // SynchronizeContract no longer accepts a $log arg — it buffers the
         // contract-log payload (#1007). When called outside a synchronize()
         // pass we flush the buffer to a synchronizationLogId set from the
         // passed-in $log (if any), then clear the buffer.
@@ -5070,7 +5075,6 @@ class SynchronizationService
      * @param array        $result          The current result tracking data.
      * @param bool         $isTest          Whether this is a test run.
      * @param bool         $force           Whether to force synchronization regardless of changes.
-     * @param ObjectEntity $log             The synchronization log.
      * @param FlowToken    $flowToken       The flow token tracking the operation.
      * @param string|null  $mutationType    The type of object mutation.
      *

--- a/tests/Unit/Controller/UiControllerTest.php
+++ b/tests/Unit/Controller/UiControllerTest.php
@@ -31,7 +31,7 @@ class UiControllerTest extends TestCase
         $methods = [
             'sources', 'sourcesLogs', 'endpoints', 'endpointsLogs', 'consumers', 'webhooks',
             'jobs', 'jobsLogs', 'mappings', 'synchronizations', 'synchronizationsContracts',
-            'synchronizationsLogs', 'cloudEvents', 'cloudEventsEvents', 'cloudEventsLogs', 'import',
+            'synchronizationsLogs', 'cloudEvents', 'cloudEventsEvents', 'cloudEventsLogs',
         ];
 
         foreach ($methods as $method) {

--- a/tests/Unit/Settings/RegisterDescriptorTest.php
+++ b/tests/Unit/Settings/RegisterDescriptorTest.php
@@ -5,10 +5,18 @@
  *
  * CI guard for chain A (openconnector-register-schema-declaration) — REQ-A-002.
  *
- * Asserts that every protected property on each of the 15 openconnector entity
- * classes appears as a property on the matching schema in
- * lib/Settings/openconnector_register.json. A missing or typo'd property
- * fails the test with a diagnostic naming the entity, field, and schema slug.
+ * Asserts structural integrity of lib/Settings/openconnector_register.json:
+ * - All 15 schema slugs are declared in the register
+ * - All 15 schemas are defined in components.schemas
+ * - Log schemas carry appendOnly/immutable/archival markers
+ * - Mutable schemas do NOT carry appendOnly/immutable
+ * - FK relations carry $ref and x-openregister-onDelete
+ * - sourceId/targetId on synchronization are plain string (no $ref)
+ *
+ * NOTE: The original REQ-A-002 test used Reflection on OCA\OpenConnector\Db\*
+ * entity classes to verify schema completeness. Those entity classes were
+ * deleted in chain C (all state now lives in OpenRegister). The Reflection
+ * assertions have been removed; the structural JSON checks below remain.
  *
  * Cross-ref: openspec/changes/openconnector-register-schema-declaration/specs/openconnector-register-schema/spec.md#req-a-002
  */
@@ -18,41 +26,36 @@ declare(strict_types=1);
 namespace OCA\OpenConnector\Tests\Unit\Settings;
 
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
-use ReflectionProperty;
 
 class RegisterDescriptorTest extends TestCase
 {
     /**
-     * Map of entity FQCN → schema slug in openconnector_register.json.
+     * The 15 schema slugs that MUST be declared in the register.
+     * Keys are the former entity FQCN (kept for diagnostic messages); values are schema slugs.
+     *
+     * @var array<string, string>
      */
-    private const ENTITY_TO_SCHEMA = [
-        'OCA\\OpenConnector\\Db\\Source'                      => 'source',
-        'OCA\\OpenConnector\\Db\\Consumer'                    => 'consumer',
-        'OCA\\OpenConnector\\Db\\Endpoint'                    => 'endpoint',
-        'OCA\\OpenConnector\\Db\\Event'                       => 'event',
-        'OCA\\OpenConnector\\Db\\EventMessage'                => 'event_message',
-        'OCA\\OpenConnector\\Db\\EventSubscription'           => 'event_subscription',
-        'OCA\\OpenConnector\\Db\\Job'                         => 'job',
-        'OCA\\OpenConnector\\Db\\Mapping'                     => 'mapping',
-        'OCA\\OpenConnector\\Db\\Rule'                        => 'rule',
-        'OCA\\OpenConnector\\Db\\Synchronization'             => 'synchronization',
-        'OCA\\OpenConnector\\Db\\SynchronizationContract'     => 'synchronization_contract',
-        'OCA\\OpenConnector\\Db\\CallLog'                     => 'call_log',
-        'OCA\\OpenConnector\\Db\\JobLog'                      => 'job_log',
-        'OCA\\OpenConnector\\Db\\SynchronizationLog'          => 'synchronization_log',
-        'OCA\\OpenConnector\\Db\\SynchronizationContractLog'  => 'synchronization_contract_log',
+    private const SCHEMA_SLUGS = [
+        'Source'                     => 'source',
+        'Consumer'                   => 'consumer',
+        'Endpoint'                   => 'endpoint',
+        'Event'                      => 'event',
+        'EventMessage'               => 'event_message',
+        'EventSubscription'          => 'event_subscription',
+        'Job'                        => 'job',
+        'Mapping'                    => 'mapping',
+        'Rule'                       => 'rule',
+        'Synchronization'            => 'synchronization',
+        'SynchronizationContract'    => 'synchronization_contract',
+        'CallLog'                    => 'call_log',
+        'JobLog'                     => 'job_log',
+        'SynchronizationLog'         => 'synchronization_log',
+        'SynchronizationContractLog' => 'synchronization_contract_log',
     ];
 
     /**
-     * Fields that exist on the entity but are intentionally NOT in the schema
-     * (OR-managed metadata that OR auto-applies — `id` is the legacy integer PK
-     * superseded by `uuid` for OR-stored objects).
+     * @var array<string, mixed>
      */
-    private const ENTITY_FIELDS_EXCLUDED_FROM_SCHEMA = [
-        'id',
-    ];
-
     private array $descriptor;
 
     protected function setUp(): void
@@ -68,11 +71,11 @@ class RegisterDescriptorTest extends TestCase
         $this->assertSame(JSON_ERROR_NONE, json_last_error(), 'JSON parse error: ' . json_last_error_msg());
 
         $this->descriptor = $parsed;
-    }
+    }//end setUp()
 
     public function testRegisterDeclaresAllFifteenSchemaSlugs(): void
     {
-        $expected = array_values(self::ENTITY_TO_SCHEMA);
+        $expected = array_values(self::SCHEMA_SLUGS);
         $actual = $this->descriptor['components']['registers']['openconnector']['schemas'] ?? [];
 
         sort($expected);
@@ -84,61 +87,39 @@ class RegisterDescriptorTest extends TestCase
             $actualSorted,
             'register.openconnector.schemas[] MUST list exactly the 15 schema slugs'
         );
-    }
+    }//end testRegisterDeclaresAllFifteenSchemaSlugs()
 
     public function testAllFifteenSchemasAreDefined(): void
     {
         $schemas = $this->descriptor['components']['schemas'] ?? [];
 
-        foreach (self::ENTITY_TO_SCHEMA as $entityFqcn => $schemaSlug) {
+        foreach (self::SCHEMA_SLUGS as $label => $schemaSlug) {
             $this->assertArrayHasKey(
                 $schemaSlug,
                 $schemas,
-                sprintf('Schema "%s" (for entity %s) MUST be declared in components.schemas', $schemaSlug, $entityFqcn)
+                sprintf('Schema "%s" (formerly entity %s) MUST be declared in components.schemas', $schemaSlug, $label)
             );
         }
-    }
+    }//end testAllFifteenSchemasAreDefined()
 
     /**
-     * @dataProvider entityProvider
+     * Each schema MUST declare a non-empty properties block.
+     *
+     * @dataProvider schemaSlugProvider
      */
-    public function testEveryProtectedEntityPropertyAppearsInSchema(string $entityFqcn, string $schemaSlug): void
+    public function testEachSchemaDeclaresSomeProperties(string $schemaSlug): void
     {
-        $this->assertTrue(
-            class_exists($entityFqcn),
-            sprintf('Entity class %s MUST exist', $entityFqcn)
-        );
-
         $schemas = $this->descriptor['components']['schemas'] ?? [];
         $schema = $schemas[$schemaSlug] ?? null;
         $this->assertIsArray($schema, sprintf('Schema "%s" MUST be defined', $schemaSlug));
 
-        $schemaProperties = $schema['properties'] ?? [];
-        $this->assertIsArray($schemaProperties, sprintf('Schema "%s" MUST declare a properties block', $schemaSlug));
-
-        $reflection = new ReflectionClass($entityFqcn);
-        $entityFields = [];
-        foreach ($reflection->getProperties(ReflectionProperty::IS_PROTECTED) as $prop) {
-            $name = $prop->getName();
-            if (in_array($name, self::ENTITY_FIELDS_EXCLUDED_FROM_SCHEMA, true)) {
-                continue;
-            }
-            $entityFields[] = $name;
-        }
-
-        $missing = array_diff($entityFields, array_keys($schemaProperties));
-
-        $this->assertEmpty(
-            $missing,
-            sprintf(
-                'Entity %s has %d protected field(s) missing from schema "%s": %s',
-                $entityFqcn,
-                count($missing),
-                $schemaSlug,
-                implode(', ', $missing)
-            )
+        $properties = $schema['properties'] ?? [];
+        $this->assertIsArray($properties, sprintf('Schema "%s" MUST declare a properties block', $schemaSlug));
+        $this->assertNotEmpty(
+            $properties,
+            sprintf('Schema "%s" properties block MUST NOT be empty', $schemaSlug)
         );
-    }
+    }//end testEachSchemaDeclaresSomeProperties()
 
     public function testLogSchemasAreAppendOnlyAndImmutable(): void
     {
@@ -162,7 +143,7 @@ class RegisterDescriptorTest extends TestCase
                 sprintf('Log schema "%s" MUST carry x-openregister-archival annotation (REQ-A-004)', $slug)
             );
         }
-    }
+    }//end testLogSchemasAreAppendOnlyAndImmutable()
 
     public function testMutableSchemasAreNotAppendOnly(): void
     {
@@ -170,7 +151,7 @@ class RegisterDescriptorTest extends TestCase
         $schemas = $this->descriptor['components']['schemas'] ?? [];
 
         foreach ($schemas as $slug => $schema) {
-            if (in_array($slug, $logSchemas, true)) {
+            if (in_array($slug, $logSchemas, true) === true) {
                 continue;
             }
             $this->assertFalse(
@@ -182,18 +163,18 @@ class RegisterDescriptorTest extends TestCase
                 sprintf('Mutable schema "%s" MUST NOT set immutable: true', $slug)
             );
         }
-    }
+    }//end testMutableSchemasAreNotAppendOnly()
 
     public function testFkRelationsCarryRefAndOnDelete(): void
     {
         $schemas = $this->descriptor['components']['schemas'] ?? [];
 
         $expectedRelations = [
-            ['schema' => 'call_log',      'property' => 'source',                    'target' => 'source',                    'onDelete' => 'SET NULL'],
-            ['schema' => 'call_log',      'property' => 'synchronization',          'target' => 'synchronization',          'onDelete' => 'SET NULL'],
-            ['schema' => 'event_message', 'property' => 'event',                    'target' => 'event',                    'onDelete' => 'CASCADE'],
-            ['schema' => 'event_message', 'property' => 'consumer',                 'target' => 'consumer',                 'onDelete' => 'SET NULL'],
-            ['schema' => 'event_message', 'property' => 'subscription',             'target' => 'event_subscription',        'onDelete' => 'CASCADE'],
+            ['schema' => 'call_log',      'property' => 'source',                       'target' => 'source',                  'onDelete' => 'SET NULL'],
+            ['schema' => 'call_log',      'property' => 'synchronization',              'target' => 'synchronization',         'onDelete' => 'SET NULL'],
+            ['schema' => 'event_message', 'property' => 'event',                        'target' => 'event',                   'onDelete' => 'CASCADE'],
+            ['schema' => 'event_message', 'property' => 'consumer',                     'target' => 'consumer',                'onDelete' => 'SET NULL'],
+            ['schema' => 'event_message', 'property' => 'subscription',                 'target' => 'event_subscription',      'onDelete' => 'CASCADE'],
             ['schema' => 'synchronization_contract_log', 'property' => 'synchronization_contract', 'target' => 'synchronization_contract', 'onDelete' => 'CASCADE'],
         ];
 
@@ -214,7 +195,7 @@ class RegisterDescriptorTest extends TestCase
                 sprintf('Relation %s.%s MUST set x-openregister-onDelete=%s', $rel['schema'], $rel['property'], $rel['onDelete'])
             );
         }
-    }
+    }//end testFkRelationsCarryRefAndOnDelete()
 
     public function testSynchronizationSourceIdAndTargetIdAreStringWithoutRef(): void
     {
@@ -229,14 +210,18 @@ class RegisterDescriptorTest extends TestCase
         $this->assertIsArray($targetId, 'synchronization.targetId MUST be declared');
         $this->assertSame('string', $targetId['type'] ?? null, 'synchronization.targetId MUST be type:string (REQ-A-006)');
         $this->assertArrayNotHasKey('$ref', $targetId, 'synchronization.targetId MUST NOT carry $ref — overloaded format');
-    }
+    }//end testSynchronizationSourceIdAndTargetIdAreStringWithoutRef()
 
-    public function entityProvider(): array
+    /**
+     * @return array<string, array<string>>
+     */
+    public function schemaSlugProvider(): array
     {
         $cases = [];
-        foreach (self::ENTITY_TO_SCHEMA as $entityFqcn => $schemaSlug) {
-            $cases[$schemaSlug] = [$entityFqcn, $schemaSlug];
+        foreach (self::SCHEMA_SLUGS as $label => $schemaSlug) {
+            $cases[$schemaSlug] = [$schemaSlug];
         }
+
         return $cases;
-    }
-}
+    }//end schemaSlugProvider()
+}//end class


### PR DESCRIPTION
## Summary

- **PHPUnit (2 tests fixed):** Removed Reflection-based testEveryProtectedEntityPropertyAppearsInSchema from RegisterDescriptorTest (entity classes deleted in chain C); replaced with testEachSchemaDeclaresSomeProperties that validates JSON schema property blocks. Removed non-existent import method from UiControllerTest::testAllRoutesReturnTemplateResponse.
- **PHPStan (7 errors fixed):** Removed 3x always-false type guards in ActionAuthService::setMatrix; corrected 4x stale @param ObjectEntity $log docblocks in SynchronizationService where actual param is array &$logData; removed orphan @param lines; fixed wrong @return ObjectEntity → @return array for synchronizeExternToIntern.
- **PHPCS (61 auto-fixed + ~30 manual):** phpcbf fixed 61 alignment/spacing/end-condition errors; manual fixes for CallService (inline-IF ternaries to if/else, missing doc block, 20+ named-args on internal method calls) and SynchronizationService (missing @var on errorRetention, 3 lowercase inline comments, named args for bufferContractLog).

## Test plan

- [ ] CI PHPUnit passes (0 failures/errors for the two fixed tests)
- [ ] CI PHPStan passes with <= 0 non-baselined errors
- [ ] CI PHPCS passes with 0 errors (warnings for missing @spec tags are pre-existing/suppressed)
- [ ] No regressions in symfony CVE bump from #1029