### PR TITLE
test(e2e): add UI specs and Playwright tests for Sources, Consumers, Webhooks, Jobs, CloudEvents

### DIFF
--- a/openspec/specs/cloud-event-management/spec.md
+++ b/openspec/specs/cloud-event-management/spec.md
@@ -1,0 +1,64 @@
+---
+status: implemented
+retrofit: true
+---
+
+# Cloud Event Management
+
+## Purpose
+
+OpenConnector provides a Cloud Events section in its SPA where administrators
+can browse incoming CloudEvents (CloudEvents spec v1.0), inspect their payload,
+and view associated call logs. Cloud Events are stored as `event` objects in
+the `openconnector` OpenRegister register. This spec covers the observable
+browser UI behaviour and the backend CloudEvents routing internals (covered by
+PHPUnit/Newman). It is a retrofit spec.
+
+## Requirements
+
+### REQ-CE-UI-001: Cloud Event Management UI
+
+OpenConnector provides a Cloud Events section in its SPA where administrators
+can browse, inspect, and manage incoming cloud events and their logs.
+
+#### Scenario: cloud events list page mounts and shows content
+
+- GIVEN an authenticated admin visits the openconnector app
+- WHEN they navigate to the Cloud Events section via the sidebar nav or direct URL `/apps/openconnector/cloud-events/events`
+- THEN the Cloud Events index page renders inside the main content area with content visible
+
+#### Scenario: add cloud event button opens the creation modal
+
+- GIVEN the Cloud Events index page is loaded
+- WHEN the user clicks the "Add Item" button
+- THEN a modal or dialog opens containing the cloud event creation form
+
+#### Scenario: cloud event logs sub-page mounts
+
+- GIVEN an authenticated admin
+- WHEN they navigate to the Cloud Event logs page at `/apps/openconnector/cloud-events/logs`
+- THEN the page mounts and renders the main content area
+
+### REQ-CE-001: CloudEvents inbound routing
+
+@e2e exclude backend CloudEvents inbound routing — covered by PHPUnit/Newman, not browser UI
+
+The system SHALL receive inbound CloudEvents at the configured receiver
+endpoint, validate the CloudEvents envelope (specversion, source, type, id),
+persist the event as an `event` object in OpenRegister, and route it to any
+matching synchronization or rule pipelines based on `type` and `source` filters.
+
+**Scenarios:**
+
+1. **GIVEN** a valid CloudEvents 1.0 envelope POSTed to the receiver
+   **WHEN** the inbound handler processes it
+   **THEN** the event is persisted as an `event` object and routed to matching
+   pipelines.
+
+2. **GIVEN** an envelope missing the required `specversion` field
+   **WHEN** the inbound handler validates it
+   **THEN** HTTP 400 is returned with a validation error and nothing is persisted.
+
+3. **GIVEN** an event whose `type` matches a configured synchronization trigger
+   **WHEN** routing runs
+   **THEN** the matching synchronization is invoked with the event payload.

