### PR TITLE
fix(security): wave-3 critical fixes

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ The OpenConnector Nextcloud app provides a ESB-framework to work together in an 
 
 **Support:** For support, contact support@conduction.nl. For a Service Level Agreement (SLA), contact sales@conduction.nl.
     ]]></description>
-	<version>0.2.10</version>
+	<version>0.2.11</version>
 	<licence>agpl</licence>
 	<category>integration</category>
 	<author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -29,7 +29,7 @@ return [
 		// controller, openspec spec, and TODO are not lost.  Re-enable only after
 		// the real verifier has been implemented and reviewed.
 		//
-		// Tracking issue: https://github.com/ConductionNL/openconnector/issues/1047
+		// Tracking issue: https://github.com/ConductionNL/openconnector/issues/1041
 		//
 		// ['name' => 'dSO#receiveVerzoek', 'url' => '/api/dso/stam/verzoeken', 'verb' => 'POST'],
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,11 +17,21 @@ return [
 		['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
 		['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
 
-		// DSO / Omgevingsloket STAM koppelvlak — inbound webhook for
-		// vergunningaanvragen, meldingen, informatieverzoeken, vooroverleg.
-		// Re-enabled with the post-OR-cutover surface (issue #881).
-		// Route name uses camelCase-slug convention (dSO = lowercase-first of DSO).
-		['name' => 'dSO#receiveVerzoek', 'url' => '/api/dso/stam/verzoeken', 'verb' => 'POST'],
+		// DSO / Omgevingsloket STAM koppelvlak — route REMOVED (wave-3 security fix).
+		//
+		// The `validateSignature` method that backs this endpoint accepts any
+		// non-empty X-DSO-Signature header without cryptographic verification
+		// (the PKIoverheid HMAC/RSA verifier, REQ-DSO-050, was never implemented).
+		// Leaving a #[PublicPage]+#[NoCSRFRequired] webhook with only a
+		// string-presence check in production is a CRITICAL vulnerability.
+		//
+		// The route is held here as a commented-out placeholder so that the
+		// controller, openspec spec, and TODO are not lost.  Re-enable only after
+		// the real verifier has been implemented and reviewed.
+		//
+		// Tracking issue: https://github.com/ConductionNL/openconnector/issues/1047
+		//
+		// ['name' => 'dSO#receiveVerzoek', 'url' => '/api/dso/stam/verzoeken', 'verb' => 'POST'],
 
 		// Source endpoints
 		['name' => 'sources#test', 'url' => '/api/sources/test/{id}', 'verb' => 'POST'],

--- a/lib/Service/AuthenticationService.php
+++ b/lib/Service/AuthenticationService.php
@@ -39,7 +39,9 @@ use OAuthException;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Twig\Environment;
+use Twig\Extension\SandboxExtension;
 use Twig\Loader\ArrayLoader;
+use Twig\Sandbox\SecurityPolicy;
 
 /**
  * Service class for handling authentication on other services.
@@ -91,6 +93,17 @@ class AuthenticationService
         ArrayLoader $loader
     ) {
         $this->twig = new Environment(loader: $loader);
+
+        // Sandbox the authentication Twig environment — templates here expand
+        // OAuth/JWT configuration tokens and should not call any PHP methods on
+        // injected objects.  Only basic control-flow tags and string filters are
+        // needed.
+        $authSandboxPolicy = new SecurityPolicy(
+            allowedTags: ['if', 'for', 'set'],
+            allowedFilters: ['upper', 'lower', 'trim', 'default', 'escape', 'raw', 'replace'],
+            allowedFunctions: ['date', 'max', 'min', 'random'],
+        );
+        $this->twig->addExtension(new SandboxExtension(policy: $authSandboxPolicy, sandboxed: true));
     }//end __construct()
 
     /**

--- a/lib/Service/AuthorizationService.php
+++ b/lib/Service/AuthorizationService.php
@@ -41,6 +41,8 @@ use Jose\Component\Signature\JWSVerifier;
 use Jose\Component\Signature\Serializer\CompactSerializer;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\IRequest;
 use OC\AppFramework\Middleware\Security\Exceptions\SecurityException;
 use OCP\AppFramework\Http\Attribute\CORS;
@@ -68,19 +70,40 @@ class AuthorizationService
     const PSS_ALGORITHMS   = ['PS256', 'PS384', 'PS512'];
 
     /**
+     * Maximum allowed token lifetime in seconds (1 hour).
+     *
+     * A consumer MUST NOT issue a token whose `exp - iat` span exceeds this
+     * value.  Tokens with longer lifetimes are rejected to limit the window of
+     * a stolen/leaked token.
+     *
+     * @var integer
+     */
+    private const MAX_TOKEN_LIFETIME_SECONDS = 3600;
+
+    /**
+     * APCu/distributed cache used for jti replay detection.
+     *
+     * @var ICache
+     */
+    private readonly ICache $jtiCache;
+
+    /**
      * Constructor.
      *
      * @param IUserManager                            $userManager     The user manager.
      * @param IUserSession                            $userSession     The user session.
      * @param \OCA\OpenRegister\Service\ObjectService $orObjectService OR ObjectService used to resolve consumers.
      * @param IGroupManager                           $groupManager    The group manager for users/groups ACL checks.
+     * @param ICacheFactory                           $cacheFactory    Cache factory used for jti replay detection.
      */
     public function __construct(
         private readonly IUserManager $userManager,
         private readonly IUserSession $userSession,
         private readonly \OCA\OpenRegister\Service\ObjectService $orObjectService,
         private readonly IGroupManager $groupManager,
+        ICacheFactory $cacheFactory,
     ) {
+        $this->jtiCache = $cacheFactory->createDistributed('openconnector.jti');
 
     }//end __construct()
 
@@ -214,13 +237,16 @@ class AuthorizationService
      * Checks:
      *   - iat is present and not in the future (beyond clock skew)
      *   - exp (default iat+1h) has not passed
+     *   - exp - iat does not exceed MAX_TOKEN_LIFETIME_SECONDS (prevents
+     *     infinite-lifetime tokens via a caller-supplied exp claim)
      *   - nbf (not-before), if present, has been reached
+     *   - jti, if present, has not been seen before (replay prevention)
      *
      * @param array $payload The payload of the JWT token.
      *
      * @return void
      *
-     * @throws AuthenticationException If the token is missing/expired/not-yet-valid.
+     * @throws AuthenticationException If the token is missing/expired/not-yet-valid/replayed.
      *
      * @spec openspec/changes/retrofit-2026-05-24-authorization-jwt/tasks.md#task-1
      */
@@ -251,8 +277,26 @@ class AuthorizationService
         $exp = clone $iat;
         $exp->modify('+1 Hour');
         if (isset($payload['exp']) === true) {
-            $exp = new DateTime('@'.$payload['exp']);
-        }
+            $callerExp = new DateTime('@'.$payload['exp']);
+
+            // Clamp the caller-supplied expiry so a consumer cannot self-issue
+            // tokens with an arbitrarily long (or infinite) lifetime.  The
+            // maximum allowed span is MAX_TOKEN_LIFETIME_SECONDS relative to iat.
+            $maxExp = clone $iat;
+            $maxExp->modify('+'.self::MAX_TOKEN_LIFETIME_SECONDS.' seconds');
+            if ($callerExp > $maxExp) {
+                throw new AuthenticationException(
+                    message: 'The token lifetime exceeds the maximum allowed duration',
+                    details: [
+                        'iat'                  => $iat->getTimestamp(),
+                        'exp'                  => $callerExp->getTimestamp(),
+                        'max_lifetime_seconds' => self::MAX_TOKEN_LIFETIME_SECONDS,
+                    ]
+                );
+            }//end if
+
+            $exp = $callerExp;
+        }//end if
 
         if ($exp->diff($now)->format('%R') === '+') {
             throw new AuthenticationException(
@@ -279,6 +323,24 @@ class AuthorizationService
                     ]
                 );
             }
+        }
+
+        // JWT ID (jti) replay prevention: if the token carries a jti claim,
+        // record it in the distributed cache for the remaining token lifetime
+        // plus the clock-skew window.  A second request with the same jti is
+        // rejected immediately.
+        if (isset($payload['jti']) === true && $payload['jti'] !== '') {
+            $cacheKey = 'jti:'.hash('sha256', (string) $payload['jti']);
+            $ttl      = max(1, ($exp->getTimestamp() - $now->getTimestamp()) + self::CLOCK_SKEW_SECONDS);
+
+            if ($this->jtiCache->get($cacheKey) !== null) {
+                throw new AuthenticationException(
+                    message: 'The token has already been used (jti replay)',
+                    details: ['jti' => $payload['jti']]
+                );
+            }
+
+            $this->jtiCache->set($cacheKey, 1, $ttl);
         }
 
     }//end validatePayload()

