### PR TITLE
fix(security): bump twig/twig to ^3.27.0 (CVE-2026-48805/06/07/08, CVE-2026-46636)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
 		"symfony/http-foundation": "^7.4.13",
 		"symfony/uid": "^6.4",
 		"symfony/yaml": "^6.4.40",
-		"twig/twig": "^3.26",
+		"twig/twig": "^3.27.0",
 		"web-token/jwt-framework": "^3"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b847762a1e462199ca29489acff08ab0",
+    "content-hash": "8864a9461f69d81fa65a933e36aba0e4",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -4012,16 +4012,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -4071,7 +4071,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4091,7 +4091,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -5333,16 +5333,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
                 "shasum": ""
             },
             "require": {
@@ -5397,7 +5397,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
             },
             "funding": [
                 {
@@ -5409,7 +5409,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:31:59+00:00"
+            "time": "2026-05-27T13:05:51+00:00"
         },
         {
             "name": "veewee/xml",


### PR DESCRIPTION
## Security Fix

Bumps `twig/twig` from **v3.26.0** → **v3.27.0** to address 5 sandbox bypass CVEs reported 2026-05-27.

## CVEs fixed

| CVE | Title |
|-----|-------|
| CVE-2026-48805 | Sandbox state regression in deprecated internal wrappers in `src/Resources/core.php` |
| CVE-2026-48806 | Sandbox `__toString()` policy bypass via dynamic mapping keys |
| CVE-2026-48807 | Sandbox `__toString()` policy bypass via `Traversable` in `join`/`replace` and `in`/`not in` operators |
| CVE-2026-48808 | Sandbox property allowlist bypass via the `column` filter under `SourcePolicyInterface` |
| CVE-2026-46636 | Sandbox filter, tag and function allow-list bypass when sandbox state changes between renders |

## Changes

- `composer.json`: `"twig/twig": "^3.26"` → `"twig/twig": "^3.27.0"`
- `composer.lock`: twig/twig v3.26.0 → v3.27.0; symfony/polyfill-ctype v1.33.0 → v1.37.0 (transitive)
- `composer audit` after bump: **No security vulnerability advisories found**

## No other changes

No PHPStan/PHPCS/PHPMD/Psalm/PHPUnit or application code was modified.