--- a/openspec/specs/consumer-management/spec.md
+++ b/openspec/specs/consumer-management/spec.md
@@ -1,0 +1,73 @@
+---
+status: implemented
+retrofit: true
+---
+
+# Consumer and Webhook Management
+
+## Purpose
+
+OpenConnector exposes two related UI sections — **Consumers** and **Webhooks** —
+that allow administrators to configure inbound access policies. A Consumer
+describes an external system that is permitted to call OpenConnector's endpoints,
+including its authorization type and allowed domains. Webhooks share the same
+underlying schema (`consumer`) and surface but are presented separately for
+clarity. This spec covers the observable browser UI behaviour and the backend
+authentication enforcement (covered by PHPUnit/Newman). It is a retrofit spec.
+
+## Requirements
+
+### REQ-CON-UI-001: Consumer Management UI
+
+OpenConnector provides a Consumers section in its SPA where administrators can
+browse, create, edit, and delete consumer configurations.
+
+#### Scenario: consumers list page mounts and shows content
+
+- GIVEN an authenticated admin visits the openconnector app
+- WHEN they navigate to the Consumers section via the sidebar nav or direct URL `/apps/openconnector/consumers`
+- THEN the Consumers index page renders inside the main content area with content visible
+
+#### Scenario: add consumer button opens the creation modal
+
+- GIVEN the Consumers index page is loaded
+- WHEN the user clicks the "Add Item" button
+- THEN a modal or dialog opens containing the consumer creation form
+
+### REQ-WBHK-UI-001: Webhook Management UI
+
+OpenConnector provides a Webhooks section in its SPA where administrators can
+browse, create, edit, and delete webhook consumers.
+
+#### Scenario: webhooks list page mounts and shows content
+
+- GIVEN an authenticated admin visits the openconnector app
+- WHEN they navigate to the Webhooks section via the sidebar nav or direct URL `/apps/openconnector/webhooks`
+- THEN the Webhooks index page renders inside the main content area with content visible
+
+#### Scenario: add webhook button opens the creation modal
+
+- GIVEN the Webhooks index page is loaded
+- WHEN the user clicks the "Add Item" button
+- THEN a modal or dialog opens containing the webhook/consumer creation form
+
+### REQ-CON-001: Consumer authentication enforcement
+
+@e2e exclude backend consumer auth enforcement — covered by PHPUnit/Newman, not browser UI
+
+The system SHALL enforce consumer-level authentication on inbound calls to
+OpenConnector endpoints by resolving the `consumer` record associated with the
+request and checking that the caller's credentials match the configured
+`authorizationType` (none, apiKey, jwt, basic, oauth2). Requests failing
+consumer auth SHALL receive HTTP 401.
+
+**Scenarios:**
+
+1. **GIVEN** a consumer with `authorizationType: apiKey` **WHEN** a request
+   arrives without a matching API key header **THEN** the response is HTTP 401.
+
+2. **GIVEN** a consumer with `authorizationType: none` **WHEN** any request
+   arrives on a matched endpoint **THEN** auth passes regardless of headers.
+
+3. **GIVEN** a consumer with allowed `domains` configured **WHEN** a request
+   originates from an unlisted domain **THEN** the response is HTTP 403.

--- a/openspec/specs/job-management/spec.md
+++ b/openspec/specs/job-management/spec.md
@@ -1,0 +1,77 @@
+---
+status: implemented
+retrofit: true
+---
+
+# Job Management
+
+## Purpose
+
+OpenConnector provides a Jobs section in its SPA where administrators can
+configure scheduled background jobs — cron-like tasks that invoke a PHP
+`jobClass` at a configured `interval`. Jobs can be enabled/disabled, run on
+demand, and tested via dry runs. Their execution history is tracked in
+`job_log` records. This spec covers the observable browser UI behaviour and
+the backend job-execution internals (covered by PHPUnit/Newman). It is a
+retrofit spec.
+
+## Requirements
+
+### REQ-JOB-UI-001: Job Management UI
+
+OpenConnector provides a Jobs section in its SPA where administrators can
+browse, create, edit, enable/disable, and manually trigger background jobs.
+
+#### Scenario: jobs list page mounts and shows content
+
+- GIVEN an authenticated admin visits the openconnector app
+- WHEN they navigate to the Jobs section via the sidebar nav or direct URL `/apps/openconnector/jobs`
+- THEN the Jobs index page renders inside the main content area with content visible
+
+#### Scenario: add job button opens the creation modal
+
+- GIVEN the Jobs index page is loaded
+- WHEN the user clicks the "Add Item" button
+- THEN a modal or dialog opens containing the job creation form
+
+#### Scenario: job logs sub-page mounts
+
+- GIVEN an authenticated admin
+- WHEN they navigate to the Job logs page at `/apps/openconnector/jobs/logs`
+- THEN the page mounts and renders the main content area
+
+### REQ-JOB-001: Job execution runtime
+
+@e2e exclude backend job-execution runtime — covered by PHPUnit/Newman, not browser UI
+
+The system SHALL execute registered jobs via the Nextcloud background-job
+framework, resolving the `jobClass`, passing `arguments` (decoded from JSON),
+and persisting a `job_log` on every run. A job disabled via `isEnabled: false`
+SHALL be skipped by the scheduler. The run-on-demand endpoint `POST
+/api/jobs/{id}/run` SHALL execute the job synchronously and return the log
+entry.
+
+**Scenarios:**
+
+1. **GIVEN** a job with `isEnabled: false` **WHEN** the scheduler tick runs
+   **THEN** the job is not executed and no `job_log` is written.
+
+2. **GIVEN** a job with a valid `jobClass` and `interval` **WHEN** its next
+   execution time is reached **THEN** the job runs and a `job_log` record is
+   persisted with start time, duration, and status.
+
+3. **GIVEN** `POST /api/jobs/{id}/run` is called by an admin **WHEN** the
+   job completes **THEN** the response includes the resulting `job_log` entry.
+
+### REQ-JOB-002: Job dry-run (test mode)
+
+@e2e exclude backend job dry-run — covered by PHPUnit/Newman, not browser UI
+
+The system SHALL provide a `POST /api/jobs/{id}/test` endpoint that executes
+the job in dry-run mode (no side-effects committed) and returns a preview log.
+
+**Scenarios:**
+
+1. **GIVEN** `POST /api/jobs/{id}/test` is called **WHEN** the job runs in
+   test mode **THEN** no persistent changes are written to the data store and
+   a preview result is returned.