--- a/lib/Service/CallService.php
+++ b/lib/Service/CallService.php
@@ -61,7 +61,9 @@ use Symfony\Component\Uid\Uuid;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\SyntaxError;
+use Twig\Extension\SandboxExtension;
 use Twig\Loader\ArrayLoader;
+use Twig\Sandbox\SecurityPolicy;
 
 /**
  * Executes outbound API calls against configured Sources and persists CallLog entries.
@@ -128,6 +130,17 @@ class CallService
     ) {
         $this->client = new Client([]);
         $this->twig   = new Environment($loader);
+
+        // Sandbox the call Twig environment — authentication templates should
+        // only need to call the declared auth-helper functions; no PHP method
+        // calls on arbitrary objects are permitted.
+        $callSandboxPolicy = new SecurityPolicy(
+            allowedTags: ['if', 'for', 'set', 'block'],
+            allowedFilters: ['upper', 'lower', 'trim', 'default', 'escape', 'raw', 'replace'],
+            allowedFunctions: ['oauthToken', 'decosToken', 'jwtToken', 'date', 'max', 'min', 'random'],
+        );
+        $this->twig->addExtension(new SandboxExtension(policy: $callSandboxPolicy, sandboxed: true));
+
         $this->twig->addExtension(new AuthenticationExtension());
         $this->twig->addRuntimeLoader(new AuthenticationRuntimeLoader(authenticationService: $authenticationService));
         $this->cookieJar = new CookieJar();

--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -31,6 +31,7 @@ use OCA\OpenRegister\Service\ObjectService as ORObjectService;
 use OCA\OpenRegister\Service\ObjectServiceMapperAdapter;
 use OCA\OpenConnector\Exception\AuthenticationException;
 use OCA\OpenConnector\Service\Helper\FlowToken;
+use OCA\OpenConnector\Util\SafeXmlParser;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Exception\ValidationException;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -2401,7 +2402,7 @@ class EndpointService
             || ($contentType === '' && $this->looksLikeXml(content: $content) === true)
         ) {
             libxml_use_internal_errors(true);
-            $xml = simplexml_load_string($content);
+            $xml = SafeXmlParser::parse($content);
             libxml_clear_errors();
 
             if ($xml !== false) {
@@ -2427,8 +2428,8 @@ class EndpointService
         // Suppress XML errors.
         libxml_use_internal_errors(true);
 
-        // Attempt to parse the content as XML.
-        $result = simplexml_load_string($content) !== false;
+        // Use the safe parser so the XXE loader cannot leak in from SOAPService.
+        $result = SafeXmlParser::parse($content) !== false;
 
         // Clear any XML errors.
         libxml_clear_errors();

--- a/lib/Service/Helper/FlowToken.php
+++ b/lib/Service/Helper/FlowToken.php
@@ -19,6 +19,7 @@
 
 namespace OCA\OpenConnector\Service\Helper;
 
+use OCA\OpenConnector\Util\SafeXmlParser;
 use OCP\AppFramework\Http\Response;
 use OCP\IRequest;
 
@@ -188,8 +189,8 @@ class FlowToken
         // Suppress XML errors.
         libxml_use_internal_errors(true);
 
-        // Attempt to parse the content as XML.
-        $result = (simplexml_load_string($content) !== false);
+        // Use the safe parser so the XXE loader cannot leak in from SOAPService.
+        $result = (SafeXmlParser::parse($content) !== false);
 
         // Clear any XML errors.
         libxml_clear_errors();
@@ -237,7 +238,7 @@ class FlowToken
             || ($contentType === '' && $this->looksLikeXml(content: $content) === true)
         ) {
             libxml_use_internal_errors(true);
-            $xml = simplexml_load_string($content);
+            $xml = SafeXmlParser::parse($content);
             libxml_clear_errors();
 
             if ($xml !== false) {

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -30,7 +30,9 @@ use Adbar\Dot;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\SyntaxError;
+use Twig\Extension\SandboxExtension;
 use Twig\Loader\ArrayLoader;
+use Twig\Sandbox\SecurityPolicy;
 use Throwable;
 use Exception;
 use Psr\Container\ContainerInterface;
@@ -89,6 +91,80 @@ class MappingService
         private readonly LoggerInterface $logger,
     ) {
         $this->twig = new Environment($loader);
+
+        // Sandbox the mapping Twig environment so template authors cannot call
+        // arbitrary PHP methods on objects or use undeclared functions.
+        // Allowed functions mirror MappingExtension::getFunctions(); allowed
+        // filters mirror MappingExtension::getFilters().
+        // NOTE: `callSource` and `executeMapping` are deliberately excluded —
+        // see MappingExtension::getFunctions() for the security rationale.
+        $sandboxPolicy = new SecurityPolicy(
+            allowedTags: [
+                'if',
+                'for',
+                'set',
+                'block',
+                'extends',
+                'include',
+                'macro',
+                'import',
+                'from',
+                'with',
+            ],
+            allowedFilters: [
+                'b64enc',
+                'b64dec',
+                'json_decode',
+                'slugify',
+                'upper',
+                'lower',
+                'trim',
+                'replace',
+                'default',
+                'join',
+                'split',
+                'keys',
+                'merge',
+                'slice',
+                'first',
+                'last',
+                'reverse',
+                'sort',
+                'length',
+                'abs',
+                'round',
+                'date',
+                'date_modify',
+                'escape',
+                'raw',
+                'nl2br',
+                'number_format',
+                'title',
+                'capitalize',
+                'striptags',
+                'format',
+                'batch',
+            ],
+            allowedFunctions: [
+                'generateUuid',
+                'getFileContents',
+                'getFiles',
+                'range',
+                'cycle',
+                'random',
+                'date',
+                'include',
+                'source',
+                'max',
+                'min',
+                'attribute',
+                'block',
+                'parent',
+                'dump',
+            ],
+        );
+        $this->twig->addExtension(new SandboxExtension(policy: $sandboxPolicy, sandboxed: true));
+
         $this->twig->addExtension(new MappingExtension());
         $this->twig->addRuntimeLoader(
             new MappingRuntimeLoader(

--- a/lib/Service/SOAPService.php
+++ b/lib/Service/SOAPService.php
@@ -255,57 +255,61 @@ class SOAPService
             unset($config['json']);
         }
 
+        // Allow the SOAP/WSDL engine to resolve schema imports during this call
+        // window only.  The permissive loader is ALWAYS restored in the finally
+        // block so that an exception inside the call cannot leave the process-
+        // global entity loader open (XXE prevention).
         libxml_set_external_entity_loader(
-            static function ($public, $system) {
+            static function (string $public, string $system): string {
                 return $system;
             }
         );
 
-        /*
-         * @var $engine Engine
-         */
+        try {
+            /*
+             * @var $engine Engine
+             */
 
-        $engine = $this->setupEngine(source: $source, passedConfig: $config);
+            $engine = $this->setupEngine(source: $source, passedConfig: $config);
 
-        if (isset($body['edcLk01']['object']['inhoud']) === true) {
-            if (is_array($body['edcLk01']['object']['inhoud']) === false) {
-                $body['edcLk01']['object']['inhoud'] = base64_decode($body['edcLk01']['object']['inhoud']);
+            if (isset($body['edcLk01']['object']['inhoud']) === true) {
+                if (is_array($body['edcLk01']['object']['inhoud']) === false) {
+                    $body['edcLk01']['object']['inhoud'] = base64_decode($body['edcLk01']['object']['inhoud']);
+                }
+
+                if (is_array($body['edcLk01']['object']['inhoud']) === true
+                    && isset($body['edcLk01']['object']['inhoud']['_']) === true
+                ) {
+                    $body['edcLk01']['object']['inhoud']['_'] = base64_decode($body['edcLk01']['object']['inhoud']['_']);
+                }
             }
 
-            if (is_array($body['edcLk01']['object']['inhoud']) === true
-                && isset($body['edcLk01']['object']['inhoud']['_']) === true
+            // In SOAP the endpoint is decided by the WSDL, however, the SOAP method
+            // can be derived from the endpoint property of the call.
+            $result = $engine->request($soapAction, $body);
+
+            // @TODO: This must be replaced by a generic detector of fields that should be parsed in the parseDynamicXsd-function.
+            if (isset($result->{'QueryExecute2Result'}) === true
+                && isset($result->{'QueryExecute2Result'}->any) === true
             ) {
-                $body['edcLk01']['object']['inhoud']['_'] = base64_decode($body['edcLk01']['object']['inhoud']['_']);
-            }
-        }
+                $result->{'QueryExecute2Result'} = $this->parseDynamicXsd(xmlString: $result->{'QueryExecute2Result'}->any);
 
-        // In SOAP the endpoint is decided by the WSDL, however, the SOAP method
-        // can be derived from the endpoint property of the call.
-        $result = $engine->request($soapAction, $body);
+                if ($result->{'QueryExecute2Result'} === null) {
+                    $result->{'QueryExecute2Result'} = [];
+                }
+            }//end if
 
-        // @TODO: This must be replaced by a generic detector of fields that should be parsed in the parseDynamicXsd-function.
-        if (isset($result->{'QueryExecute2Result'}) === true
-            && isset($result->{'QueryExecute2Result'}->any) === true
-        ) {
-            $result->{'QueryExecute2Result'} = $this->parseDynamicXsd(xmlString: $result->{'QueryExecute2Result'}->any);
-
-            if ($result->{'QueryExecute2Result'} === null) {
-                $result->{'QueryExecute2Result'} = [];
-            }
-        }
-
-        // @TODO: The detection of binary data fields should be dynamic.
-        // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps -- External SOAP XML element name.
-        if (isset($result->FileBytes) === true && json_encode($result) === false) {
+            // @TODO: The detection of binary data fields should be dynamic.
             // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps -- External SOAP XML element name.
-            $result->FileBytes = base64_encode($result->FileBytes);
-        }
-
-        libxml_set_external_entity_loader(
-            static function () {
-                return null;
+            if (isset($result->FileBytes) === true && json_encode($result) === false) {
+                // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps -- External SOAP XML element name.
+                $result->FileBytes = base64_encode($result->FileBytes);
             }
-        );
+        } finally {
+            // Restore the safe null-resolver regardless of success or failure so
+            // the permissive loader cannot leak into subsequent simplexml calls.
+            libxml_set_external_entity_loader(static fn (): null => null);
+        }//end try
 
         return new Response(status: 200, body: json_encode($result));
 

--- a/lib/Service/SynchronizationService.php
+++ b/lib/Service/SynchronizationService.php
@@ -29,6 +29,7 @@ use JWadhams\JsonLogic;
 use OC\User\NoUserException;
 use OCA\OpenRegister\Service\ObjectService as ORObjectService;
 use OCA\OpenConnector\Service\Helper\FlowToken;
+use OCA\OpenConnector\Util\SafeXmlParser;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
@@ -3128,7 +3129,7 @@ class SynchronizationService
         // If JSON parsing failed, try XML.
         if (empty($result) === true) {
             libxml_use_internal_errors(true);
-            $xml = simplexml_load_string($body, "SimpleXMLElement", LIBXML_NOCDATA);
+            $xml = SafeXmlParser::parse($body, 'SimpleXMLElement', LIBXML_NOCDATA);
 
             if ($xml !== false) {
                 $result = $this->xmlToArray(xml: $xml);

--- a/lib/Twig/MappingExtension.php
+++ b/lib/Twig/MappingExtension.php
@@ -48,13 +48,28 @@ class MappingExtension extends AbstractExtension
      * Return the Twig functions registered by this extension.
      *
      * @return array<int, TwigFunction>
+     *
+     * SECURITY NOTE: `callSource` and `executeMapping` are intentionally NOT
+     * registered here.  They were removed from the template surface in the
+     * wave-3 security hardening pass because:
+     *   - `callSource` performs an outbound HTTP call from within a mapping
+     *     template; any admin that can author a mapping could exfiltrate data
+     *     through SSRF-style calls to internal services.
+     *   - `executeMapping` allows arbitrary mapping chaining, which makes it
+     *     impossible to reason about the maximum blast radius of a mapping.
+     *
+     * If either function is genuinely needed in future, it must be gated behind
+     * an explicit "trusted-ops" feature flag that is documented in the OpenSpec
+     * and reviewed for SSRF/RCE blast radius before re-enabling.
+     *
+     * `getFileContents` and `getFiles` are kept because they are already
+     * scoped to a specific objectId — files returned are those attached to the
+     * given object, so they cannot be used to read arbitrary filesystem paths.
      */
     public function getFunctions(): array
     {
         return [
-            new TwigFunction(name: 'executeMapping', callable: [MappingRuntime::class, 'executeMapping']),
             new TwigFunction(name: 'generateUuid', callable: [MappingRuntime::class, 'generateUuid']),
-            new TwigFunction(name: 'callSource', callable: [MappingRuntime::class, 'callSource']),
             new TwigFunction(name: 'getFileContents', callable: [MappingRuntime::class, 'getFileContents']),
             new TwigFunction(name: 'getFiles', callable: [MappingRuntime::class, 'getFiles']),
         ];

--- a/lib/Util/SafeXmlParser.php
+++ b/lib/Util/SafeXmlParser.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * OpenConnector SafeXmlParser utility.
+ *
+ * Centralises all SimpleXML parsing behind a defensive wrapper that:
+ *   - pins the libxml external-entity loader to null before every parse
+ *     (defense-in-depth: prevents XXE even if another call site leaks the
+ *     permissive loader that SOAPService installs during WSDL resolution), and
+ *   - passes LIBXML_NONET so libxml cannot open network connections while
+ *     resolving entities.
+ *
+ * @category Util
+ * @package  OCA\OpenConnector\Util
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenConnector.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenConnector\Util;
+
+use SimpleXMLElement;
+
+/**
+ * Stateless helper for safe XML parsing.
+ *
+ * All call sites that need to parse untrusted or semi-trusted XML content
+ * should use this class instead of calling simplexml_load_string() directly,
+ * so that the XXE / SSRF defence is applied consistently.
+ *
+ * @spec openspec/changes/retrofit-2026-05-28-xml-xxe-hardening/tasks.md#task-1
+ */
+class SafeXmlParser
+{
+    /**
+     * Parse an XML string safely, returning a SimpleXMLElement or false.
+     *
+     * Guarantees:
+     *   1. The libxml external-entity loader is set to null for the duration
+     *      of the parse — preventing file-read and SSRF via entity expansion.
+     *   2. LIBXML_NONET is passed so libxml cannot open network connections.
+     *   3. The previous entity loader is unconditionally restored afterwards
+     *      via a finally block, so a parse exception cannot leave the loader
+     *      in an unsafe state.
+     *
+     * @param string $data    The XML string to parse.
+     * @param string $class   The SimpleXMLElement sub-class to use (default SimpleXMLElement).
+     * @param int    $options Additional LIBXML_* flags (LIBXML_NONET is always added).
+     *
+     * @return SimpleXMLElement|false Returns a SimpleXMLElement on success, false on failure.
+     *
+     * @psalm-return SimpleXMLElement|false
+     *
+     * @spec openspec/changes/retrofit-2026-05-28-xml-xxe-hardening/tasks.md#task-1
+     */
+    public static function parse(
+        string $data,
+        string $class='SimpleXMLElement',
+        int $options=0,
+    ): SimpleXMLElement|false {
+        // Pin the external-entity loader to null before parsing.
+        $previousLoader = libxml_get_external_entity_loader();
+        libxml_set_external_entity_loader(static fn (): null => null);
+
+        try {
+            return simplexml_load_string($data, $class, ($options | LIBXML_NONET));
+        } finally {
+            // Restore whatever loader was in place before, so this helper is
+            // transparent to callers that legitimately use a custom loader.
+            libxml_set_external_entity_loader($previousLoader);
+        }
+    }//end parse()
+}//end class


### PR DESCRIPTION
## Summary

Wave-3 CRITICAL security fixes for ConductionNL/openconnector. Reference triage doc: `/tmp/triage-openconnector.md`.

### C1 — DSO webhook route removed (public endpoint, unverified signature)

`appinfo/routes.php` — The `/api/dso/stam/verzoeken` route accepted any non-empty `X-DSO-Signature` header without cryptographic verification. The PKIoverheid HMAC/RSA verifier (REQ-DSO-050) was never implemented despite the route being live as `#[PublicPage]+#[NoCSRFRequired]`. Route removed and left as commented placeholder until the real verifier ships. Tracking: https://github.com/ConductionNL/openconnector/issues/1047

### C2 — SOAPService XXE loader leak fixed (try/finally)

`lib/Service/SOAPService.php` — The permissive `libxml_set_external_entity_loader` installed before `$engine->request()` was only restored on the success path. Any exception during the SOAP call left the process-global entity loader open, exposing all subsequent `simplexml_load_string` calls to XXE/SSRF. Fixed by wrapping the SOAP execution in a `try/finally` that always restores the null loader.

### C3 — SafeXmlParser helper + 3 call sites hardened (XXE defense-in-depth)

`lib/Util/SafeXmlParser.php` (new) — Centralised XML parsing helper that pins the entity loader to null, adds `LIBXML_NONET`, and restores the previous loader in a `finally` block. All three undefended `simplexml_load_string` call sites replaced: `lib/Service/EndpointService.php`, `lib/Service/Helper/FlowToken.php`, `lib/Service/SynchronizationService.php`.

### C4 — Twig SandboxExtension added to all 3 environments; callSource + executeMapping removed

`lib/Service/MappingService.php`, `lib/Service/CallService.php`, `lib/Service/AuthenticationService.php` — Each Twig environment is now wrapped in a globally-enabled `SandboxExtension` with an explicit `SecurityPolicy`. This prevents template authors from calling arbitrary PHP methods on injected objects or using undeclared functions. `callSource` and `executeMapping` removed from `MappingExtension::getFunctions()` — these allowed admin mapping authors to exfiltrate data via outbound HTTP calls or create unbounded mapping chains (SSRF/privilege-escalation risk). `getFileContents`/`getFiles` retained (objectId-scoped, existing ACL).

### C5 — JWT exp clamped + jti replay cache (AuthorizationService)

`lib/Service/AuthorizationService.php` — A consumer could self-issue tokens with arbitrary lifetimes by supplying a far-future `exp` claim. Added `MAX_TOKEN_LIFETIME_SECONDS = 3600`; tokens whose `exp - iat` span exceeds 1 hour are rejected. Added `ICacheFactory`-backed `jti` replay detection: the first use of a `jti` is recorded in the distributed cache for its remaining TTL; a duplicate `jti` throws `AuthenticationException`.

## Quality gates

- PHPStan level 5: no new errors on all changed files
- PHPCS: no errors on all changed files (pre-existing `@spec` class-level warnings unchanged)
- Version bumped `0.2.10 → 0.2.11`

## Test plan

- [ ] `POST /api/dso/stam/verzoeken` returns 404 (route removed)
- [ ] SOAP sources still function end-to-end (try/finally transparent on success)
- [ ] JWT auth rejects tokens with `exp - iat > 3600s`
- [ ] JWT auth rejects replayed tokens (same `jti` twice within TTL)
- [ ] Mapping templates can still use `generateUuid`, `getFileContents`, `getFiles`, all listed filters
- [ ] Mapping templates cannot call `callSource` or `executeMapping` (throws `SecurityNotAllowedFunctionError`)
- [ ] XML parsing works for endpoint requests and sync responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)