### PR TITLE
fix(security): wave-5 — close C2 partial-fix in parseDynamicXsd (XXE/SSRF)

### DIFF
--- a/lib/Service/SOAPService.php
+++ b/lib/Service/SOAPService.php
@@ -28,6 +28,7 @@ use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Response;
+use OCA\OpenConnector\Util\SafeXmlParser;
 use OCA\OpenRegister\Db\ObjectEntity;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -58,6 +59,8 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  * @SuppressWarnings(PHPMD.StaticAccess)
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-http-call-engine/tasks.md#task-4
  */
 class SOAPService
 {
@@ -188,6 +191,13 @@ class SOAPService
     /**
      * Parse an XML snippet with its own dynamic XSD.
      *
+     * Both the DOMDocument load (used for optional schema validation) and the
+     * SimpleXML parse are delegated to SafeXmlParser so that the external-entity
+     * loader is pinned to null for each parse, even when this method is called
+     * from inside the permissive-loader window that callSoapSource opens for
+     * WSDL resolution (C2 partial-fix: the permissive loader was only restored
+     * in finally but the parse calls inside the try block were still exposed).
+     *
      * @param string $xmlString The XML split in two parts: the XSD and the data to parse.
      *
      * @return \SimpleXMLElement|null The resulting XML element, or null when no document element is present.
@@ -199,8 +209,11 @@ class SOAPService
         // @TODO: This is awfully specific, to be replaced by a more generic fix for faulty XSD.
         $xmlString = '<any>'.str_replace('NewDataSet', 'DocumentElement', $xmlString).'</any>';
 
+        // Load via SafeXmlParser so the entity loader is pinned to null for the
+        // duration of the load, regardless of any permissive-loader window opened
+        // by callSoapSource for WSDL resolution.
         $dom = new DOMDocument();
-        $dom->loadXML($xmlString);
+        SafeXmlParser::loadDom($dom, $xmlString);
 
         // OPTIONAL: Validate against schema in the XML itself (or use an external .xsd file).
         libxml_use_internal_errors(true);
@@ -208,21 +221,21 @@ class SOAPService
             libxml_clear_errors();
         }
 
-        // Parse the data inside diffgram.
-        $simpleXml = simplexml_load_string(
-            $xmlString,
-            'SimpleXMLElement',
-            0,
-            'diffgr',
-            true
-        );
+        // Parse the data inside diffgram via SafeXmlParser (pins entity loader + LIBXML_NONET).
+        $simpleXml = SafeXmlParser::parse($xmlString, 'SimpleXMLElement', 0);
 
-        // The diffgram will be under the 'diffgram' namespace.
+        if ($simpleXml === false) {
+            return null;
+        }
+
+        // The diffgram will be under the 'diffgram' namespace (unused directly — kept for
+        // explicit namespace resolution; DocumentElement is retrieved via xpath below).
         $namespaces = $simpleXml->getNamespaces(true);
-        $diffgram   = $simpleXml->children($namespaces['diffgr'])->diffgram;
+        // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter,SlevomatCodingStandard.Variables.UnusedVariable -- retained for namespace context.
+        $diffgram = $simpleXml->children($namespaces['diffgr'] ?? '')->diffgram;
 
         // Or just get the DocumentElement directly.
-        $documentElement = $simpleXml->xpath('//DocumentElement')[0];
+        $documentElement = $simpleXml->xpath('//DocumentElement')[0] ?? null;
 
         if ($documentElement === null) {
             return null;

--- a/lib/Util/SafeXmlParser.php
+++ b/lib/Util/SafeXmlParser.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenConnector\Util;
 
+use DOMDocument;
 use SimpleXMLElement;
 
 /**
@@ -76,4 +77,39 @@ class SafeXmlParser
             libxml_set_external_entity_loader($previousLoader);
         }
     }//end parse()
+
+    /**
+     * Load an XML string into a DOMDocument safely.
+     *
+     * Guarantees:
+     *   1. The libxml external-entity loader is set to null for the duration
+     *      of the load — preventing file-read and SSRF via entity expansion,
+     *      including during any permissive-loader window opened by the caller.
+     *   2. LIBXML_NONET is always added to the options so libxml cannot open
+     *      network connections while resolving entities.
+     *   3. The previous entity loader is unconditionally restored via finally.
+     *
+     * @param DOMDocument $dom     The DOMDocument instance to load the XML into.
+     * @param string      $data    The XML string to load.
+     * @param int         $options Additional LIBXML_* flags (LIBXML_NONET always added).
+     *
+     * @return bool Returns true on success, false on failure (mirrors DOMDocument::loadXML).
+     *
+     * @psalm-suppress MixedMethodCall
+     *
+     * @spec openspec/changes/retrofit-2026-05-28-xml-xxe-hardening/tasks.md#task-1
+     */
+    public static function loadDom(DOMDocument $dom, string $data, int $options=0): bool
+    {
+        // Pin the external-entity loader to null before loading.
+        $previousLoader = libxml_get_external_entity_loader();
+        libxml_set_external_entity_loader(static fn (): null => null);
+
+        try {
+            return $dom->loadXML($data, ($options | LIBXML_NONET));
+        } finally {
+            // Restore whatever loader was in place before.
+            libxml_set_external_entity_loader($previousLoader);
+        }
+    }//end loadDom()
 }//end class


### PR DESCRIPTION
## Summary

- **Bug:** SOAPService::parseDynamicXsd (wave-4 C2 partial-fix) called DOMDocument::loadXML and simplexml_load_string inside the permissive external-entity-loader try block that callSoapSource opens for WSDL resolution. The C2 fix only restored the safe loader in finally; both parse calls were still reachable while the permissive loader was active, allowing an attacker-controlled SOAP response to trigger XXE entity expansion.

- **Fix:** Extended SafeXmlParser with a new loadDom(DOMDocument, string, int): bool static method that pins the entity loader to null and adds LIBXML_NONET for the duration of the DOM load, mirroring the existing parse() contract. Rewrote parseDynamicXsd to delegate both the DOMDocument::loadXML call and the simplexml_load_string call to SafeXmlParser, making both immune to the surrounding permissive-loader window regardless of call site.

- **Scope:** lib/Util/SafeXmlParser.php (new loadDom method) and lib/Service/SOAPService.php (import + updated parseDynamicXsd + @spec tag on class docblock).

## Gates

- PHPCS: clean (0 errors, 0 warnings on changed files)
- PHPStan: OK No errors
- PHPMD: no new violations (pre-existing ElseExpression on setupEngine unchanged)
- Psalm: no new errors introduced (pre-existing baseline of 9 errors unchanged)
- Unit tests: pre-existing 62 errors from unrelated getUuid mock issue, unchanged

## Test plan

- [ ] Verify SafeXmlParser::loadDom pins entity loader and restores it in finally
- [ ] Verify parseDynamicXsd no longer calls raw DOMDocument::loadXML or simplexml_load_string directly
- [ ] Confirm a SOAP call with QueryExecute2Result still parses correctly end-to-end

Generated with Claude Code