--- a/openspec/specs/source-management/spec.md
+++ b/openspec/specs/source-management/spec.md
@@ -1,0 +1,77 @@
+---
+status: implemented
+retrofit: true
+---
+
+# Source Management
+
+## Purpose
+
+OpenConnector provides a Sources section in its SPA where administrators can
+browse, create, edit, and test external source connections (APIs, databases,
+registers). A Source is the foundational entity that describes how to connect to
+an external system — its URL, authentication type, headers, and rate-limit
+configuration. This spec covers the **observable browser UI behaviour** of the
+Sources section plus the backend call/rate-limit internals (covered by PHPUnit
+and Newman). It is a retrofit spec: the code already exists.
+
+## Requirements
+
+### REQ-SRC-UI-001: Source Management UI
+
+OpenConnector provides a Sources section in its SPA where administrators can
+browse, create, edit, delete, and test source connections.
+
+#### Scenario: sources list page mounts and shows content
+
+- GIVEN an authenticated admin visits the openconnector app
+- WHEN they navigate to the Sources section via the sidebar nav or direct URL `/apps/openconnector/sources`
+- THEN the Sources index page renders inside the main content area with content visible
+
+#### Scenario: add source button opens the creation modal
+
+- GIVEN the Sources index page is loaded
+- WHEN the user clicks the "Add Item" button
+- THEN a modal or dialog opens containing the source creation form fields
+
+#### Scenario: source logs sub-page mounts
+
+- GIVEN an authenticated admin
+- WHEN they navigate to the Source logs page at `/apps/openconnector/sources/logs`
+- THEN the page mounts and renders the main content area
+
+### REQ-SRC-001: External HTTP source call
+
+@e2e exclude backend CallService HTTP dispatch — covered by PHPUnit/Newman, not browser UI
+
+The system SHALL dispatch HTTP calls to external sources via `CallService`,
+applying source-configured authentication (bearer, basic, API key, JWT),
+headers, rate-limit tracking, and response normalisation. All call records are
+persisted as `call_log` objects in OpenRegister.
+
+**Scenarios:**
+
+1. **GIVEN** a source with bearer auth configured **WHEN** a call is dispatched
+   **THEN** the `Authorization: Bearer <token>` header is included.
+
+2. **GIVEN** a source whose rate-limit remaining reaches zero **WHEN** a call
+   is attempted **THEN** a 429 exception is raised and the call is not dispatched.
+
+3. **GIVEN** a dispatched call **WHEN** the response is received **THEN** a
+   `call_log` record is persisted with the source id, status code, and duration.
+
+### REQ-SRC-002: Source connection test
+
+@e2e exclude backend source-test endpoint — covered by PHPUnit/Newman, not browser UI
+
+The system SHALL provide a `POST /api/sources/{id}/test` endpoint that
+dispatches a single test call to the source and returns the response body and
+status code without persisting a log record.
+
+**Scenarios:**
+
+1. **GIVEN** a source with a reachable URL **WHEN** the test endpoint is called
+   **THEN** the response contains the upstream status code and body.
+
+2. **GIVEN** a source with an unreachable URL **WHEN** the test endpoint is called
+   **THEN** a descriptive error response is returned rather than a 500 crash.

--- a/tests/e2e/spec-coverage/cloud-event-management.spec.ts
+++ b/tests/e2e/spec-coverage/cloud-event-management.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Spec coverage: openspec/specs/cloud-event-management/spec.md
+ *
+ * REQ-CE-UI-001 (Cloud Event Management UI) — real Playwright UI tests
+ * covering the Cloud Events SPA section: list, modal, logs.
+ *
+ * REQ-CE-001 describes backend CloudEvents inbound routing internals that
+ * carry @e2e exclude and are covered by PHPUnit/Newman.
+ *
+ * NOTE: /index.php/apps/openconnector/* redirects to /apps/openconnector/ (loses
+ * the deep-link path). Always use the /apps/ prefix.
+ *
+ * Known bug #996: Table view renders all cells as "—". Assertions use
+ * the main content area rather than relying on table cell content.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const OR_BASE = '/index.php/apps/openregister/api/objects/openconnector'
+// /index.php/apps/openconnector/* strips the path on redirect; use /apps/ prefix.
+const APP_BASE = '/apps/openconnector'
+
+// ---------------------------------------------------------------------------
+// REQ-CE-UI-001: Cloud Event Management UI
+// ---------------------------------------------------------------------------
+
+test.describe('REQ-CE-UI-001: Cloud Events list page mounts', () => {
+	// @e2e cloud-event-management::cloud-events-list-page-mounts-and-shows-content
+	test('Cloud Events index page renders inside main content area', async ({ page }) => {
+		await page.goto(`${APP_BASE}/cloud-events/events`, { waitUntil: 'networkidle' })
+		await expect(page.locator('main').first()).toBeVisible({ timeout: 15_000 })
+		const html = await page.locator('main').first().innerHTML()
+		expect(html.length).toBeGreaterThan(100)
+	})
+})
+
+test.describe('REQ-CE-UI-001: Add Cloud Event modal', () => {
+	// @e2e cloud-event-management::add-cloud-event-button-opens-the-creation-modal
+	test('Add Item button on Cloud Events page opens modal/dialog', async ({ page }) => {
+		await page.goto(`${APP_BASE}/cloud-events/events`, { waitUntil: 'networkidle' })
+		// Switch to Cards view to ensure the add button is accessible
+		const cardsRadio = page.getByRole('radio', { name: /Cards/i })
+		if (await cardsRadio.isVisible({ timeout: 3_000 }).catch(() => false)) {
+			await cardsRadio.click()
+		}
+		const addBtn = page.getByRole('button', { name: /Add (Item|Cloud Event|Event)/i })
+		await expect(addBtn, 'Add Item button must be visible on Cloud Events page').toBeVisible({ timeout: 20_000 })
+		await addBtn.click()
+		const dialog = page.getByRole('dialog').first()
+		await expect(dialog, 'Modal must open after clicking Add Item on Cloud Events').toBeVisible({ timeout: 10_000 })
+		// Dismiss without saving
+		const cancelBtn = dialog.getByRole('button', { name: /Cancel|Close/i }).first()
+		if (await cancelBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+			await cancelBtn.click()
+		} else {
+			await page.keyboard.press('Escape')
+		}
+	})
+})
+
+test.describe('REQ-CE-UI-001: Cloud Event logs sub-page', () => {
+	// @e2e cloud-event-management::cloud-event-logs-sub-page-mounts
+	test('Cloud Event logs page mounts and shows main content area', async ({ page }) => {
+		await page.goto(`${APP_BASE}/cloud-events/logs`, { waitUntil: 'networkidle' })
+		await expect(page.locator('main').first()).toBeVisible({ timeout: 15_000 })
+	})
+})
+
+// ---------------------------------------------------------------------------
+// API surface helpers (no @e2e spec tag — backend scenarios carry @e2e exclude)
+// ---------------------------------------------------------------------------
+
+test.describe('Cloud Events OR API — list', () => {
+	test('OR returns event objects for the openconnector register', async ({ request }) => {
+		const resp = await request.get(`${OR_BASE}/event?_limit=10`, {
+			failOnStatusCode: false,
+		})
+		expect(resp.status()).toBe(200)
+		const body = await resp.json()
+		expect(body).toHaveProperty('results')
+		expect(Array.isArray(body.results)).toBe(true)
+	})
+})

--- a/tests/e2e/spec-coverage/consumer-management.spec.ts
+++ b/tests/e2e/spec-coverage/consumer-management.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Spec coverage: openspec/specs/consumer-management/spec.md
+ *
+ * REQ-CON-UI-001 (Consumer Management UI) — real Playwright UI tests covering
+ * the Consumers SPA section: list, modal.
+ *
+ * REQ-WBHK-UI-001 (Webhook Management UI) — real Playwright UI tests covering
+ * the Webhooks SPA section: list, modal.
+ *
+ * REQ-CON-001 describes backend consumer auth enforcement that carries
+ * @e2e exclude and is covered by PHPUnit/Newman.
+ *
+ * NOTE: /index.php/apps/openconnector/* redirects to /apps/openconnector/ (loses
+ * the deep-link path). Always use the /apps/ prefix.
+ *
+ * Known bug #996: Table view renders all cells as "—". Assertions use
+ * the main content area rather than relying on table cell content.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const OR_BASE = '/index.php/apps/openregister/api/objects/openconnector'
+// /index.php/apps/openconnector/* strips the path on redirect; use /apps/ prefix.
+const APP_BASE = '/apps/openconnector'
+
+// ---------------------------------------------------------------------------
+// REQ-CON-UI-001: Consumer Management UI
+// ---------------------------------------------------------------------------
+
+test.describe('REQ-CON-UI-001: Consumers list page mounts', () => {
+	// @e2e consumer-management::consumers-list-page-mounts-and-shows-content
+	test('Consumers index page renders inside main content area', async ({ page }) => {
+		await page.goto(`${APP_BASE}/consumers`, { waitUntil: 'networkidle' })
+		await expect(page.locator('main').first()).toBeVisible({ timeout: 15_000 })
+		const html = await page.locator('main').first().innerHTML()
+		expect(html.length).toBeGreaterThan(100)
+	})
+})
+
+test.describe('REQ-CON-UI-001: Add Consumer modal', () => {
+	// @e2e consumer-management::add-consumer-button-opens-the-creation-modal
+	test('Add Item button on Consumers page opens modal/dialog', async ({ page }) => {
+		await page.goto(`${APP_BASE}/consumers`, { waitUntil: 'networkidle' })
+		// Switch to Cards view to ensure the add button is accessible
+		const cardsRadio = page.getByRole('radio', { name: /Cards/i })
+		if (await cardsRadio.isVisible({ timeout: 3_000 }).catch(() => false)) {
+			await cardsRadio.click()
+		}
+		const addBtn = page.getByRole('button', { name: /Add (Item|Consumer)/i })
+		await expect(addBtn, 'Add Item button must be visible on Consumers page').toBeVisible({ timeout: 20_000 })
+		await addBtn.click()
+		const dialog = page.getByRole('dialog').first()
+		await expect(dialog, 'Modal must open after clicking Add Item on Consumers').toBeVisible({ timeout: 10_000 })
+		// Dismiss without saving
+		const cancelBtn = dialog.getByRole('button', { name: /Cancel|Close/i }).first()
+		if (await cancelBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+			await cancelBtn.click()
+		} else {
+			await page.keyboard.press('Escape')
+		}
+	})
+})
+
+// ---------------------------------------------------------------------------
+// REQ-WBHK-UI-001: Webhook Management UI
+// ---------------------------------------------------------------------------
+
+test.describe('REQ-WBHK-UI-001: Webhooks list page mounts', () => {
+	// @e2e consumer-management::webhooks-list-page-mounts-and-shows-content
+	test('Webhooks index page renders inside main content area', async ({ page }) => {
+		await page.goto(`${APP_BASE}/webhooks`, { waitUntil: 'networkidle' })
+		await expect(page.locator('main').first()).toBeVisible({ timeout: 15_000 })
+		const html = await page.locator('main').first().innerHTML()
+		expect(html.length).toBeGreaterThan(100)
+	})
+})
+
+test.describe('REQ-WBHK-UI-001: Add Webhook modal', () => {
+	// @e2e consumer-management::add-webhook-button-opens-the-creation-modal
+	test('Add Item button on Webhooks page opens modal/dialog', async ({ page }) => {
+		await page.goto(`${APP_BASE}/webhooks`, { waitUntil: 'networkidle' })
+		// Switch to Cards view to ensure the add button is accessible
+		const cardsRadio = page.getByRole('radio', { name: /Cards/i })
+		if (await cardsRadio.isVisible({ timeout: 3_000 }).catch(() => false)) {
+			await cardsRadio.click()
+		}
+		const addBtn = page.getByRole('button', { name: /Add (Item|Webhook|Consumer)/i })
+		await expect(addBtn, 'Add Item button must be visible on Webhooks page').toBeVisible({ timeout: 20_000 })
+		await addBtn.click()
+		const dialog = page.getByRole('dialog').first()
+		await expect(dialog, 'Modal must open after clicking Add Item on Webhooks').toBeVisible({ timeout: 10_000 })
+		// Dismiss without saving
+		const cancelBtn = dialog.getByRole('button', { name: /Cancel|Close/i }).first()
+		if (await cancelBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+			await cancelBtn.click()
+		} else {
+			await page.keyboard.press('Escape')
+		}
+	})
+})
+
+// ---------------------------------------------------------------------------
+// API surface helpers (no @e2e spec tag — backend scenarios carry @e2e exclude)
+// ---------------------------------------------------------------------------
+
+test.describe('Consumers OR API — list', () => {
+	test('OR returns consumer objects for the openconnector register', async ({ request }) => {
+		const resp = await request.get(`${OR_BASE}/consumer?_limit=10`, {
+			failOnStatusCode: false,
+		})
+		expect(resp.status()).toBe(200)
+		const body = await resp.json()
+		expect(body).toHaveProperty('results')
+		expect(Array.isArray(body.results)).toBe(true)
+	})
+})

--- a/tests/e2e/spec-coverage/job-management.spec.ts
+++ b/tests/e2e/spec-coverage/job-management.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Spec coverage: openspec/specs/job-management/spec.md
+ *
+ * REQ-JOB-UI-001 (Job Management UI) — real Playwright UI tests covering
+ * the Jobs SPA section: list, modal, logs.
+ *
+ * REQ-JOB-001 and REQ-JOB-002 describe backend job-execution and dry-run
+ * internals that carry @e2e exclude and are covered by PHPUnit/Newman.
+ *
+ * NOTE: /index.php/apps/openconnector/* redirects to /apps/openconnector/ (loses
+ * the deep-link path). Always use the /apps/ prefix.
+ *
+ * Known bug #996: Table view renders all cells as "—". Assertions use
+ * the main content area rather than relying on table cell content.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const OR_BASE = '/index.php/apps/openregister/api/objects/openconnector'
+// /index.php/apps/openconnector/* strips the path on redirect; use /apps/ prefix.
+const APP_BASE = '/apps/openconnector'
+
+// ---------------------------------------------------------------------------
+// REQ-JOB-UI-001: Job Management UI
+// ---------------------------------------------------------------------------
+
+test.describe('REQ-JOB-UI-001: Jobs list page mounts', () => {
+	// @e2e job-management::jobs-list-page-mounts-and-shows-content
+	test('Jobs index page renders inside main content area', async ({ page }) => {
+		await page.goto(`${APP_BASE}/jobs`, { waitUntil: 'networkidle' })
+		await expect(page.locator('main').first()).toBeVisible({ timeout: 15_000 })
+		const html = await page.locator('main').first().innerHTML()
+		expect(html.length).toBeGreaterThan(100)
+	})
+})
+
+test.describe('REQ-JOB-UI-001: Add Job modal', () => {
+	// @e2e job-management::add-job-button-opens-the-creation-modal
+	test('Add Item button on Jobs page opens modal/dialog', async ({ page }) => {
+		await page.goto(`${APP_BASE}/jobs`, { waitUntil: 'networkidle' })
+		// Switch to Cards view to ensure the add button is accessible
+		const cardsRadio = page.getByRole('radio', { name: /Cards/i })
+		if (await cardsRadio.isVisible({ timeout: 3_000 }).catch(() => false)) {
+			await cardsRadio.click()
+		}
+		const addBtn = page.getByRole('button', { name: /Add (Item|Job)/i })
+		await expect(addBtn, 'Add Item button must be visible on Jobs page').toBeVisible({ timeout: 20_000 })
+		await addBtn.click()
+		const dialog = page.getByRole('dialog').first()
+		await expect(dialog, 'Modal must open after clicking Add Item on Jobs').toBeVisible({ timeout: 10_000 })
+		// Dismiss without saving
+		const cancelBtn = dialog.getByRole('button', { name: /Cancel|Close/i }).first()
+		if (await cancelBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+			await cancelBtn.click()
+		} else {
+			await page.keyboard.press('Escape')
+		}
+	})
+})
+
+test.describe('REQ-JOB-UI-001: Job logs sub-page', () => {
+	// @e2e job-management::job-logs-sub-page-mounts
+	test('Job logs page mounts and shows main content area', async ({ page }) => {
+		await page.goto(`${APP_BASE}/jobs/logs`, { waitUntil: 'networkidle' })
+		await expect(page.locator('main').first()).toBeVisible({ timeout: 15_000 })
+	})
+})
+
+// ---------------------------------------------------------------------------
+// API surface helpers (no @e2e spec tag — backend scenarios carry @e2e exclude)
+// ---------------------------------------------------------------------------
+
+test.describe('Jobs OR API — list', () => {
+	test('OR returns job objects for the openconnector register', async ({ request }) => {
+		const resp = await request.get(`${OR_BASE}/job?_limit=10`, {
+			failOnStatusCode: false,
+		})
+		expect(resp.status()).toBe(200)
+		const body = await resp.json()
+		expect(body).toHaveProperty('results')
+		expect(Array.isArray(body.results)).toBe(true)
+	})
+})

--- a/tests/e2e/spec-coverage/source-management.spec.ts
+++ b/tests/e2e/spec-coverage/source-management.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Spec coverage: openspec/specs/source-management/spec.md
+ *
+ * REQ-SRC-UI-001 (Source Management UI) — real Playwright UI tests covering
+ * the Sources SPA section: list, modal, logs.
+ *
+ * REQ-SRC-001 and REQ-SRC-002 describe backend call/test internals that carry
+ * @e2e exclude and are covered by PHPUnit/Newman.
+ *
+ * NOTE: /index.php/apps/openconnector/* redirects to /apps/openconnector/ (loses
+ * the deep-link path). Always use the /apps/ prefix.
+ *
+ * Known bug #996: Table view renders all cells as "—". Assertions use
+ * the main content area rather than relying on table cell content.
+ * Use Cards view where the Add Item button is always visible.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const OR_BASE = '/index.php/apps/openregister/api/objects/openconnector'
+// /index.php/apps/openconnector/* strips the path on redirect; use /apps/ prefix.
+const APP_BASE = '/apps/openconnector'
+
+// ---------------------------------------------------------------------------
+// REQ-SRC-UI-001: Source Management UI
+// ---------------------------------------------------------------------------
+
+test.describe('REQ-SRC-UI-001: Sources list page mounts', () => {
+	// @e2e source-management::sources-list-page-mounts-and-shows-content
+	test('Sources index page renders inside main content area', async ({ page }) => {
+		await page.goto(`${APP_BASE}/sources`, { waitUntil: 'networkidle' })
+		await expect(page.locator('main').first()).toBeVisible({ timeout: 15_000 })
+		const html = await page.locator('main').first().innerHTML()
+		expect(html.length).toBeGreaterThan(100)
+	})
+})
+
+test.describe('REQ-SRC-UI-001: Add Source modal', () => {
+	// @e2e source-management::add-source-button-opens-the-creation-modal
+	test('Add Item button on Sources page opens modal/dialog', async ({ page }) => {
+		await page.goto(`${APP_BASE}/sources`, { waitUntil: 'networkidle' })
+		// Switch to Cards view to ensure the add button is accessible
+		const cardsRadio = page.getByRole('radio', { name: /Cards/i })
+		if (await cardsRadio.isVisible({ timeout: 3_000 }).catch(() => false)) {
+			await cardsRadio.click()
+		}
+		const addBtn = page.getByRole('button', { name: /Add (Item|Source)/i })
+		await expect(addBtn, 'Add Item button must be visible on Sources page').toBeVisible({ timeout: 20_000 })
+		await addBtn.click()
+		const dialog = page.getByRole('dialog').first()
+		await expect(dialog, 'Modal must open after clicking Add Item on Sources').toBeVisible({ timeout: 10_000 })
+		// Dismiss without saving
+		const cancelBtn = dialog.getByRole('button', { name: /Cancel|Close/i }).first()
+		if (await cancelBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+			await cancelBtn.click()
+		} else {
+			await page.keyboard.press('Escape')
+		}
+	})
+})
+
+test.describe('REQ-SRC-UI-001: Source logs sub-page', () => {
+	// @e2e source-management::source-logs-sub-page-mounts
+	test('Source logs page mounts and shows main content area', async ({ page }) => {
+		await page.goto(`${APP_BASE}/sources/logs`, { waitUntil: 'networkidle' })
+		await expect(page.locator('main').first()).toBeVisible({ timeout: 15_000 })
+	})
+})
+
+// ---------------------------------------------------------------------------
+// API surface helpers (no @e2e spec tag — backend scenarios carry @e2e exclude)
+// ---------------------------------------------------------------------------
+
+test.describe('Sources OR API — list', () => {
+	test('OR returns source objects for the openconnector register', async ({ request }) => {
+		const resp = await request.get(`${OR_BASE}/source?_limit=10`, {
+			failOnStatusCode: false,
+		})
+		expect(resp.status()).toBe(200)
+		const body = await resp.json()
+		expect(body).toHaveProperty('results')
+		expect(Array.isArray(body.results)).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary

- Five SPA sections (Sources, Consumers, Webhooks, Jobs, Cloud Events) had no openspec/e2e coverage at all — no spec files, so the gate could not track any UI test scenarios for those connection-setup flows.
- Added 4 new spec files with UI requirements (list-page, add-modal, logs-sub-page) plus granular `@e2e exclude` tags only for genuine backend-only scenarios.
- Added 4 matching `tests/e2e/spec-coverage/*.spec.ts` with real Playwright assertions: navigate to the section, wait for main to mount, click the Add Item button, assert the dialog opens. Uses Cards view per bug #996 (table rendering issue).
- Webhooks and Consumers share a single spec/test file since they use the same consumer schema.

## Gate result

| | Before | After |
|---|---|---|
| Total scenarios | 163 | 191 |
| Covered (real tests) | 14 | 27 |
| Excluded (backend-only) | 149 | 164 |
| Uncovered | 0 | 0 |

Gate: 0 uncovered before and after — this PR fixes the structural gap (missing specs) rather than a gate failure.

## Test plan

- [ ] `python3 scripts/lib/check_e2e_coverage.py . --mode report` shows 0 uncovered
- [ ] `npx playwright test --project regression tests/e2e/spec-coverage/source-management.spec.ts` passes
- [ ] `npx playwright test --project regression tests/e2e/spec-coverage/consumer-management.spec.ts` passes
- [ ] `npx playwright test --project regression tests/e2e/spec-coverage/job-management.spec.ts` passes
- [ ] `npx playwright test --project regression tests/e2e/spec-coverage/cloud-event-management.spec.ts` passes

Closes: #998
Ref: ConductionNL/.github#105 §4